### PR TITLE
Add Copilot instructions with project coding directions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# Copilot Instructions for Bunnify
+
+## Python Version Policy
+
+**Always use the latest stable Python version.** As of the last update, this is Python 3.14.
+
+When making changes:
+- Ensure `pyproject.toml` specifies `requires-python` with the latest stable Python version
+- Ensure `.github/workflows/bunnify.yml` tests only the latest stable Python version
+- Do not add support for older Python versions
+
+## Package Management
+
+This project uses **uv** exclusively for Python dependency management:
+- Use `uv sync` to install dependencies
+- Use `uv run python` to execute Python commands
+- Use `uv add <package>` to add new dependencies
+- Never use pip, poetry, or other package managers
+
+## Git Configuration
+
+For this repository:
+- Use the `thehcma` GitHub account
+- Ensure all commits are GPG signed
+
+## Pull Request Workflow
+
+After creating a PR:
+1. Wait for GitHub Actions CI to complete
+2. Verify all checks pass
+3. Ask the developer for manual validation before merging
+
+## Code Style
+
+- Follow PEP 8 guidelines
+- Use type hints where appropriate
+- Use pathlib for file operations
+- Add docstrings to functions and classes


### PR DESCRIPTION
## Summary

Adds a `.github/copilot-instructions.md` file to provide consistent coding directions for GitHub Copilot.

## Coding Directions Captured

### Python Version Policy
- **Always use the latest stable Python version** (currently 3.14)
- Update both `pyproject.toml` and CI workflow when upgrading
- No support for older Python versions

### Package Management  
- Use **uv** exclusively (no pip, poetry, etc.)

### Git Configuration
- Use `thehcma` GitHub account
- All commits must be GPG signed

### PR Workflow
1. Wait for GitHub Actions CI to complete
2. Verify all checks pass
3. Ask developer for manual validation before merging

### Code Style
- PEP 8 guidelines
- Type hints
- pathlib for file operations
- Docstrings on functions and classes