### PR TITLE
chore: sync agent review cursor rule with canonical breadcrumb

### DIFF
--- a/.cursor/rules/pr-ship-and-review.mdc
+++ b/.cursor/rules/pr-ship-and-review.mdc
@@ -17,7 +17,18 @@ rh="${REPOSITORY_HELPERS_DIR:-$HOME/work/ai/repository-helpers}"
 
 Configure `~/.config/agent-review.env` from `${rh}/etc/agent-review.env.example` (`AGENT_REVIEW_REPORT_TO`, SMTP).
 
-Full loop (exit codes, quota fallback, Bugbot): `${rh}/.cursor/rules/pr-ship-and-review.mdc`.
+<!-- pr-ship-canonical-rule: https://github.com/the-hcma/repository-helpers/blob/main/.cursor/rules/pr-ship-and-review.mdc -->
+
+**Canonical operator prompt (read first):** This file is a consumer summary. Exit codes,
+dual-timeout semantics, quota chains, and triage details are maintained in
+repository-helpers and may change between releases.
+
+Agents **must** read the canonical rule before running the agent review loop:
+
+- **GitHub (`main`):** https://github.com/the-hcma/repository-helpers/blob/main/.cursor/rules/pr-ship-and-review.mdc
+- **Local clone (when `${rh}` is synced to `main`):** `${rh}/.cursor/rules/pr-ship-and-review.mdc`
+
+When this summary and the canonical rule disagree, follow the canonical rule.
 
 ## 1. Local quality gates (all must pass before submit)
 
@@ -53,6 +64,10 @@ Prefer the built-in loop:
 ```bash
 "${rh}/scripts/wait-for-agent-review" loop --pr <n>
 ```
+
+**Dual timeouts** (see `${rh}/etc/agent-review.env.example`): **15m** idle-success after
+all threads are addressed and CI is green; **12h** cap when review cycles never converge.
+Per-agent quota caches skip exhausted agents (CodeRabbit, Copilot, Bugbot).
 
 When `loop` exits **3**, triage each unaddressed agent thread:
 


### PR DESCRIPTION
## Summary

- Sync `.cursor/rules/pr-ship-and-review.mdc` to include the `pr-ship-canonical-rule` breadcrumb and GitHub URL to the canonical operator prompt in repository-helpers.
- Enforced by `github-repo-lint` after repository-helpers #312.

## Test plan

- [x] `github-repo-lint --repo OWNER/NAME` passes pr-ship-and-review rule check after merge

Made with [Cursor](https://cursor.com)