### PR TITLE
chore(deps): batch dependency updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,10 @@ description = "Smart bookmark manager and URL shortcut system"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
-    "django>=6.0",
-    "jsonschema>=4.0",
+    "black>=26.3.1",
+    "django>=6.0.4",
+    "isort>=8.0.1",
+    "jsonschema>=4.26.0",
     "packaging==26.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,9 @@ name = "bunnify"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "black" },
     { name = "django" },
+    { name = "isort" },
     { name = "jsonschema" },
     { name = "packaging" },
 ]
@@ -61,8 +63,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=6.0" },
-    { name = "jsonschema", specifier = ">=4.0" },
+    { name = "black", specifier = ">=26.3.1" },
+    { name = "django", specifier = ">=6.0.4" },
+    { name = "isort", specifier = ">=8.0.1" },
+    { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "packaging", specifier = "==26.1" },
 ]
 


### PR DESCRIPTION
## Batch dependency updates

Automated dependency updates via `dep-update --batch`.

All outdated packages and CVE fixes combined into a single PR.

## Python updates

| Package | From | To |
|---|---|---|
| `django` | `6.0` | `6.0.4` |
| `jsonschema` | `4.0` | `4.26.0` |
| `isort` | `7.0.0` | `8.0.1` |
| `black` | `24.3.0` | `26.3.1` |
