### PR TITLE
chore: delete PR head branches in merged-pr-closer

### DIFF
--- a/.github/workflows/merged-pr-closer.yml
+++ b/.github/workflows/merged-pr-closer.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:
@@ -35,6 +36,12 @@ jobs:
 
           closed_count=0
           summary_rows=""
+
+          delete_head_branch() {
+            local head_ref="$1"
+            local encoded="${head_ref//\//%2F}"
+            gh api --method DELETE "repos/${REPO}/git/refs/heads/${encoded}" >/dev/null 2>&1 || true
+          }
 
           for pr in ${open_prs}; do
             pr_data=$(gh api "repos/${REPO}/pulls/${pr}" \
@@ -105,6 +112,7 @@ jobs:
               --method PATCH \
               --field state=closed \
               --silent
+            delete_head_branch "$(echo "${pr_data}" | jq -r '.head_ref')"
 
             closed_count=$((closed_count + 1))
             summary_rows="${summary_rows}| #${pr} | ${title} | ${close_reason} |\n"


### PR DESCRIPTION
## Summary
- Update `.github/workflows/merged-pr-closer.yml` to delete the PR head branch when closing merged or stale Graphite MQ draft PRs (immediate cleanup instead of waiting for the daily sweeper).
- Adds `contents: write` permission required for branch ref deletion.
- Follow-up rollout from [repository-helpers#228](https://github.com/the-hcma/repository-helpers/pull/228).

## Test plan
- [x] CI green on this PR
- [ ] Merge via Graphite MQ
- [ ] After merge: confirm the next closer run on `main` push deletes orphaned head refs for closed PRs