### PR TITLE
feat: fall back to Google search for unmatched queries

### DIFF
--- a/bookmarks/templates/bookmarks/cmd.html
+++ b/bookmarks/templates/bookmarks/cmd.html
@@ -453,7 +453,10 @@
                 const bookmark = findBookmarkByKey(firstWord);
                 
                 if (!bookmark) {
-                    showError(`Bookmark '${firstWord}' not found. Type 'h' to see all available bookmarks.`);
+                    addToHistory(inputValue);
+                    window.open(`/search/?q=${encodeURIComponent(inputValue)}`, '_blank');
+                    input.value = '';
+                    historyIndex = -1;
                     return;
                 }
                 
@@ -490,8 +493,8 @@
                     addToHistory(inputValue);
                     window.open(`/search/?q=${encodeURIComponent(inputValue)}`, '_blank');
                 } else {
-                    // Show error instead of executing invalid command
-                    showError(`Bookmark '${firstWord}' not found. Type 'h' to see all available bookmarks.`);
+                    addToHistory(inputValue);
+                    window.open(`/search/?q=${encodeURIComponent(inputValue)}`, '_blank');
                 }
             }
             return;
@@ -538,7 +541,7 @@
             const bookmark = findBookmarkByKey(firstWord);
             
             if (!bookmark) {
-                showError(`Bookmark '${firstWord}' not found. Type 'h' to see all available bookmarks.`);
+                window.open(`/search/?q=${encodeURIComponent(query)}`, '_blank');
                 return;
             }
             

--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -76,9 +76,13 @@ class SmokeTests(TestCase):
         self.assertContains(response, "requires parameter(s):", status_code=400)
 
     def test_search_nonexistent_bookmark(self):
-        """Test that searching for nonexistent bookmark returns 404"""
-        response = self.client.get("/search/", {"q": "nonexistent"})
-        self.assertEqual(response.status_code, 404)
+        """Test that unmatched queries fall back to Google search"""
+        response = self.client.get("/search/", {"q": "nonexistent query"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            "https://www.google.com/search?q=nonexistent%20query",
+        )
 
     def test_search_printer_shortcut(self):
         """Test printer shortcut redirect"""

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 # Get logger for this module
 logger = logging.getLogger(__name__)
 PLACEHOLDER_PATTERN = re.compile(r"#\{(\w+)\}")
+GOOGLE_SEARCH_URL = "https://www.google.com/search?q=#{search_terms}"
 
 
 def _encode_placeholder_value(url_template: str, placeholder: str, value: str) -> str:
@@ -54,6 +55,11 @@ def _substitute_placeholder_values(
         substituted_url = substituted_url.replace(f"#{{{placeholder}}}", encoded_value)
 
     return substituted_url
+
+
+def _google_search_url(query: str) -> str:
+    """Build a Google search URL for the given query string."""
+    return _substitute_placeholder_values(GOOGLE_SEARCH_URL, {"search_terms": query})
 
 
 def _make_redirect_response(request: HttpRequest, url: str) -> HttpResponse:
@@ -114,8 +120,8 @@ def search_redirect(request: HttpRequest) -> HttpResponse:
             f"Found bookmark: key='{key}', url='{bookmark.url}', params='{param_string}'"
         )
     except Bookmark.DoesNotExist:
-        logger.warning(f"Bookmark not found: key='{key}'")
-        return HttpResponseNotFound(content=f"Bookmark '{key}' not found")
+        logger.info(f"No bookmark for key='{key}', falling back to Google search")
+        return _make_redirect_response(request, _google_search_url(query))
 
     url = bookmark.url
 

--- a/test_integration
+++ b/test_integration
@@ -110,6 +110,9 @@ assert_redirect "/gh/" "https://github.com"
 # E.g. "g query" mapped via `search_redirect` view which catches /search/?q=g%20query
 assert_redirect "/search/?q=g%20hello" "https://www.google.com/search?q=hello"
 
+# Test Google search fallback for unmatched queries
+assert_redirect "/search/?q=random%20stuff" "https://www.google.com/search?q=random%20stuff"
+
 # Test direct URL passthrough
 assert_redirect "/search/?q=http%3A%2F%2Fexample.com" "http://example.com"
 


### PR DESCRIPTION
When no bookmark matches the typed query, redirect to Google search instead of returning 404, including from the command palette.

Co-authored-by: Cursor <cursoragent@cursor.com>