### PR TITLE
fix(ci): improving merge-related workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: Bunnify CI
 
 on:
-  push:
-    branches: [ main ]
+  # Omitting push: main — the merge queue already validates the integrated
+  # state before landing; a second run after merge duplicates work without
+  # adding signal.
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
     branches-ignore:
       - '**/graphite-base/**'
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,7 +4,7 @@ name: Dependabot Auto Merge
 # picked up by the Graphite merge queue without manual intervention.
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/merged-pr-closer.yml
+++ b/.github/workflows/merged-pr-closer.yml
@@ -1,9 +1,10 @@
 name: Merged PR Closer
 
-# When Graphite merges a stack, child PRs can remain OPEN even though their
-# commits have landed on main.  This workflow detects those PRs by checking
-# for the "Merged by the [Graphite merge queue]" comment posted by
-# graphite-app[bot], then closes them automatically.
+# Open PRs can remain OPEN even after their commits land on main — either
+# because Graphite merged a stack (leaving child PRs open) or because GitHub
+# merged the PR but didn't update its state.  This workflow closes them by
+# checking (1) the GitHub API merged flag, and (2) the Graphite merge queue
+# comment as a fallback.
 on:
   push:
     branches: [main]
@@ -17,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Close open PRs that were merged by Graphite
+    - name: Close open PRs that have already been merged
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
@@ -36,28 +37,36 @@ jobs:
         summary_rows=""
 
         for pr in ${open_prs}; do
-          merge_comment=$(gh api "repos/${REPO}/issues/${pr}/comments" \
-            --jq '[.[] | select(
-              .user.login == "graphite-app[bot]" and
-              (.body | test("Merged by the \\[Graphite merge queue\\]"))
-            )] | first // empty')
+          pr_data=$(gh api "repos/${REPO}/pulls/${pr}" --jq '{title: .title, merged: .merged, merged_at: .merged_at}')
+          title=$(echo "${pr_data}" | jq -r '.title')
+          is_merged=$(echo "${pr_data}" | jq -r '.merged')
+          merge_time=$(echo "${pr_data}" | jq -r '.merged_at // "unknown time"')
 
-          if [ -n "${merge_comment}" ]; then
-            title=$(gh api "repos/${REPO}/pulls/${pr}" --jq '.title')
+          if [ "${is_merged}" = "true" ]; then
+            : # merged via GitHub API — fall through to close
+          else
+            merge_comment=$(gh api "repos/${REPO}/issues/${pr}/comments" \
+              --jq '[.[] | select(
+                .performed_via_github_app.slug == "graphite-app" and
+                (.body | test("Merged by the \\[Graphite merge queue\\]"))
+              )] | first // empty')
+            [ -n "${merge_comment}" ] || { echo "PR #${pr}: open and not yet merged — skipping."; continue; }
             merge_time=$(echo "${merge_comment}" | jq -r '.body' \
               | grep -oP '\*\*[^*]+\*\*(?=: Merged)' | tr -d '*' || echo "unknown time")
-
-            echo "Closing PR #${pr}: \"${title}\" (reason: merged by Graphite merge queue at ${merge_time})"
-            gh api "repos/${REPO}/pulls/${pr}" \
-              --method PATCH \
-              --field state=closed \
-              --silent
-
-            closed_count=$((closed_count + 1))
-            summary_rows="${summary_rows}| #${pr} | ${title} | ${merge_time} |\n"
-          else
-            echo "PR #${pr}: open and not yet merged by merge queue — skipping."
           fi
+
+          echo "Closing PR #${pr}: \"${title}\" (merged at ${merge_time})"
+          gh api "repos/${REPO}/issues/${pr}/comments" \
+            --method POST \
+            --field body="This PR's changes have already landed on \`main\` (merged at ${merge_time}). Closing automatically." \
+            --silent
+          gh api "repos/${REPO}/pulls/${pr}" \
+            --method PATCH \
+            --field state=closed \
+            --silent
+
+          closed_count=$((closed_count + 1))
+          summary_rows="${summary_rows}| #${pr} | ${title} | ${merge_time} |\n"
         done
 
         echo ""
@@ -69,7 +78,7 @@ jobs:
           if [ "${closed_count}" -eq 0 ]; then
             echo "No PRs needed closing."
           else
-            echo "Closed **${closed_count}** PR(s) that were already merged by the Graphite merge queue:"
+            echo "Closed **${closed_count}** PR(s) that were already merged:"
             echo ""
             echo "| PR | Title | Merged at |"
             echo "|----|-------|-----------|"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,9 @@ This file defines the non-negotiable standards for all contributors (human or AI
 - All work is done in stacked branches via `gt create`, `gt modify`, and `gt submit`.
 - Never work directly on `main`. Always create a stack branch: `gt create -m "feat: description"`.
 - Submit stacks with `gt submit` — do not open PRs manually via the GitHub UI.
+- After submitting, mark PRs as ready for review: `gh pr ready <number>`. `gt submit --no-interactive` creates drafts by default.
+- To merge a PR, add the `merge-it` label: `gh pr edit <number> --add-label merge-it`. Never use `gh pr merge` directly.
+- **Always ask the user for confirmation before adding the `merge-it` label.** Adding it triggers the Graphite merge queue; it must not be applied without explicit user approval.
 - Follow **Conventional Commits**: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`.
 - Keep commits focused. One logical change per commit.
 - **Always run the full local pre-PR checklist (see below) before calling `gt submit`.** Do not rely on CI to catch issues that can be caught locally.


### PR DESCRIPTION
Drop redundant push-to-main CI trigger, add ready_for_review PR events,
harden merged-pr-closer to detect GitHub-merged PRs, and document merge-it usage.

Co-authored-by: Cursor <cursoragent@cursor.com>