### PR TITLE
fix(ci): skip duplicate push CI when open PR exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ concurrency:
 
 jobs:
   guard:
+    permissions:
+      contents: read
+      pull-requests: read
     name: Guard
     runs-on: ubuntu-latest
     outputs:
@@ -33,33 +36,35 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          # Skip merge-queue staging branches; Graphite validates the integrated state.
+          # Skip merge-queue staging branches — the merge queue validates the
+          # integrated state itself; CI there duplicates work.
           if [[ "${HEAD_REF}" == gtmq_merge_* ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Skip when the PR is already merged — Graphite pushes a restack
+          # commit to the next branch after a merge lands, which would otherwise
+          # trigger a redundant CI run on an already-validated diff.
+          if [[ -n "${PR_NUMBER}" ]]; then
+            state=$(gh pr view "${PR_NUMBER}" --repo "${REPOSITORY}" --json state -q .state 2>/dev/null || true)
+            if [[ "${state}" == "MERGED" ]]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
 
-          # Skip push CI when pull_request CI is already queued for this SHA.
-          # Both events fire on every PR-branch push; only pull_request checks
-          # should run so we avoid duplicate work without cross-cancelling runs.
-          # If no pull_request run appears (e.g. gt sync restack), push CI runs.
+          # Skip push CI when an open PR already covers this branch.
+          # GitHub always delivers pull_request synchronize for PR-head pushes;
+          # the push trigger is only for restacks without an open PR.
           if [[ "${{ github.event_name }}" == "push" ]]; then
             BRANCH="${GITHUB_REF#refs/heads/}"
             PR_COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" \
-              --head "${GITHUB_REPOSITORY_OWNER}:${BRANCH}" --state open \
+              --head "$BRANCH" --state open \
               --json number --jq 'length')
             if [[ "$PR_COUNT" -gt 0 ]]; then
-              for _ in 1 2 3 4 5 6; do
-                RUNS=$(gh api \
-                  "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${GITHUB_SHA}&event=pull_request&per_page=1" \
-                  --jq '.total_count')
-                if [[ "$RUNS" -gt 0 ]]; then
-                  echo "skip=true" >> "$GITHUB_OUTPUT"
-                  echo "Push CI skipped: pull_request workflow covers ${GITHUB_SHA}"
-                  exit 0
-                fi
-                sleep 10
-              done
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "Push CI skipped: open PR exists; pull_request handles this push"
+              exit 0
             fi
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Rollout from repository-helpers #237 — fix duplicate push/pull_request CI by correcting gh pr list head filter and adding guard pull-requests: read.