### PR TITLE
feat: redirect htt-prefixed queries to typed URLs

### DIFF
--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -102,6 +102,18 @@ class SmokeTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], "http://sony.house.hcma")
 
+    def test_search_direct_url_http(self):
+        """Test that queries starting with htt redirect to the typed URL"""
+        response = self.client.get("/search/", {"q": "http://example.com/path"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "http://example.com/path")
+
+    def test_search_direct_url_https(self):
+        """Test that https URLs are passed through directly"""
+        response = self.client.get("/search/", {"q": "https://example.com"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], "https://example.com")
+
     def test_direct_bookmark_redirect(self):
         """Test direct URL redirect via /key/"""
         response = self.client.get("/gh/")

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -56,6 +56,16 @@ def _substitute_placeholder_values(
     return substituted_url
 
 
+def _make_redirect_response(request: HttpRequest, url: str) -> HttpResponse:
+    """Return a redirect (or browser_url page for special protocols)."""
+    if url.startswith(("chrome://", "about://", "file://")):
+        return render(request, "bookmarks/browser_url.html", {"url": url})
+
+    response = HttpResponse(status=302)
+    response["Location"] = url
+    return response
+
+
 @require_http_methods(["GET"])
 def search_redirect(request: HttpRequest) -> HttpResponse:
     """
@@ -73,6 +83,10 @@ def search_redirect(request: HttpRequest) -> HttpResponse:
     if not query:
         logger.warning("Empty search query received")
         return HttpResponseNotFound(content="No search query provided")
+
+    if query.lower().startswith("htt"):
+        logger.info(f"Direct URL redirect: url='{query}'")
+        return _make_redirect_response(request, query)
 
     # Split the query into parts
     parts = query.split(None, 1)  # Split into key and rest
@@ -167,16 +181,7 @@ def search_redirect(request: HttpRequest) -> HttpResponse:
         # Replace all placeholders with their values
         url = _substitute_placeholder_values(url, param_mapping)
 
-    # Check if this is a special protocol (chrome://, about://, etc.)
-    # Browsers block navigation to these URLs from web pages for security
-    # So we display the URL with copy-paste instructions
-    if url.startswith(("chrome://", "about://", "file://")):
-        return render(request, "bookmarks/browser_url.html", {"url": url})
-
-    # For normal HTTP(S) URLs, use a standard 302 redirect
-    response = HttpResponse(status=302)
-    response["Location"] = url
-    return response
+    return _make_redirect_response(request, url)
 
 
 @require_http_methods(["GET"])
@@ -224,16 +229,7 @@ def redirect_bookmark(request: HttpRequest, key: str) -> HttpResponse:
         url = _substitute_placeholder_values(url, param_mapping)
 
     logger.info(f"Redirecting to: {url}")
-    # Check if this is a special protocol (chrome://, about://, etc.)
-    # Browsers block navigation to these URLs from web pages for security
-    # So we display the URL with copy-paste instructions
-    if url.startswith(("chrome://", "about://", "file://")):
-        return render(request, "bookmarks/browser_url.html", {"url": url})
-
-    # For normal HTTP(S) URLs, use a standard 302 redirect
-    response = HttpResponse(status=302)
-    response["Location"] = url
-    return response
+    return _make_redirect_response(request, url)
 
 
 @never_cache

--- a/test_integration
+++ b/test_integration
@@ -110,6 +110,9 @@ assert_redirect "/gh/" "https://github.com"
 # E.g. "g query" mapped via `search_redirect` view which catches /search/?q=g%20query
 assert_redirect "/search/?q=g%20hello" "https://www.google.com/search?q=hello"
 
+# Test direct URL passthrough
+assert_redirect "/search/?q=http%3A%2F%2Fexample.com" "http://example.com"
+
 # Test multi parameter substitution PR bookmark
 assert_redirect "/search/?q=pr%20the-hcma%2Fbunnify%20123" "https://github.com/the-hcma/bunnify/pull/123"
 


### PR DESCRIPTION
Treat search queries starting with htt as direct URL entry so users can navigate to sites they type in full.

Co-authored-by: Cursor <cursoragent@cursor.com>