### PR TITLE
fix(ci): replace per-job graphite bot condition with guard job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,45 @@ on:
       - '**/graphite-base/**'
 
 jobs:
+  guard:
+    name: Guard
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          # Skip merge-queue staging branches — the merge queue validates the
+          # integrated state itself; CI there duplicates work.
+          if [[ "$HEAD_REF" == gtmq_merge_* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Skip when the PR is already merged — Graphite pushes a restack
+          # commit to the next branch after a merge lands, which would otherwise
+          # trigger a redundant CI run on an already-validated diff.
+          pr_number="$PR_NUMBER"
+          if [[ -n "$pr_number" ]]; then
+            state=$(gh pr view "$pr_number" --repo "$REPOSITORY" --json state -q .state)
+            if [[ "$state" == "MERGED" ]]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint-python:
     name: Python lint & format checks
+    needs: guard
+    if: needs.guard.outputs.skip != 'true'
     runs-on: ubuntu-latest
-    if: github.actor != 'graphite-app[bot]' || (github.event.pull_request.draft == true && !startsWith(github.head_ref, 'gtmq_merge_'))
     steps:
     - uses: actions/checkout@v6
 
@@ -38,8 +73,9 @@ jobs:
 
   lint-shell:
     name: Shell script linting
+    needs: guard
+    if: needs.guard.outputs.skip != 'true'
     runs-on: ubuntu-latest
-    if: github.actor != 'graphite-app[bot]' || (github.event.pull_request.draft == true && !startsWith(github.head_ref, 'gtmq_merge_'))
     steps:
     - uses: actions/checkout@v6
 
@@ -54,8 +90,9 @@ jobs:
 
   test:
     name: Tests & validations
+    needs: guard
+    if: needs.guard.outputs.skip != 'true'
     runs-on: ubuntu-latest
-    if: github.actor != 'graphite-app[bot]' || (github.event.pull_request.draft == true && !startsWith(github.head_ref, 'gtmq_merge_'))
     steps:
     - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem

The old per-job condition:

```
if: github.actor != 'graphite-app[bot]' || (github.event.pull_request.draft == true
&& !startsWith(github.head_ref, 'gtmq_merge_'))
```

When Graphite restacks a branch after a stack member merges, the actor is `graphite-app[bot]` and the PR is not a draft — so the expression evaluates to false and CI silently never runs. Any PR stuck in a Graphite restack will have zero CI results.

## Solution

A single `guard` job runs first and sets a `skip` output. All three work jobs (`lint-python`, `lint-shell`, `test`) declare `needs: guard` and `if: needs.guard.outputs.skip != 'true'`.

The guard skips only two cases:

- **Merge-queue staging branches** (`gtmq_merge_*`) — the queue validates integrated state itself; running CI there duplicates work
- **Already-merged PRs** — Graphite pushes a restack commit to the next branch after a merge lands; that push would otherwise trigger a redundant run on an already-validated diff

All other pushes — human or Graphite bot restack on a live PR — run CI normally.