### PR TITLE
feat: add gm shortcut for Gmail

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -55,6 +55,10 @@
     "description": "Google Keep",
     "url": "https://keep.google.com"
   },
+  "gm": {
+    "description": "Gmail",
+    "url": "https://mail.google.com"
+  },
   "gpr": {
     "description": "Graphite PR review (Usage: gpr <org/repo> <pr_number>)",
     "url": "https://app.graphite.com/github/#{repo}/pull/#{pr_number}"

--- a/bunnify.json.example
+++ b/bunnify.json.example
@@ -7,6 +7,10 @@
     "description": "Google Search",
     "url": "https://www.google.com/search?q=#{search_terms}"
   },
+  "gm": {
+    "description": "Gmail",
+    "url": "https://mail.google.com"
+  },
   "gh": {
     "description": "GitHub",
     "url": "https://github.com"


### PR DESCRIPTION
## Stack Context

This stack adds a new useful bookmark to the default configuration.

## Why?

Gmail is a highly used service, and adding a `gm` shortcut follows the project's pattern of using `g` + service initial (like `gd` and `gk`). This improves the out-of-the-box utility of Bunnify.
