### PR TITLE
chore: adopt Ruff for lint and format

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,13 +42,13 @@ After creating a PR:
 Before committing, always run these checks locally:
 
 ```bash
-# Check import sorting (must pass with no changes needed)
-uv run isort --check-only --diff .
+# Lint (must pass with no findings)
+uv run ruff check .
 
-# Fix import sorting if needed
-uv run isort .
+# Format check (fix with: uv run ruff format .)
+uv run ruff format --check .
 
-# Type checking (must be 0 errors, 0 warnings)
+# Type checking (must be 0 errors, 0 warnings) — complementary to Ruff
 uv run pyright --warnings
 
 # Shell script linting (must pass with no errors or warnings)
@@ -56,7 +56,7 @@ shellcheck bunnify-server test_integration
 find scripts -type f | xargs shellcheck
 ```
 
-All checks (`isort`, `pyright`, and `shellcheck`) must pass with zero issues before committing. The CI workflow enforces this - PRs with any issues will fail.
+All checks (`ruff check`, `ruff format --check`, `pyright`, and `shellcheck`) must pass with zero issues before committing. The CI workflow enforces this - PRs with any issues will fail.
 
 ## Shell Script Guidelines
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,11 +104,11 @@ jobs:
     - name: Install dependencies (including dev)
       run: uv sync --all-groups
 
-    - name: Check import sorting (isort)
-      run: uv run isort --check-only --diff .
+    - name: Lint with Ruff
+      run: uv run ruff check .
 
