### PR TITLE
feat: add gda shortcut for google domain admin

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -15,6 +15,10 @@
     "description": "Google Search",
     "url": "https://www.google.com/search?q=#{search_terms}"
   },
+  "gda": {
+    "description": "hcma.info Google Domain Admin",
+    "url": "https://admin.google.com/ac/domains/manage"
+  },
   "gemini": {
     "description": "Gemini",
     "url": "https://gemini.google.com"


### PR DESCRIPTION
Adds the gda shortcut pointing to the hcma.info domains admin manage page.