### PR TITLE
chore: auto-label Dependabot PRs with merge-it

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot Auto Merge
+
+# Automatically add the "merge-it" label to Dependabot PRs so they are
+# picked up by the Graphite merge queue without manual intervention.
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add merge-it label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "${PR}" --add-label merge-it --repo "${REPO}"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/dependabot-auto-merge.yml` so Dependabot PRs receive the `merge-it` label and enter the Graphite merge queue automatically.

## Test plan

- [ ] CI green
- [ ] After merge, next Dependabot PR gets `merge-it` on open


Made with [Cursor](https://cursor.com)