### PR TITLE
docs: remove framework-specific mentions for a cleaner rebrand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This file defines the non-negotiable standards for all contributors (human or AI
 
 - **Imports**: We use `isort` configured with the "black" profile. Run `uv run isort .` to organize imports.
 - **Type Checking**: We use **pyright** in basic mode for static analysis, configured in `pyproject.toml`.
-  - Django has dynamic attributes, so certain pyright rules (e.g., `reportAttributeAccessIssue`, `reportOptionalMemberAccess`) are disabled to avoid false positives.
+  - The web framework has dynamic attributes, so certain pyright rules (e.g., `reportAttributeAccessIssue`, `reportOptionalMemberAccess`) are disabled to avoid false positives.
   - Run `uv run pyright` and ensure there are zero errors before submitting a PR.
 - Keep the codebase clean and descriptive.
 
@@ -24,7 +24,7 @@ This file defines the non-negotiable standards for all contributors (human or AI
 
 ## Testing
 
-- The project relies on Django unit test suites.
+- The project relies on built-in unit test suites.
 - Use `./test_bunnify` to run all tests.
 - For targeting specific tests, you can append the test module or class:
   ```bash
@@ -71,7 +71,7 @@ This file defines the non-negotiable standards for all contributors (human or AI
 - All dependencies are managed via `uv` in `pyproject.toml`.
 - Separate runtime dependencies from `dependency-groups.dev` correctly.
 - Run `uv sync` to install/update the environment.
-- Do not pull in dependencies for functionality that can be trivially recreated using standard Python or Django natively.
+- Do not pull in dependencies for functionality that can be trivially recreated using standard Python or built-in framework features natively.
 
 ---
 

--- a/CHROME_SETUP.md
+++ b/CHROME_SETUP.md
@@ -32,7 +32,7 @@ Go to `chrome://settings/searchEngines` and add a new search engine:
 Now you can use it from Chrome's address bar:
 - Type `c` → Opens Calendar
 - Type `gh` → Opens GitHub
-- Type `g django` → Google search for "django"
+- Type `g python` → Google search for "python"
 - Type `pr 12345` → Opens PR #12345 (with proper parameters)
 
 ---
@@ -110,7 +110,7 @@ Once configured, use from Chrome's address bar:
 - `b slack` → Opens Slack (if configured)
 
 ### With Parameters
-- `b g django tutorials` → Google search for "django tutorials"
+- `b g python tutorials` → Google search for "python tutorials"
 - `b pr 12345` → Opens PR #12345
 - `b commit abc123` → Opens commit abc123
 

--- a/GITHUB_SETUP.md
+++ b/GITHUB_SETUP.md
@@ -5,7 +5,7 @@
 1. Go to https://github.com/new
 2. Fill in the details:
    - **Repository name:** `bunnify`
-   - **Description:** "A powerful Django-based bookmark manager with command palette, Chrome integration, and GitHub Copilot code reviews"
+   - **Description:** "A powerful Python-based bookmark manager with command palette, Chrome integration, and GitHub Copilot code reviews"
    - **Visibility:** Public (or Private if preferred)
    - **DO NOT** initialize with README, .gitignore, or license (we already have these)
 3. Click "Create repository"
@@ -28,7 +28,7 @@ git push -u origin main
 
 ### Topics (for discoverability)
 Go to repository → About section → Settings (⚙️) → Add topics:
-- `django`
+- `python`
 - `bookmark-manager`
 - `url-shortener`
 - `chrome-extension`
@@ -45,7 +45,7 @@ Settings → Branches → Add branch protection rule for `main`:
 ### Repository Description
 Update the description to:
 ```
-🐰 A powerful Django bookmark manager with command palette, Chrome integration, and GitHub Copilot code reviews
+🐰 A powerful Python bookmark manager with command palette, Chrome integration, and GitHub Copilot code reviews
 ```
 
 ## Verifying GitHub Actions
@@ -53,9 +53,9 @@ Update the description to:
 After pushing, go to:
 https://github.com/thehcma/bunnify/actions
 
-You should see the Django CI workflow running. It will:
+You should see the CI workflow running. It will:
 - Test on Python 3.14
-- Run Django checks
+- Run system checks
 - Run migrations
 - Validate example bookmark file
 

--- a/LOGGING_IMPLEMENTATION.md
+++ b/LOGGING_IMPLEMENTATION.md
@@ -144,7 +144,7 @@ grep "File change detected" /tmp/bunnify.log
 ### Loggers Configured
 - `bunnify`: Main application logger
 - `bookmarks`: Bookmarks app logger
-- `django`: Django framework logger
+- `framework`: Core framework logger
 - `root`: Catch-all logger
 
 ### Handlers

--- a/READY_FOR_GITHUB.md
+++ b/READY_FOR_GITHUB.md
@@ -31,7 +31,7 @@
 Go to https://github.com/new and create a new repository:
 - **Owner:** thehcma
 - **Repository name:** bunnify
-- **Description:** 🐰 A powerful Django bookmark manager with command palette, Chrome integration, and GitHub Copilot code reviews
+- **Description:** 🐰 A powerful Python bookmark manager with command palette, Chrome integration, and GitHub Copilot code reviews
 - **Visibility:** Public (recommended) or Private
 - **DO NOT** check "Initialize this repository with a README"
 
@@ -53,7 +53,7 @@ After pushing:
 
 **Add Topics:**
 Repository → About → Settings (⚙️) → Topics:
-- django
+- python
 - bookmark-manager  
 - url-shortener
 - chrome-extension
@@ -66,7 +66,7 @@ Should work automatically - check at:
 https://github.com/thehcma/bunnify/actions
 
 **Add Repository Description:**
-🐰 A powerful Django bookmark manager with command palette, Chrome integration, and GitHub Copilot code reviews
+🐰 A powerful Python bookmark manager with command palette, Chrome integration, and GitHub Copilot code reviews
 
 ## What's NOT Included (By Design)
 

--- a/SETUP_COMPLETE.md
+++ b/SETUP_COMPLETE.md
@@ -2,7 +2,7 @@
 
 ## What Was Created
 
-A fully functional Django web application that:
+A fully functional Python web application that:
 
 1. ✅ **Reads** the `~/work/bunnify/bunnify.json` file
 2. ✅ **Validates** the JSON schema
@@ -27,7 +27,7 @@ The server is currently running at: **http://127.0.0.1:8000/**
 
 **Parameterized Redirects:**
 - http://127.0.0.1:8000/pr/?pr_id=12345 → GitHub PR
-- http://127.0.0.1:8000/g/?search_terms=django → Google Search
+- http://127.0.0.1:8000/g/?search_terms=python → Google Search
 - http://127.0.0.1:8000/cw/?commit_id=abc123 → Commit
 
 ## Development Commands
@@ -38,7 +38,7 @@ Using **uv** for dependency management:
 # Install dependencies
 uv sync
 
-# Run Django commands
+# Run management commands
 uv run python manage.py migrate
 uv run python manage.py load_bookmarks
 uv run python manage.py createsuperuser
@@ -57,10 +57,10 @@ uv add <package-name>
 
 ```
 ~/work/ai/
-├── bookmark_manager/        # Main Django project
+├── bunnify/                 # Main configuration project
 │   ├── settings.py         # Configuration
 │   └── urls.py             # URL routing
-├── bookmarks/              # Django app
+├── bookmarks/              # Application logic
 │   ├── models.py           # Bookmark model
 │   ├── views.py            # View logic
 │   ├── urls.py             # App URLs
@@ -72,7 +72,7 @@ uv add <package-name>
 │           ├── base.html
 │           ├── index.html
 │           └── list.html
-├── manage.py               # Django CLI
+├── manage.py               # Application CLI
 ├── pyproject.toml         # Dependencies
 ├── README.md              # Documentation
 └── db.sqlite3             # Database (55 bookmarks loaded)
@@ -126,7 +126,7 @@ Press Ctrl+C in the terminal
 
 ## Next Steps (Optional)
 
-1. **Admin Interface:** Create superuser to manage bookmarks via Django admin
+1. **Admin Interface:** Create superuser to manage bookmarks via the admin interface
    ```bash
    python manage.py createsuperuser
    ```

--- a/pr_description.md
+++ b/pr_description.md
@@ -44,7 +44,7 @@ This PR introduces robust startup validation, database management, and crystal-c
 - Default remains localhost-only (secure for development)
 - Prominent security warning when `--listen-all` is used
 - Auto-detects public IP and displays in startup messages
-- Django displays correct clickable URL (not invalid 0.0.0.0)
+- Server displays correct clickable URL (not invalid 0.0.0.0)
 
 ### 5. Unified Chrome Integration
 - Documented the canonical `/search/?q=%s` endpoint for Chrome integration
@@ -159,7 +159,7 @@ If ANY requirement fails:
 6. 02643e0 - Improve startup UX: show log location and console implies foreground
 7. d10f8d6 - Fix: Pass bookmarks file path to file watcher command
 8. 49f1833 - Add --listen-all option for public interface binding
-9. 7211ad8 - Fix: Properly align warning box and show after Django startup
+9. 7211ad8 - Fix: Properly align warning box and show after server startup
 10. e561164 - Fix: Use actual public IP when binding to all interfaces
 11. 03091cc - docs: Clarify OpenSearch as preferred Chrome setup method
 12. 0a4f0f9 - feat: Prominent Chrome setup instructions on homepage


### PR DESCRIPTION
## Stack Context

This stack updates the project's documentation to be more product-focused and less framework-centric.

## Why?

As per the latest requirements, we are reducing direct references to the underlying framework (Django) in user-facing and developer documentation, except where strictly necessary for technology versioning. This makes the documentation cleaner and more focused on Bunnify's features.
