### PR TITLE
fix(ci): key CI concurrency on head SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
     branches-ignore:
       - '**/graphite-base/**'
 
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     name: Guard
@@ -134,6 +139,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6.0.2
         with:


### PR DESCRIPTION
## Summary
- Sync `ci.yml` from repository-helpers #211: per-head-SHA concurrency (avoids zombie Secret Scan checks) and canonical `secret-scan` job with `timeout-minutes: 10`.

## Test plan
- [ ] CI passes (Secret Scan completes, not stuck pending)