### PR TITLE
persistent-service: add health check endpoint

### DIFF
--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -132,3 +132,10 @@ class SmokeTests(TestCase):
         self.assertEqual(
             response["Location"], "https://github.com/Shopify/shopify-build/pull/12345"
         )
+
+    def test_health_check_loads(self):
+        """Test that the health check endpoint loads successfully"""
+        response = self.client.get("/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), "ok")
+        self.assertEqual(response["Content-Type"], "text/plain")

--- a/bookmarks/urls.py
+++ b/bookmarks/urls.py
@@ -14,5 +14,6 @@ urlpatterns = [
     path("api/suggestions/", views.search_suggestions, name="suggestions"),
     path("api/history/", views.command_history, name="history"),
     path("review-pr/", views.request_copilot_review, name="review_pr"),
+    path("health", views.health_check, name="health_check"),
     path("<str:key>/", views.redirect_bookmark, name="redirect"),
 ]

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -664,6 +664,13 @@ def request_copilot_review(
             logger.error(f"Error during streaming: {e}", exc_info=True)
             yield f'<script>document.querySelector(".spinner").style.display = "none"; document.getElementById("status-text").innerHTML = "❌ Error: {html_module.escape(str(e))}";</script>'
 
-    from django.http import StreamingHttpResponse
-
     return StreamingHttpResponse(stream_review(), content_type="text/html")
+
+
+@require_http_methods(["GET"])
+def health_check(request: HttpRequest) -> HttpResponse:
+    """
+    Simple health check endpoint that returns 'ok'
+    Used by systemd and monitoring tools to verify the service is alive.
+    """
+    return HttpResponse("ok", content_type="text/plain")


### PR DESCRIPTION
## Stack Context

This stack enables Bunnify to run as a persistent background service on Linux, mirroring improvements from the fpdf repository.

## Why?

Adds a `/health` endpoint and associated unit tests. This is a prerequisite for systemd liveness checks and external monitoring to verify that the server is alive and responding.
