### PR TITLE
feat: add mqh bookmark for the-hcma GitHub Merge Queue

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -167,6 +167,10 @@
     "description": "Graphite's merge queue for my-tracks",
     "url": "https://app.graphite.com/merges?repo=my-tracks&org=the-hcma&tab=queue"
   },
+  "mqh": {
+    "description": "the-hcma GitHub Merge Queue (Usage: mqh <repo>)",
+    "url": "https://github.com/the-hcma/#{repo}/queue/main"
+  },
   "mt": {
     "description": "MyTracks",
     "url": "https://mytracks.hcma.info"


### PR DESCRIPTION
## Summary
- Add `mqh` bookmark (like `prh`) for the-hcma GitHub Merge Queue pages
- Usage: `mqh <repo>` → `https://github.com/the-hcma/<repo>/queue/main` (e.g. `mqh repository-helpers`)

## Test plan
- [x] `uv run ruff check .` / `ruff format --check` / `pyright --warnings`
- [x] `./test_bunnify`
- [x] `./test_integration`
- [ ] After deploy/reload: `mqh repository-helpers` opens the GitHub merge queue for that repo