### PR TITLE
fix(ci): run CI on Graphite restack (push fallback + guard dedup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,17 @@ on:
   # state before landing; a second run after merge duplicates work without
   # adding signal.
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+      types: [opened, reopened, synchronize, ready_for_review, edited]
+    types: [opened, reopened, synchronize, ready_for_review, edited]
     branches-ignore:
       - '**/graphite-base/**'
 
 
+
+  push:
+    branches-ignore:
+      - main
+      - '**/graphite-base/**'
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
@@ -24,7 +30,8 @@ jobs:
       - id: check
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.head_ref }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
@@ -43,6 +50,30 @@ jobs:
             if [[ "$state" == "MERGED" ]]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
             else
+
+          # Skip push CI when pull_request CI is already queued for this SHA.
+          # Both events fire on every PR-branch push; only pull_request checks
+          # should run so we avoid duplicate work without cross-cancelling runs.
+          # If no pull_request run appears (e.g. gt sync restack), push CI runs.
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            PR_COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+              --head "${GITHUB_REPOSITORY_OWNER}:${BRANCH}" --state open \
+              --json number --jq 'length')
+            if [[ "$PR_COUNT" -gt 0 ]]; then
+              for _ in 1 2 3 4 5 6; do
+                RUNS=$(gh api \
+                  "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${GITHUB_SHA}&event=pull_request&per_page=1" \
+                  --jq '.total_count')
+                if [[ "$RUNS" -gt 0 ]]; then
+                  echo "skip=true" >> "$GITHUB_OUTPUT"
+                  echo "Push CI skipped: pull_request workflow covers ${GITHUB_SHA}"
+                  exit 0
+                fi
+                sleep 10
+              done
+            fi
+          fi
               echo "skip=false" >> "$GITHUB_OUTPUT"
             fi
           else


### PR DESCRIPTION
## Summary
- Sync full Graphite restack CI coverage: feature-branch `push` trigger, guard push dedup, and `pull_request` `edited` type.

## Test plan
- [ ] CI passes on this PR