### PR TITLE
docs: forbid agent writes on main worktree

### DIFF
--- a/.cursor/rules/main-worktree-off-limits.mdc
+++ b/.cursor/rules/main-worktree-off-limits.mdc
@@ -1,0 +1,38 @@
+---
+description: Never modify the primary (main) git worktree unless the user explicitly authorizes it
+alwaysApply: true
+---
+
+# Main worktree is off-limits
+
+The **primary clone** at the repo root (first line of `git worktree list`) is the **main worktree**. Do **not** modify it unless the user explicitly authorizes that in the current conversation.
+
+## Do all work in a stack worktree
+
+1. Run `~/work/ai/repository-helpers/scripts/dev/start-development --worktree <stack-name> --no-interactive`.
+2. `cd` into `.worktrees/<stack-name>-wt` before any implementation, tests, or git writes.
+3. Point tools at the stack worktree (`--dir`, working directory, file paths).
+
+## Forbidden on the main worktree (without explicit user authorization)
+
+- File edits, dependency installs, tests, builds, linters, formatters
+- `dep-updater --dir <repo-root>` (fast-forwards the primary clone and changes git state)
+- `gt create` / `gt modify` / `gt submit` / `gt sync` / `gt restack` / commits / checkouts
+- Leaving uncommitted changes or stray branches
+
+## Read-only on main is OK
+
+`git log`, `git show`, `gh pr view`, and reading files without writing are fine on the main worktree.
+
+## Investigating without polluting main
+
+Use a detached temporary worktree, not the primary clone:
+
+```bash
+git worktree add --detach /tmp/repo-inspect-<id> origin/main
+# ... read-only or isolated experiments ...
+git worktree remove --force /tmp/repo-inspect-<id>
+```
+
+`start-development` may sync the main worktree for environment setup; that does **not** grant permission to implement or run mutating commands there.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,23 @@ This file defines the non-negotiable standards for all contributors (human or AI
   ~/work/ai/repository-helpers/scripts/dev/start-development --worktree <stack-name> --no-interactive
   ```
 - Pass `--resume` to instead pick up an existing in-progress worktree: it lists pending worktrees and lets you select one (or creates a new one if none exist).
+- After `start-development` finishes, **`cd` into the stack worktree** (`.worktrees/<stack-name>-wt`) before any other work. Do not stay in the primary clone.
 
+### Main worktree is off-limits (agents)
+
+The **primary clone** (repo root — first entry in `git worktree list`, usually on branch `main`) is the **main worktree**. Treat it as **read-only** unless the user explicitly authorizes touching it in the current conversation.
+
+**Never on the main worktree** (without explicit user authorization):
+
+- Edit, create, or delete source files, config, or lockfiles
+- Run `uv sync`, tests, builds, or formatters
+- Run `dep-updater` with `--dir` pointing at the primary clone (it may fast-forward `main` and mutate git state)
+- Run `gt create`, `gt modify`, `gt submit`, `gt sync`, `gt restack`, or other Graphite/git write operations
+- Leave uncommitted changes, stray branches, or detached HEAD state
+
+**Always** do implementation, investigation that mutates state, and validation in a **stack worktree** under `.worktrees/<stack-name>-wt`. Pass that path to tools (`--dir`, `cd`, etc.).
+
+`start-development` may update the main worktree for environment sync only; that is not permission to work there. If you need to inspect `main` without changing it, use read-only commands (`git log`, `git show`, `gh pr view`) or a **detached temporary worktree** — not the primary clone.
 
 ## Language & Runtime
 


### PR DESCRIPTION
## Summary
- Document that the primary git worktree (repo root) is read-only for agents unless the user explicitly authorizes otherwise
- Add an always-on Cursor rule (`.cursor/rules/main-worktree-off-limits.mdc`) where applicable
- Require all mutating work in stack worktrees under `.worktrees/<stack-name>-wt`

## Test plan
- [x] Docs only — no code changes

Made with [Cursor](https://cursor.com)