### PR TITLE
ci: drive Python lint & format checks via .github/ci/python-static

### DIFF
--- a/.github/ci/python-static
+++ b/.github/ci/python-static
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# One sync for ruff + pyright (shared venv). Prefer this in CI over inline steps.
+bash .github/ci/setup-python
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright --warnings

--- a/.github/ci/setup-python
+++ b/.github/ci/setup-python
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+uv python install 3.14
+uv sync --all-groups

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
             fi
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
-  lint-python:
+  python-static:
     name: Python lint & format checks
     needs: guard
     if: needs.guard.outputs.skip != 'true'
@@ -98,20 +98,8 @@ jobs:
       with:
         version: "latest"
 
-    - name: Set up Python 3.14
-      run: uv python install 3.14
-
-    - name: Install dependencies (including dev)
-      run: uv sync --all-groups
-
-    - name: Lint with Ruff
-      run: uv run ruff check .
-
-    - name: Check formatting with Ruff
-      run: uv run ruff format --check .
-
-    - name: Type check (pyright)
-      run: uv run pyright --warnings
+    - name: Python lint & format checks
+      run: bash .github/ci/python-static
 
   lint-shell:
     name: Shell script linting


### PR DESCRIPTION
## Summary
- Adds `.github/ci/setup-python` and `.github/ci/python-static` (ruff check + format --check + pyright).
- Points the existing `Python lint & format checks` job at the wrapper instead of inlined steps (matches org `github-repo-lint` python-static rule).

## Test plan
- [ ] CI green (`Python lint & format checks` still runs)
- [ ] After merge, `scripts/github-repo-lint --repo the-hcma/bunnify` passes the python-static check

Made with [Cursor](https://cursor.com)