### PR TITLE
ci: Fix GitHub Actions workflow - add tests, update Python versions, validate scripts

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -21,20 +21,29 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     
-    - name: Install dependencies
+    - name: Create virtual environment and install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python -m venv venv
+        ./venv/bin/python -m pip install --upgrade pip
+        ./venv/bin/pip install -r requirements.txt
     
     - name: Run Django checks
       run: |
-        python manage.py check
+        ./venv/bin/python manage.py check
     
     - name: Run migrations
       run: |
-        python manage.py migrate
+        ./venv/bin/python manage.py migrate
     
     - name: Validate example bookmark file
       run: |
         cp bunnify.json.example /tmp/test_bookmarks.json
-        python manage.py load_bookmarks --file /tmp/test_bookmarks.json
+        ./venv/bin/python manage.py load_bookmarks --file /tmp/test_bookmarks.json
+    
+    - name: Validate start script
+      run: |
+        ./start --help
+    
+    - name: Run tests
+      run: |
+        ./test_bunnify


### PR DESCRIPTION
## Problems Fixed

1. **Missing test run** - Workflow validated example file but never ran the test suite, causing PRs to stay pending
2. **Python version incompatibility** - Tested against Python 3.11, but Django 6.0 requires Python 3.12+
3. **Inconsistent environment setup** - Used system Python instead of venv like documentation describes
4. **No validation of wrapper scripts** - Didn't verify `./start` and `./test_bunnify` scripts work

## Changes

- Added `Run tests` step using `./test_bunnify` wrapper script
- Updated Python version matrix from `['3.11', '3.12', '3.13']` to `['3.12', '3.13']`
- Create venv and use `./venv/bin/python` consistently (matches README setup)
- Added `Validate start script` step to verify `./start --help` works
- All steps now follow documented setup procedure

## Impact

✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅✅��llow
✅ Wrapper scripts (`./start`, `./test_bunnify`) are validated