### PR TITLE
chore(deps): batch dependency updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Smart bookmark manager and URL shortcut system"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "asgiref==3.12.1",
     "click>=8.4.2",
     "django>=6.0.7",
     "jsonschema>=4.26.0",
@@ -21,7 +22,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "pyright>=1.1.410",
+    "pyright>=1.1.411",
     "ruff>=0.15.17",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,11 +4,11 @@ requires-python = ">=3.14"
 
 [[package]]
 name = "asgiref"
-version = "3.11.1"
+version = "3.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
 ]
 
 [[package]]
@@ -25,6 +25,7 @@ name = "bunnify"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "asgiref" },
     { name = "click" },
     { name = "django" },
     { name = "jsonschema" },
@@ -43,6 +44,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asgiref", specifier = "==3.12.1" },
     { name = "click", specifier = ">=8.4.2" },
     { name = "django", specifier = ">=6.0.7" },
     { name = "jsonschema", specifier = ">=4.26.0" },
@@ -55,7 +57,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pyright", specifier = ">=1.1.410" },
+    { name = "pyright", specifier = ">=1.1.411" },
     { name = "ruff", specifier = ">=0.15.17" },
 ]
 


### PR DESCRIPTION
## Batch dependency updates

Automated dependency updates via `dep-updater --batch`.

All outdated packages and CVE fixes combined into a single PR.

## Dependency update summary

| Ecosystem | Package | From | To | CVE? | CVEs |
|---|---|---|---|---|---|
| python/uv | `pyright` | `1.1.410` | `1.1.411` | no | - |
| python/uv | `asgiref` | `3.11.1` | `3.12.1` | no | - |

## Python updates

| Package | From | To |
|---|---|---|
| `pyright` | `1.1.410` | `1.1.411` |
| `asgiref` | `3.11.1` | `3.12.1` |
