### PR TITLE
feat: add prh shortcut for the-hcma repo PRs page

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -179,6 +179,10 @@
     "description": "GitHub Pull Request (Usage: pr <org/repo> <pr_number>)",
     "url": "https://github.com/#{repo}/pull/#{pr_number}"
   },
+  "prh": {
+    "description": "the-hcma GitHub Pull Requests (Usage: prh <repo>)",
+    "url": "https://github.com/the-hcma/#{repo}/pulls"
+  },
   "printer": {
     "description": "House printer",
     "url": "http://printer.house.hcma"


### PR DESCRIPTION
## Summary
- Add `prh` bookmark shortcut to open the GitHub pull requests page for a the-hcma repo (e.g. `prh bunnify` → `https://github.com/the-hcma/bunnify/pulls`).
- Mirrors the existing `ghh` shortcut pattern, which opens the repo root under the-hcma.

## Test plan
- [x] `./test_bunnify bookmarks.tests.SmokeTests` passes locally
- [ ] After deploy/reload bookmarks, verify `prh bunnify` opens the PRs list in the browser