### PR TITLE
fix(ci): delete Graphite MQ staging branches when PR closes

### DIFF
--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -2,10 +2,8 @@ name: Cleanup Merged Branches
 
 on:
   schedule:
-    # Run daily at 6 AM UTC
     - cron: '0 6 * * *'
   workflow_dispatch:
-    # Allow manual trigger
 
 permissions:
   contents: write
@@ -15,65 +13,62 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cleanup all merged branches
+      - name: Delete merged and stale closed PR branches
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
-          echo "🔍 Finding all branches..."
+          is_graphite_mq_branch() {
+            case "${1}" in
+              gtmq_batch_*|gtmq_merge_*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
 
-          # Get all branches except main (use || true to handle case where only main exists)
-          BRANCHES=$(gh api repos/${{ github.repository }}/branches --paginate --jq '.[].name' | grep -v '^main$' || true)
-
-          if [ -z "$BRANCHES" ]; then
-            echo "ℹ️ No branches found (besides main)"
+          branches="$(gh api "repos/${REPOSITORY}/branches" --paginate --jq '.[].name' | grep -v '^main$' || true)"
+          if [[ -z "${branches}" ]]; then
+            echo "No branches found besides main."
             exit 0
           fi
 
-          echo "Found $(echo "$BRANCHES" | wc -l | tr -d ' ') branches to check"
-          echo ""
+          cutoff="$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)"
+          deleted=0
+          kept=0
 
-          # Calculate date 30 days ago (for closed PR cleanup)
-          THIRTY_DAYS_AGO=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ)
-          echo "Cutoff date for closed PRs: ${THIRTY_DAYS_AGO}"
-          echo ""
-
-          DELETED=0
-          KEPT=0
-
-          for BRANCH in $BRANCHES; do
-            echo "Checking branch: ${BRANCH}..."
-
-            # Search for closed PRs that used this branch as head
-            PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?state=closed&head=${{ github.repository_owner }}:${BRANCH}" --jq '.[0].number' 2>/dev/null || echo "")
-
-            if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
-              echo "  No closed PR found for this branch, keeping"
-              KEPT=$((KEPT + 1))
+          for branch in ${branches}; do
+            pr_number="$(
+              gh api "repos/${REPOSITORY}/pulls?state=closed&head=${REPOSITORY_OWNER}:${branch}" \
+                --jq '.[0].number // empty' 2>/dev/null || true
+            )"
+            if [[ -z "${pr_number}" ]]; then
+              kept=$(( kept + 1 ))
               continue
             fi
 
-            # Fetch full PR details to get merged status
-            PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '{merged, closed_at}' 2>/dev/null || echo "")
-            PR_MERGED=$(echo "$PR_DATA" | jq -r '.merged')
-            PR_CLOSED_AT=$(echo "$PR_DATA" | jq -r '.closed_at')
+            pr_data="$(gh api "repos/${REPOSITORY}/pulls/${pr_number}" --jq '{merged, closed_at}')"
+            pr_merged="$(jq -r '.merged' <<<"${pr_data}")"
+            pr_closed_at="$(jq -r '.closed_at' <<<"${pr_data}")"
 
-            if [ "$PR_MERGED" = "true" ]; then
-              echo "  Branch was merged via PR #${PR_NUMBER}, deleting..."
-              gh api "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" -X DELETE 2>/dev/null && \
-                echo "  ✅ Deleted ${BRANCH}" && \
-                DELETED=$((DELETED + 1)) || \
-                echo "  ⚠️ Failed to delete ${BRANCH}"
-            elif [[ "$PR_CLOSED_AT" < "$THIRTY_DAYS_AGO" ]]; then
-              echo "  PR #${PR_NUMBER} was closed without merge on ${PR_CLOSED_AT} (>30 days), deleting..."
-              gh api "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" -X DELETE 2>/dev/null && \
-                echo "  ✅ Deleted ${BRANCH}" && \
-                DELETED=$((DELETED + 1)) || \
-                echo "  ⚠️ Failed to delete ${BRANCH}"
+            delete_branch=0
+            if [[ "${pr_merged}" == "true" ]]; then
+              delete_branch=1
+            elif is_graphite_mq_branch "${branch}"; then
+              # Graphite MQ staging branches are ephemeral once their PR closes.
+              delete_branch=1
+            elif [[ "${pr_closed_at}" < "${cutoff}" ]]; then
+              delete_branch=1
+            fi
+
+            if [[ "${delete_branch}" -eq 1 ]]; then
+              if gh api --method DELETE "repos/${REPOSITORY}/git/refs/heads/${branch}" >/dev/null 2>&1; then
+                deleted=$(( deleted + 1 ))
+              else
+                kept=$(( kept + 1 ))
+              fi
             else
-              echo "  PR #${PR_NUMBER} was closed without merge on ${PR_CLOSED_AT} (<30 days), keeping branch"
-              KEPT=$((KEPT + 1))
+              kept=$(( kept + 1 ))
             fi
           done
 
-          echo ""
-          echo "📊 Summary: Deleted ${DELETED} branches, kept ${KEPT} branches"
+          echo "Deleted ${deleted} branches; kept ${kept} branches."


### PR DESCRIPTION
## Summary
- Sync `cleanup-merged-branches.yml` from repository-helpers so `gtmq_batch_*` and `gtmq_merge_*` branches are deleted as soon as their PR closes (merged or abandoned), not after the 30-day stale window.

## Test plan
- [ ] CI passes
- [ ] After merge, run **Cleanup Merged Branches** workflow (`workflow_dispatch`) to sweep existing stale Graphite MQ branches