-    - name: Check formatting (black)
-      run: uv run black --check .
+    - name: Check formatting with Ruff
+      run: uv run ruff format --check .
 
     - name: Type check (pyright)
       run: uv run pyright --warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ The **primary clone** (repo root — first entry in `git worktree list`, usually
 
 ## Formatting & Linting
 
-- **Imports**: We use `isort` configured with the "black" profile. Run `uv run isort .` to organize imports.
-- **Type Checking**: We use **pyright** in basic mode for static analysis, configured in `pyproject.toml`.
+- **Lint + format**: We use **Ruff** (`[tool.ruff]` in `pyproject.toml`). Run `uv run ruff check .` and `uv run ruff format .` (or `--check` in CI). Ruff replaces black/isort — it does **not** replace type checking.
+- **Type checking**: We use **pyright** in basic mode for static analysis, configured in `pyproject.toml`.
   - The web framework has dynamic attributes, so certain pyright rules (e.g., `reportAttributeAccessIssue`, `reportOptionalMemberAccess`) are disabled to avoid false positives.
   - Run `uv run pyright` and ensure there are zero errors before submitting a PR.
 - Keep the codebase clean and descriptive.
@@ -131,8 +131,9 @@ New dependency versions are adopted on a staggered schedule so **dep-updater** (
 ## CI Checks / Pre-PR (all must pass)
 
 ```bash
-uv run isort --check .
-uv run pyright
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright --warnings
 ./test_bunnify
 ```
 
@@ -141,10 +142,10 @@ No PR may be merged if the above commands fail.
 ### Pre-PR Local Checklist (recommended)
 
 - **Run the unified preflight script:** Prefer using `scripts/checks` which runs formatting, linters, unit tests and (optionally) integration tests with sensible timeouts.
-- **Formatting & linting:** `uv run isort --check-only --diff .` and `uv run black --check .` and `uv run pyright --warnings` must pass locally before creating a PR.
+- **Formatting & linting:** `uv run ruff check .`, `uv run ruff format --check .`, and `uv run pyright --warnings` must pass locally before creating a PR.
 - **Shell linting:** Run `shellcheck bunnify-server test_integration scripts/*` and ensure there are no new errors or warnings.
 - **Unit tests:** Run `./test_bunnify` and ensure all tests pass.
 - **Integration tests (required pre-PR):** Run `./test_integration` — this script uses OS-chosen ephemeral ports when passed `--port 0` and includes explicit timeouts; run it locally to validate end-to-end behavior.
-- **Parallelization guidance:** When possible, run formatting and static checks in parallel to reduce feedback time (our CI runs `isort`, `black`, and `pyright` in a separate job from shellcheck and tests). Locally, `scripts/checks` can be used as a single-entrypoint; CI runs jobs in parallel automatically.
+- **Parallelization guidance:** When possible, run formatting and static checks in parallel to reduce feedback time (our CI runs `ruff check`, `ruff format --check`, and `pyright` in a separate job from shellcheck and tests). Locally, `scripts/checks` can be used as a single-entrypoint; CI runs jobs in parallel automatically.
 
 If any of the above fail locally, fix the issues before opening a PR. The CI will re-run these checks in parallel and block merges on failures.

--- a/bookmarks/admin.py
+++ b/bookmarks/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/bookmarks/management/commands/check_database.py
+++ b/bookmarks/management/commands/check_database.py
@@ -40,10 +40,10 @@ class Command(BaseCommand):
             self.stdout.write("✓ Database connection OK")
             if verbose:
                 self.stdout.write(
-                    f'  Engine: {connection.settings_dict.get("ENGINE", "unknown")}'
+                    f"  Engine: {connection.settings_dict.get('ENGINE', 'unknown')}"
                 )
                 self.stdout.write(
-                    f'  Name: {connection.settings_dict.get("NAME", "unknown")}'
+                    f"  Name: {connection.settings_dict.get('NAME', 'unknown')}"
                 )
         except Exception as e:
             self.stdout.write(self.style.ERROR(f"✗ Database connection failed: {e}"))

--- a/bookmarks/management/commands/load_bookmarks.py
+++ b/bookmarks/management/commands/load_bookmarks.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
             logger.info("Starting JSON schema validation")
             validate(instance=data, schema=schema)
             logger.info("JSON schema validation passed")
-            self.stdout.write(self.style.SUCCESS(f"✓ JSON schema validation passed"))
+            self.stdout.write(self.style.SUCCESS("✓ JSON schema validation passed"))
 
             # Check for reserved keywords
             reserved_keywords = ["h", "help"]
@@ -67,8 +67,9 @@ class Command(BaseCommand):
                     )
                     self.stdout.write(
                         self.style.ERROR(
-                            f'Error: Bookmark key "{key}" is reserved and cannot be used.\n'
-                            f'Reserved keywords: {", ".join(reserved_keywords)}'
+                            f'Error: Bookmark key "{key}" is reserved and '
+                            f"cannot be used.\n"
+                            f"Reserved keywords: {', '.join(reserved_keywords)}"
                         )
                     )
                     return

--- a/bookmarks/management/commands/watch_bookmarks.py
+++ b/bookmarks/management/commands/watch_bookmarks.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import time
 from pathlib import Path
@@ -68,7 +67,10 @@ class Command(BaseCommand):
 
                 if current_hash and current_hash != last_hash:
                     logger.info(
-                        f"File change detected in {json_file_path}, hash changed from {last_hash} to {current_hash}"
+                        "File change detected in %s, hash changed from %s to %s",
+                        json_file_path,
+                        last_hash,
+                        current_hash,
                     )
                     self.stdout.write(
                         self.style.WARNING(f"\n🔄 Change detected in {json_file_path}")

--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -1,5 +1,4 @@
 from django.test import Client, TestCase
-from django.urls import reverse
 
 from .models import Bookmark
 

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -7,12 +7,10 @@ import re
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
-from django.core.cache import cache
 from django.db import models
 from django.http import (
     HttpResponse,
     HttpResponseNotFound,
-    HttpResponseRedirect,
     JsonResponse,
 )
 from django.shortcuts import redirect, render
@@ -117,7 +115,10 @@ def search_redirect(request: HttpRequest) -> HttpResponse:
     try:
         bookmark = Bookmark.objects.get(key=key)
         logger.info(
-            f"Found bookmark: key='{key}', url='{bookmark.url}', params='{param_string}'"
+            "Found bookmark: key=%r, url=%r, params=%r",
+            key,
+            bookmark.url,
+            param_string,
         )
     except Bookmark.DoesNotExist:
         logger.info(f"No bookmark for key='{key}', falling back to Google search")
@@ -142,7 +143,7 @@ def search_redirect(request: HttpRequest) -> HttpResponse:
                 )
             else:
                 return HttpResponse(
-                    f"Bookmark '{key}' requires a parameter.\n" f"Usage: {key} <value>",
+                    f"Bookmark '{key}' requires a parameter.\nUsage: {key} <value>",
                     status=400,
                 )
         else:
@@ -175,12 +176,14 @@ def search_redirect(request: HttpRequest) -> HttpResponse:
                     optional_params = [
                         p for p in placeholders if p in (bookmark.defaults or {})
                     ]
+                    required = ", ".join(required_params)
+                    usage_args = " ".join(f"<{p}>" for p in required_params)
+                    optional_suffix = (
+                        f" [{' '.join(optional_params)}]" if optional_params else ""
+                    )
                     return HttpResponse(
-                        f"Bookmark '{key}' requires parameter(s): {', '.join(required_params)}\n"
-                        f"Usage: {key} {' '.join(f'<{p}>' for p in required_params)}"
-                        + (
-                            f" [{' '.join(optional_params)}]" if optional_params else ""
-                        ),
+                        f"Bookmark '{key}' requires parameter(s): {required}\n"
+                        f"Usage: {key} {usage_args}{optional_suffix}",
                         status=400,
                     )
 
@@ -335,8 +338,10 @@ def bookmark_status(request: HttpRequest) -> JsonResponse:
 @require_http_methods(["GET"])
 def search_suggestions(request: HttpRequest) -> JsonResponse:
     """
-    OpenSearch suggestions API - provides autocomplete suggestions for bookmarks
-    Returns suggestions in OpenSearch format: [query, [suggestions], [descriptions], [urls]]
+    OpenSearch suggestions API - provides autocomplete suggestions for bookmarks.
+
+    Returns suggestions in OpenSearch format:
+    [query, [suggestions], [descriptions], [urls]]
     """
     query_param = request.GET.get("q", "")
     query = str(query_param).strip().lower() if query_param else ""
@@ -352,9 +357,7 @@ def search_suggestions(request: HttpRequest) -> JsonResponse:
     bookmarks = Bookmark.objects.filter(
         models.Q(key__istartswith=search_key)
         | models.Q(description__icontains=search_key)
-    )[
-        :10
-    ]  # Limit to 10 suggestions
+    )[:10]  # Limit to 10 suggestions
 
     # Also include special commands
     special_commands = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,12 @@ description = "Smart bookmark manager and URL shortcut system"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
