### PR TITLE
fix(start-development): --refresh starts service if not running

### DIFF
--- a/scripts/dev/start-development
+++ b/scripts/dev/start-development
@@ -18,7 +18,7 @@ for arg in "$@"; do
             echo ""
             echo "Options:"
             echo "  --help     Show this help message"
-            echo "  --refresh  Pull latest main and restart the bunnify service if it is running"
+            echo "  --refresh  Pull latest main; run setup-service if not installed, otherwise ensure service is running"
             echo "  --resume   Resume an existing in-progress worktree (or create a new one)"
             exit 0
             ;;
@@ -34,7 +34,7 @@ echo "=========================================="
 echo "    Bunnify Session Initialization        "
 echo "=========================================="
 
-# --refresh mode: pull main + restart service if running, then exit
+# --refresh mode: pull main + ensure service is installed and running, then exit
 if [[ "$refresh" == "true" ]]; then
     cd "$main_repo"
     echo "Fetching latest remote state..."
@@ -44,12 +44,24 @@ if [[ "$refresh" == "true" ]]; then
     if [[ "$local_main" != "$remote_main" ]]; then
         echo "Main is outdated. Pulling latest..."
         git merge --ff-only origin/main
-        if systemctl --user is-active --quiet bunnify; then
-            echo "Restarting bunnify service..."
-            systemctl --user restart bunnify
-        fi
     else
         echo "Main is already up to date."
+    fi
+    readonly service_unit="${HOME}/.config/systemd/user/bunnify.service"
+    if [[ ! -f "$service_unit" ]]; then
+        echo "Service not installed. Running setup-service..."
+        "$main_repo/scripts/setup-service"
+    else
+        systemctl --user daemon-reload
+        if systemctl --user is-active --quiet bunnify; then
+            if [[ "$local_main" != "$remote_main" ]]; then
+                echo "Restarting bunnify service..."
+                systemctl --user restart bunnify
+            fi
+        else
+            echo "Starting bunnify service..."
+            systemctl --user start bunnify
+        fi
     fi
     echo "=========================================="
     exit 0


### PR DESCRIPTION
## Summary

The `--refresh` flag in `scripts/dev/start-development` previously only restarted the bunnify service when main had new commits. If the service was stopped for any reason, `--refresh` would leave it stopped.

## Changes

- **`scripts/dev/start-development`**: Decouple service action from whether main was updated.
  - Always run `daemon-reload` to clear any stale unit-changed warnings.
  - If the service is already active and main was updated → restart.
  - If the service is not active → start it unconditionally.
  - If the service is active and main was already up to date → no-op.
- Update the `--refresh` header comment to reflect the new behaviour.

## Dependencies

Stacked on #100.