### PR TITLE
feat: add prhh shortcut for personal GitHub PR lists

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -183,6 +183,10 @@
     "description": "the-hcma GitHub Pull Requests (Usage: prh <repo>)",
     "url": "https://github.com/the-hcma/#{repo}/pulls"
   },
+  "prhh": {
+    "description": "thehcma GitHub Pull Requests (Usage: prhh <repo>)",
+    "url": "https://github.com/thehcma/#{repo}/pulls"
+  },
   "printer": {
     "description": "House printer",
     "url": "http://printer.house.hcma"


### PR DESCRIPTION
## Summary
- Add `prhh` bookmark shortcut mirroring `prh`, but for personal repos under `thehcma`
- Example: `prhh init-files` → `https://github.com/thehcma/init-files/pulls`

## Test plan
- [ ] Reload bookmarks (`load_bookmarks` or file watcher)
- [ ] Confirm `prhh init-files` redirects to the personal repo pulls page
- [ ] Confirm existing `prh <repo>` still targets `the-hcma` org