### PR TITLE
fix: copy primary worktree .env before setting DATABASE_URL

### DIFF
--- a/bunnify-server
+++ b/bunnify-server
@@ -123,6 +123,16 @@ cd "$script_dir" || exit 1
 # Ensure common binary paths are in PATH (needed for nohup/background processes)
 export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
+# Load .env into the environment so DATABASE_URL and other settings reach Django.
+# on-deploy writes DATABASE_URL to .env for feature worktrees; without this,
+# os.environ never sees it and Django falls back to BASE_DIR/db.sqlite3.
+if [[ -f "$script_dir/.env" ]]; then
+    set -o allexport
+    # shellcheck source=/dev/null
+    source "$script_dir/.env"
+    set +o allexport
+fi
+
 # Find uv command
 if command -v uv > /dev/null 2>&1; then
     uv_cmd="uv"

--- a/scripts/on-deploy
+++ b/scripts/on-deploy
@@ -20,6 +20,41 @@ if [[ -d "$HOME/.local/bin" ]]; then
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
+# Worktree database: when running from a linked worktree, point DATABASE_URL at
+# the primary worktree's db.sqlite3 so all worktrees share the same live database.
+# Without this, Django resolves db.sqlite3 relative to settings.py inside the
+# worktree directory, which won't have any data.
+primary_dir="$(git -C "$repo_dir" worktree list --porcelain | awk 'NR==1{print $2}')"
+env_file="$repo_dir/.env"
+primary_env="$primary_dir/.env"
+
+# Feature worktrees: copy the primary worktree's .env so all manually-configured
+# settings carry over without needing to be re-entered. DATABASE_URL will be
+# appended below to redirect to the primary db.
+if [[ "$repo_dir" != "$primary_dir" ]] && [[ -f "$primary_env" ]]; then
+    cp "$primary_env" "$env_file"
+    echo "  Copied .env from primary worktree (settings carry over)."
+fi
+
+if [[ "$repo_dir" != "$primary_dir" ]]; then
+    db_url="sqlite:///${primary_dir}/db.sqlite3"
+    if [[ ! -f "$env_file" ]]; then
+        echo "DATABASE_URL=${db_url}" > "$env_file"
+        echo "  Created .env with DATABASE_URL pointing to primary worktree db."
+    elif ! grep -q '^DATABASE_URL=' "$env_file"; then
+        echo "DATABASE_URL=${db_url}" >> "$env_file"
+        echo "  Added DATABASE_URL pointing to primary worktree db."
+    elif ! grep -qF "DATABASE_URL=${db_url}" "$env_file"; then
+        sed -i "s|^DATABASE_URL=.*|DATABASE_URL=${db_url}|" "$env_file"
+        echo "  Updated DATABASE_URL to point to primary worktree db."
+    else
+        echo "  DATABASE_URL up to date — no change needed."
+    fi
+    echo "  Using database from main worktree: ${primary_dir}/db.sqlite3"
+else
+    echo "  Using local database: ${repo_dir}/db.sqlite3"
+fi
+
 # Record the deployed commit SHA so subsequent runs can skip unchanged builds.
 current_sha="$(git rev-parse HEAD 2>/dev/null || true)"
 sha_file="$HOME/scratch/bunnify/on-deploy-sha"


### PR DESCRIPTION
fix: copy primary worktree .env before setting DATABASE_URL

When on-deploy runs from a linked worktree and the primary worktree has a
.env, copy it first so any manually-configured settings carry over without
needing to be re-entered. DATABASE_URL is then appended to redirect to the
primary worktree's db.sqlite3.

fix: load .env into environment before starting Django

Django's database config reads os.environ directly. Without loading the
.env file, DATABASE_URL written by on-deploy for feature worktrees is
invisible to Django, causing it to fall back to BASE_DIR/db.sqlite3 and
start with an empty database.