### PR TITLE
feat: add hmb shortcut for Half Moon Bay HOA portal

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -135,6 +135,10 @@
     "description": "Graphite PR review for the-hcma org (Usage: hgpr <repo> <pr_number>)",
     "url": "https://app.graphite.com/github/pr/the-hcma/#{repo}/#{pr_number}"
   },
+  "hmb": {
+    "description": "Half Moon Bay HOA management company",
+    "url": "https://westchester-kc.ssnc.cloud/skylineportal_v20"
+  },
   "hpr": {
     "description": "the-hcma GitHub Pull Request (Usage: hpr <repo> <pr_number>)",
     "url": "https://github.com/the-hcma/#{repo}/pull/#{pr_number}"


### PR DESCRIPTION
## Summary

- Add `hmb` bookmark shortcut pointing at the Half Moon Bay HOA Skyline portal.

## Test plan

- [x] `uv run ruff check .` / `ruff format --check` / `pyright --warnings`
- [x] `./test_bunnify`
- [x] `./test_integration`
- [ ] Confirm `hmb` redirects to `https://westchester-kc.ssnc.cloud/skylineportal_v20` when the bookmarks file is loaded
