### PR TITLE
feat: add navan bookmark for Navan travel app

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -183,6 +183,10 @@
     "description": "MyTracks",
     "url": "https://mytracks.hcma.info"
   },
+  "navan": {
+    "description": "Navan",
+    "url": "https://app.navan.com"
+  },
   "nm": {
     "description": "YouTube Music New Release Mix",
     "url": "https://music.youtube.com/playlist?list=RDTMAK5uy_m_S_9S_9S_9S_9S_9S_9S_9S_9S_9S_9S"


### PR DESCRIPTION
## Summary
- Add `navan` bookmark pointing at `https://app.navan.com` (Navan travel/expense app login).
- LinkedIn Search (`ls`) already exists with a direct search URL; no change needed.

## Test plan
- [ ] Load bookmarks and confirm `navan` resolves to `https://app.navan.com`
- [ ] Confirm `ls <terms>` still hits LinkedIn search with `keywords=`