-    "black>=26.5.1",
     "click>=8.4.2",
     "django>=6.0.7",
-    "isort>=8.0.1",
     "jsonschema>=4.26.0",
     "packaging==26.2",
     "pathspec==1.1.1",
     "platformdirs==4.10.0",
-    "pyright==1.1.411",
     "rpds-py>=2026.6.3",
     "typing-extensions==4.16.0",
 ]
@@ -24,15 +21,9 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "isort>=8.0.1",
     "pyright>=1.1.410",
-    "black>=26.5.1",
+    "ruff>=0.15.17",
 ]
-
-[tool.isort]
-profile = "black"
-line_length = 88
-skip = [".venv", "venv", "migrations"]
 
 [tool.pyright]
 pythonVersion = "3.14"
@@ -44,3 +35,22 @@ reportIndexIssue = "none"
 reportCallIssue = "none"
 reportOptionalMemberAccess = "none"
 reportArgumentType = "none"  # Django HttpResponse accepts str, pyright thinks bytes
+
+[tool.ruff]
+line-length = 88
+target-version = "py314"
+extend-exclude = ["**/migrations"]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.ruff.lint]
+# Replaces black/isort-adjacent flake8 E/F and isort (I). Pyright remains for types.
+select = ["E", "F", "I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["bookmarks", "bunnify"]
+
+[tool.ruff.lint.per-file-ignores]
+# Django settings: late imports + long AUTH_PASSWORD_VALIDATORS / LOGGING strings.
+"bunnify/settings.py" = ["E402", "E501"]

--- a/scripts/checks
+++ b/scripts/checks
@@ -28,8 +28,8 @@ run() {
 echo "🔎 Running preflight checks"
 
 # Python formatting and linting
-run "$uv_cmd run isort --check-only --diff ."
-run "$uv_cmd run black --check ."
+run "$uv_cmd run ruff check ."
+run "$uv_cmd run ruff format --check ."
 run "$uv_cmd run pyright --warnings"
 
 # Shell linting (only when shellcheck is available)

--- a/uv.lock
+++ b/uv.lock
@@ -21,72 +21,42 @@ wheels = [
 ]
 
 [[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
-]
-
-[[package]]
 name = "bunnify"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
-    { name = "black" },
     { name = "click" },
     { name = "django" },
-    { name = "isort" },
     { name = "jsonschema" },
     { name = "packaging" },
     { name = "pathspec" },
     { name = "platformdirs" },
-    { name = "pyright" },
     { name = "rpds-py" },
     { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "black" },
-    { name = "isort" },
     { name = "pyright" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "black", specifier = ">=26.5.1" },
     { name = "click", specifier = ">=8.4.2" },
     { name = "django", specifier = ">=6.0.7" },
-    { name = "isort", specifier = ">=8.0.1" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "packaging", specifier = "==26.2" },
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "platformdirs", specifier = "==4.10.0" },
-    { name = "pyright", specifier = "==1.1.411" },
     { name = "rpds-py", specifier = ">=2026.6.3" },
     { name = "typing-extensions", specifier = "==4.16.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "black", specifier = ">=26.5.1" },
-    { name = "isort", specifier = ">=8.0.1" },
     { name = "pyright", specifier = ">=1.1.410" },
+    { name = "ruff", specifier = ">=0.15.17" },
 ]
 
 [[package]]
@@ -125,15 +95,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
-]
-
-[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -158,15 +119,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -216,25 +168,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]
@@ -314,6 +247,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
     { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
     { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace **black** + **isort** with **Ruff** for lint and format (`ruff check` / `ruff format`)
- Keep **pyright** for type checking (complementary — not sunset)
- Autofix unused imports, pointless f-strings, and line-length issues; update CI, `AGENTS.md`, `scripts/checks`, and Copilot instructions

Closes #211

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright --warnings`
- [x] `./test_bunnify`
- [ ] CI green on this PR