### PR TITLE
feat: add ep1 shortcut for Everything Presence One

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -27,6 +27,10 @@
     "description": "Domestic-bot (home automation)",
     "url": "https://db.hcma.info"
   },
+  "ep1": {
+    "description": "Everything Presence One USB-based configuration",
+    "url": "https://docs.everythingsmart.io/flash/everything-presence-one.html"
+  },
   "fpdf": {
     "description": "fpdf",
     "url": "https://fpdf.hcma.info"


### PR DESCRIPTION
## Summary

- Add `ep1` bookmark shortcut for Everything Presence One USB-based configuration docs.

## Test plan

- [x] `uv run ruff check .` / `ruff format --check` / `pyright --warnings`
- [x] `./test_bunnify`
- [x] `./test_integration`
- [ ] Confirm `ep1` redirects to `https://docs.everythingsmart.io/flash/everything-presence-one.html` when the bookmarks file is loaded
