### PR TITLE
fix(ci): harden Graphite restack guard push dedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,12 @@ jobs:
           # the push trigger is only for restacks without an open PR.
           if [[ "${{ github.event_name }}" == "push" ]]; then
             BRANCH="${GITHUB_REF#refs/heads/}"
-            PR_COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" \
-              --head "$BRANCH" --state open \
-              --json number --jq 'length')
+            PR_COUNT=0
+            if count="$(gh pr list --repo "$GITHUB_REPOSITORY" \
+                --head "$BRANCH" --state open \
+                --json number --jq 'length' 2>/dev/null)"; then
+              PR_COUNT="$count"
+            fi
             if [[ "$PR_COUNT" -gt 0 ]]; then
               echo "skip=true" >> "$GITHUB_OUTPUT"
               echo "Push CI skipped: open PR exists; pull_request handles this push"


### PR DESCRIPTION
## Summary

- Harden guard push-dedup: use `PR_COUNT=0` and `if count="$(gh pr list ...)"` instead of `$(gh ... || echo 0)` (matches repository-helpers template).

## Test plan

- [ ] CI passes on this PR
