### PR TITLE
fix(deps): batch updates including CVE fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.14"
 dependencies = [
     "black>=26.5.1",
     "click>=8.4.2",
-    "django>=6.0.6",
+    "django>=6.0.7",
     "isort>=8.0.1",
     "jsonschema>=4.26.0",
     "packaging==26.2",

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ dev = [
 requires-dist = [
     { name = "black", specifier = ">=26.5.1" },
     { name = "click", specifier = ">=8.4.2" },
-    { name = "django", specifier = ">=6.0.6" },
+    { name = "django", specifier = ">=6.0.7" },
     { name = "isort", specifier = ">=8.0.1" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "packaging", specifier = "==26.2" },
@@ -110,16 +110,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.6"
+version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/29/ac41e16097af67066d97a7d5775c5d8e7efc5d0284f6b0a159e07b9adb92/django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713", size = 10905525, upload-time = "2026-06-03T13:02:46.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2", size = 8373354, upload-time = "2026-06-03T13:02:41.72Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Batch dependency updates

Automated dependency updates via `dep-updater --batch`.

All outdated packages and CVE fixes combined into a single PR.

## Python CVEs addressed

| Package | Current | Fixed | CVEs |
|---|---|---|---|
| `django` | `6.0.6` | `6.0.7` | PYSEC-2026-2090,  PYSEC-2026-2092, PYSEC-2026-2091 |

## Dependency update summary

| Ecosystem | Package | From | To | CVE? | CVEs |
|---|---|---|---|---|---|
| python/uv | `django` | `6.0.6` | `6.0.7` | no | - |
| python/uv | `django` | `6.0.6` | `6.0.7` | yes | PYSEC-2026-2090,  PYSEC-2026-2092, PYSEC-2026-2091 |

## Python updates

| Package | From | To |
|---|---|---|
| `django` | `6.0.6` | `6.0.7` |
