### PR TITLE
chore: add merged-branch cleanup workflows

### DIFF
--- a/.github/workflows/cleanup-branch-on-merge.yml
+++ b/.github/workflows/cleanup-branch-on-merge.yml
@@ -1,0 +1,35 @@
+name: Cleanup Branch on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-merged-branch:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Delete merged branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          # Don't delete main
+          if [ "$BRANCH_NAME" = "main" ]; then
+            echo "ℹ️ Skipping main branch"
+            exit 0
+          fi
+
+          echo "PR was merged, deleting branch ${BRANCH_NAME}..."
+
+          # Delete the branch
+          if gh api "repos/${REPOSITORY}/git/refs/heads/${BRANCH_NAME}" -X DELETE 2>/dev/null; then
+            echo "✅ Deleted ${BRANCH_NAME}"
+          else
+            echo "ℹ️ Branch ${BRANCH_NAME} already deleted or doesn't exist"
+          fi

--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -1,0 +1,79 @@
+name: Cleanup Merged Branches
+
+on:
+  schedule:
+    # Run daily at 6 AM UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-merged-branches:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cleanup all merged branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🔍 Finding all branches..."
+
+          # Get all branches except main (use || true to handle case where only main exists)
+          BRANCHES=$(gh api repos/${{ github.repository }}/branches --paginate --jq '.[].name' | grep -v '^main$' || true)
+
+          if [ -z "$BRANCHES" ]; then
+            echo "ℹ️ No branches found (besides main)"
+            exit 0
+          fi
+
+          echo "Found $(echo "$BRANCHES" | wc -l | tr -d ' ') branches to check"
+          echo ""
+
+          # Calculate date 30 days ago (for closed PR cleanup)
+          THIRTY_DAYS_AGO=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ)
+          echo "Cutoff date for closed PRs: ${THIRTY_DAYS_AGO}"
+          echo ""
+
+          DELETED=0
+          KEPT=0
+
+          for BRANCH in $BRANCHES; do
+            echo "Checking branch: ${BRANCH}..."
+
+            # Search for closed PRs that used this branch as head
+            PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?state=closed&head=${{ github.repository_owner }}:${BRANCH}" --jq '.[0].number' 2>/dev/null || echo "")
+
+            if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+              echo "  No closed PR found for this branch, keeping"
+              KEPT=$((KEPT + 1))
+              continue
+            fi
+
+            # Fetch full PR details to get merged status
+            PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{merged, closed_at}' 2>/dev/null || echo "")
+            PR_MERGED=$(echo "$PR_DATA" | jq -r '.merged')
+            PR_CLOSED_AT=$(echo "$PR_DATA" | jq -r '.closed_at')
+
+            if [ "$PR_MERGED" = "true" ]; then
+              echo "  Branch was merged via PR #${PR_NUMBER}, deleting..."
+              gh api "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" -X DELETE 2>/dev/null && \
+                echo "  ✅ Deleted ${BRANCH}" && \
+                DELETED=$((DELETED + 1)) || \
+                echo "  ⚠️ Failed to delete ${BRANCH}"
+            elif [[ "$PR_CLOSED_AT" < "$THIRTY_DAYS_AGO" ]]; then
+              echo "  PR #${PR_NUMBER} was closed without merge on ${PR_CLOSED_AT} (>30 days), deleting..."
+              gh api "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" -X DELETE 2>/dev/null && \
+                echo "  ✅ Deleted ${BRANCH}" && \
+                DELETED=$((DELETED + 1)) || \
+                echo "  ⚠️ Failed to delete ${BRANCH}"
+            else
+              echo "  PR #${PR_NUMBER} was closed without merge on ${PR_CLOSED_AT} (<30 days), keeping branch"
+              KEPT=$((KEPT + 1))
+            fi
+          done
+
+          echo ""
+          echo "📊 Summary: Deleted ${DELETED} branches, kept ${KEPT} branches"


### PR DESCRIPTION
## Summary

- **`cleanup-branch-on-merge.yml`** — delete the PR head branch when a PR merges.
- **`cleanup-merged-branches.yml`** — daily sweep (6:00 UTC) plus `workflow_dispatch` for merged branches and closed-without-merge branches older than 30 days.

Same pattern as my-tracks, domesti-bot, fpdf, and tsp-maximizer.

## Test plan

- [ ] CI green
- [ ] Optional: `workflow_dispatch` on Cleanup Merged Branches after merge


Made with [Cursor](https://cursor.com)