### PR TITLE
Secure repository sections via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,16 @@
 # Code owners for bunnify
 # These owners will be automatically requested for review when PRs are opened
 
-# Default owner for everything in the repo
+# Primary repository owner
 * @thehcma
+
+# Infrastructure and configuration
+/.github/ @thehcma
+/pyproject.toml @thehcma
+/requirements.txt @thehcma
+
+# Core server and bookmarks logic
+/bunnify-server @thehcma
+/bookmarks/ @thehcma
+/bunnify/ @thehcma
+/manage.py @thehcma


### PR DESCRIPTION
Assigns ownership for infrastructure, configuration, and core logic to @thehcma to ensure proper review cycles.