### PR TITLE
feat: richer key listings and GitHub param Tab completion

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -15,6 +15,8 @@ from prompt_toolkit.shortcuts import CompleteStyle
 
 from app.client import (
     ClientError,
+    KeyEntry,
+    fetch_key_entries,
     fetch_keys,
     fetch_suggestions,
     resolve_shortcut,
@@ -31,6 +33,7 @@ from app.interactive import (
     repl_prompt_message,
 )
 from app.theme import Theme, stdout_color_enabled
+from app.usage import format_key_usage_lines
 
 
 def open_url(url: str, *, opener: Callable[[str], bool] | None = None) -> None:
@@ -187,7 +190,8 @@ def _run_repl(
     fzf_picker: Callable[..., str | None],
     editing_mode: EditingMode,
 ) -> None:
-    keys = fetch_keys(base_url=base_url)
+    entries = fetch_key_entries(base_url=base_url)
+    keys = [entry.key for entry in entries]
     click.echo(
         f"{theme.brand('bunnify')} "
         f"{theme.dim('interactive — Tab fuzzy-completes; quit to exit')}"
@@ -222,6 +226,7 @@ def _run_repl(
                 fzf_picker=fzf_picker,
                 session=None,
                 set_keys=None,
+                set_entries=None,
             ):
                 break
         return
@@ -234,12 +239,17 @@ def _run_repl(
         theme=theme,
         editing_mode=editing_mode,
         suggestions_fn=suggestions_fn,
+        entries=entries,
     )
 
     def set_keys(new_keys: list[str]) -> None:
         nonlocal keys
         keys = new_keys
         completer.set_keys(new_keys)
+
+    def set_entries(new_entries: list[KeyEntry]) -> None:
+        completer.set_entries(new_entries)
+        set_keys([entry.key for entry in new_entries])
 
     while True:
         try:
@@ -268,6 +278,7 @@ def _run_repl(
             fzf_picker=fzf_picker,
             session=session,
             set_keys=set_keys,
+            set_entries=set_entries,
         ):
             break
 
@@ -284,6 +295,7 @@ def _dispatch_repl_line(
     fzf_picker: Callable[..., str | None],
     session: object | None,
     set_keys: Callable[[list[str]], None] | None,
+    set_entries: Callable[[list[KeyEntry]], None] | None = None,
 ) -> bool:
     """Handle one REPL line. Returns False when the REPL should exit."""
     parts = line.split(None, 1)
@@ -299,17 +311,25 @@ def _dispatch_repl_line(
         _print_repl_help(theme)
         return True
     if lowered == "keys" and "keys" not in key_set:
-        for key in keys:
-            click.echo(f"  {theme.cmd(key)}")
-        click.echo(theme.meta(f"{len(keys)} keys"))
-        return True
-    if lowered == "refresh" and "refresh" not in key_set:
         try:
-            new_keys = fetch_keys(base_url=base_url)
+            entries = fetch_key_entries(base_url=base_url)
         except ClientError as exc:
             click.echo(theme.err(f"error: {exc}"), err=True)
             return True
-        if set_keys is not None:
+        for usage_line in format_key_usage_lines(entries, theme=theme):
+            click.echo(usage_line)
+        click.echo(theme.meta(f"{len(entries)} keys"))
+        return True
+    if lowered == "refresh" and "refresh" not in key_set:
+        try:
+            new_entries = fetch_key_entries(base_url=base_url)
+        except ClientError as exc:
+            click.echo(theme.err(f"error: {exc}"), err=True)
+            return True
+        new_keys = [entry.key for entry in new_entries]
+        if set_entries is not None:
+            set_entries(new_entries)
+        elif set_keys is not None:
             set_keys(new_keys)
         else:
             keys[:] = new_keys
@@ -339,6 +359,7 @@ def _run(
     shortcut_args: tuple[str, ...],
     base_url: str,
     list_keys: bool,
+    list_usage: bool = False,
     use_fzf: bool,
     fzf_query: str,
     print_url: bool,
@@ -351,6 +372,12 @@ def _run(
 ) -> None:
     active_theme = theme or Theme(enabled=False)
     picker = fzf_picker or pick_key_with_fzf
+
+    if list_usage:
+        entries = fetch_key_entries(base_url=base_url)
+        for usage_line in format_key_usage_lines(entries, theme=active_theme):
+            click.echo(usage_line)
+        return
 
     if list_keys:
         for key in fetch_keys(base_url=base_url):
@@ -419,6 +446,11 @@ def _run(
     help="Print shortcut keys (one per line) for fzf / shell completion.",
 )
 @click.option(
+    "--list-usage",
+    is_flag=True,
+    help="Print short usage for each shortcut (params, description, target).",
+)
+@click.option(
     "--fzf",
     "use_fzf",
     is_flag=True,
@@ -468,6 +500,7 @@ def main(
     shortcut_args: tuple[str, ...],
     base_url_option: str | None,
     list_keys: bool,
+    list_usage: bool,
     use_fzf: bool,
     fzf_query: str,
     print_url: bool,
@@ -492,6 +525,7 @@ def main(
     Fuzzy pick (fzf) for argv / shell completion workflows:
       ./scripts/bunnify --fzf
       ./scripts/bunnify --list-keys | fzf
+      ./scripts/bunnify --list-usage
     """
     theme = Theme(enabled=stdout_color_enabled(color_mode.lower()))
     mode_name = (
@@ -514,6 +548,7 @@ def main(
             shortcut_args=shortcut_args,
             base_url=resolved_url,
             list_keys=list_keys,
+            list_usage=list_usage,
             use_fzf=use_fzf,
             fzf_query=fzf_query,
             print_url=print_url or dry_run,

--- a/app/client.py
+++ b/app/client.py
@@ -24,6 +24,16 @@ class ResolvedShortcut:
     key: str | None
 
 
+@dataclass(frozen=True)
+class KeyEntry:
+    """Shortcut metadata from ``/api/keys/`` (short usage / completion)."""
+
+    key: str
+    description: str = ""
+    url: str = ""
+    params: tuple[str, ...] = ()
+
+
 def _request_json(
     url: str,
     *,
@@ -90,22 +100,73 @@ def resolve_shortcut(
     )
 
 
+def parse_key_entry(raw: Any) -> KeyEntry | None:
+    """Parse one structured keys API entry; ignore malformed objects."""
+    if not isinstance(raw, dict):
+        return None
+    key = raw.get("key")
+    if not isinstance(key, str) or not key:
+        return None
+    description = raw.get("description", "")
+    url = raw.get("url", "")
+    params_raw = raw.get("params", [])
+    if not isinstance(description, str):
+        description = "" if description is None else str(description)
+    if not isinstance(url, str):
+        url = "" if url is None else str(url)
+    params: tuple[str, ...] = ()
+    if isinstance(params_raw, list):
+        params = tuple(str(item) for item in params_raw)
+    return KeyEntry(key=key, description=description, url=url, params=params)
+
+
+def parse_keys_payload(payload: Any) -> list[KeyEntry]:
+    """Normalize ``/api/keys/`` JSON into ``KeyEntry`` rows."""
+    if not isinstance(payload, dict):
+        raise ClientError("Keys response was not a JSON object")
+
+    entries_raw = payload.get("entries")
+    if isinstance(entries_raw, list) and entries_raw:
+        parsed = [entry for item in entries_raw if (entry := parse_key_entry(item))]
+        if parsed:
+            return parsed
+
+    keys = payload.get("keys")
+    if not isinstance(keys, list):
+        raise ClientError("Keys response missing keys list")
+    result: list[KeyEntry] = []
+    for item in keys:
+        if isinstance(item, str) and item:
+            result.append(KeyEntry(key=item))
+        else:
+            entry = parse_key_entry(item)
+            if entry is not None:
+                result.append(entry)
+    return result
+
+
+def fetch_key_entries(
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[KeyEntry]:
+    """Fetch structured shortcut entries from ``/api/keys/``."""
+    payload = _request_json(
+        f"{base_url.rstrip('/')}/api/keys/",
+        timeout=timeout,
+    )
+    return parse_keys_payload(payload)
+
+
 def fetch_keys(
     *,
     base_url: str = DEFAULT_BASE_URL,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> list[str]:
     """Fetch bookmark keys (plus specials) from ``/api/keys/``."""
-    payload = _request_json(
-        f"{base_url.rstrip('/')}/api/keys/",
-        timeout=timeout,
-    )
-    if not isinstance(payload, dict):
-        raise ClientError("Keys response was not a JSON object")
-    keys = payload.get("keys")
-    if not isinstance(keys, list):
-        raise ClientError("Keys response missing keys list")
-    return [str(key) for key in keys]
+    return [
+        entry.key for entry in fetch_key_entries(base_url=base_url, timeout=timeout)
+    ]
 
 
 def fetch_suggestions(

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -1,0 +1,254 @@
+"""GitHub-backed parameter completions via the REST API (fail-soft)."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_CACHE_TTL_SECONDS = 60.0
+_DEFAULT_TIMEOUT_SECONDS = 8.0
+_REPO_PARAM_NAMES = frozenset({"repo", "repository", "org_repo"})
+_PR_PARAM_NAMES = frozenset(
+    {"pr_number", "pr_id", "pr", "pull", "pull_number", "number"}
+)
+_API_ROOT = "https://api.github.com"
+
+_cache: dict[str, tuple[float, list[str]]] = {}
+
+_GITHUB_ORG_REPO = re.compile(
+    r"(?:github\.com|graphite\.com/github/pr)/([^/#{}]+)/#\{repo\}",
+    re.IGNORECASE,
+)
+
+
+def infer_fixed_github_org(url_template: str) -> str | None:
+    """Return a fixed org/owner when the template is ``…/ORG/#{repo}…``."""
+    match = _GITHUB_ORG_REPO.search(url_template)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _cache_get(key: str) -> list[str] | None:
+    hit = _cache.get(key)
+    if hit is None:
+        return None
+    expires_at, values = hit
+    if time.monotonic() >= expires_at:
+        _cache.pop(key, None)
+        return None
+    return list(values)
+
+
+def _cache_set(key: str, values: list[str]) -> None:
+    _cache[key] = (time.monotonic() + _CACHE_TTL_SECONDS, list(values))
+
+
+def clear_github_completion_cache() -> None:
+    """Test helper: drop in-process completion cache."""
+    _cache.clear()
+
+
+def github_token_from_environ(
+    environ: dict[str, str] | None = None,
+) -> str | None:
+    """Return a GitHub token from standard env vars, if set."""
+    env = environ if environ is not None else os.environ
+    for name in ("GITHUB_TOKEN", "GH_TOKEN"):
+        value = (env.get(name) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _github_get_json(
+    path: str,
+    *,
+    query: dict[str, str] | None = None,
+    token: str | None = None,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    opener: Any | None = None,
+) -> Any | None:
+    """GET a GitHub REST path. Return parsed JSON, or ``None`` on failure."""
+    auth = token if token is not None else github_token_from_environ()
+    if not auth:
+        return None
+    params = urllib.parse.urlencode(query or {})
+    url = f"{_API_ROOT}{path}"
+    if params:
+        url = f"{url}?{params}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {auth}",
+            "User-Agent": "bunnify-cli",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="GET",
+    )
+    open_url = opener or urllib.request.urlopen
+    try:
+        with open_url(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            return json.loads(body)
+    except urllib.error.HTTPError:
+        return None
+    except urllib.error.URLError:
+        return None
+    except TimeoutError:
+        return None
+    except json.JSONDecodeError:
+        return None
+    except OSError:
+        return None
+
+
+def list_github_repos(
+    *,
+    org: str | None = None,
+    prefix: str = "",
+    limit: int = 100,
+    token: str | None = None,
+    opener: Any | None = None,
+) -> list[str]:
+    """List repo names (short when ``org`` set, else ``owner/name``)."""
+    cache_key = f"repos:{org or '*'}:{limit}"
+    cached = _cache_get(cache_key)
+    if cached is None:
+        per_page = min(max(limit, 1), 100)
+        if org:
+            payload = _github_get_json(
+                f"/orgs/{urllib.parse.quote(org)}/repos",
+                query={
+                    "per_page": str(per_page),
+                    "type": "all",
+                    "sort": "full_name",
+                },
+                token=token,
+                opener=opener,
+            )
+            if payload is None:
+                return []
+            names: list[str] = []
+            if isinstance(payload, list):
+                for item in payload:
+                    if isinstance(item, dict) and isinstance(item.get("name"), str):
+                        names.append(item["name"])
+            cached = names[:limit]
+        else:
+            payload = _github_get_json(
+                "/user/repos",
+                query={
+                    "per_page": str(per_page),
+                    "affiliation": "owner,collaborator,organization_member",
+                    "sort": "full_name",
+                },
+                token=token,
+                opener=opener,
+            )
+            if payload is None:
+                return []
+            names = []
+            if isinstance(payload, list):
+                for item in payload:
+                    if isinstance(item, dict) and isinstance(
+                        item.get("full_name"), str
+                    ):
+                        names.append(item["full_name"])
+            cached = names[:limit]
+        _cache_set(cache_key, cached)
+
+    needle = prefix.lower()
+    return [name for name in cached if name.lower().startswith(needle)]
+
+
+def list_open_pull_requests(
+    repo: str,
+    *,
+    prefix: str = "",
+    limit: int = 50,
+    token: str | None = None,
+    opener: Any | None = None,
+) -> list[str]:
+    """List open PR numbers (as strings) for ``owner/name``."""
+    if not repo or "/" not in repo:
+        return []
+    owner, name = repo.split("/", 1)
+    if not owner or not name:
+        return []
+    cache_key = f"prs:{repo}:{limit}"
+    cached = _cache_get(cache_key)
+    if cached is None:
+        per_page = min(max(limit, 1), 100)
+        payload = _github_get_json(
+            f"/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(name)}/pulls",
+            query={
+                "state": "open",
+                "per_page": str(per_page),
+                "sort": "updated",
+                "direction": "desc",
+            },
+            token=token,
+            opener=opener,
+        )
+        if payload is None:
+            return []
+        numbers: list[str] = []
+        if isinstance(payload, list):
+            for item in payload:
+                if isinstance(item, dict) and isinstance(item.get("number"), int):
+                    numbers.append(str(item["number"]))
+        cached = numbers[:limit]
+        _cache_set(cache_key, cached)
+
+    needle = prefix.lower()
+    return [num for num in cached if num.startswith(needle)]
+
+
+def resolve_repo_for_pr(
+    *,
+    url_template: str,
+    repo_arg: str,
+) -> str | None:
+    """Build ``owner/name`` for PR listing from the template + typed repo token."""
+    repo_arg = repo_arg.strip()
+    if not repo_arg:
+        return None
+    if "/" in repo_arg:
+        return repo_arg
+    org = infer_fixed_github_org(url_template)
+    if org:
+        return f"{org}/{repo_arg}"
+    return None
+
+
+def suggest_param_values(
+    *,
+    param_name: str,
+    url_template: str,
+    filled_args: list[str],
+    prefix: str,
+    token: str | None = None,
+    opener: Any | None = None,
+) -> list[str]:
+    """Return completion candidates for the next unresolved placeholder."""
+    name = param_name.lower()
+    if name in _REPO_PARAM_NAMES:
+        org = infer_fixed_github_org(url_template)
+        return list_github_repos(org=org, prefix=prefix, token=token, opener=opener)
+    if name in _PR_PARAM_NAMES:
+        repo_token = filled_args[-1] if filled_args else ""
+        full_repo = resolve_repo_for_pr(url_template=url_template, repo_arg=repo_token)
+        if full_repo is None:
+            return []
+        return list_open_pull_requests(
+            full_repo, prefix=prefix, token=token, opener=opener
+        )
+    return []

--- a/app/interactive.py
+++ b/app/interactive.py
@@ -20,7 +20,8 @@ from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.formatted_text import AnyFormattedText
 from prompt_toolkit.history import FileHistory, InMemoryHistory
 
-from app.client import ClientError
+from app.client import ClientError, KeyEntry
+from app.github_complete import suggest_param_values
 from app.theme import Theme
 
 try:
@@ -32,7 +33,7 @@ REPL_META_COMMANDS: tuple[tuple[str, str], ...] = (
     ("edit-mode", "Switch Emacs vs Vim keys: edit-mode emacs | vim"),
     ("exit", "Leave the REPL"),
     ("help", "Show this help"),
-    ("keys", "List known shortcut keys"),
+    ("keys", "List shortcuts with params / description / target"),
     ("quit", "Leave the REPL"),
     ("refresh", "Re-fetch shortcut keys from the server"),
 )
@@ -69,12 +70,33 @@ def history_file_path() -> Path:
     return Path(user_cache_dir("bunnify")) / "repl_history"
 
 
+def completion_token_state(text: str) -> tuple[str, list[str], str, int]:
+    """
+    Split ``text`` into ``(key, completed_args, prefix, arg_index)``.
+
+    ``arg_index`` is the parameter index currently being typed (0-based).
+    A trailing space means the next empty argument is being completed.
+    """
+    stripped_right = text.rstrip(" \t")
+    trailing_space = len(text) > len(stripped_right)
+    tokens = stripped_right.split()
+    if not tokens:
+        return "", [], "", 0
+    key = tokens[0]
+    args = tokens[1:]
+    if trailing_space:
+        return key, args, "", len(args)
+    if not args:
+        return key, [], "", 0
+    return key, args[:-1], args[-1], len(args) - 1
+
+
 class ShortcutCompleter(Completer):
     """
     Tab-complete the first token against meta-commands + shortcut keys.
 
-    After a space, completes via optional ``suggestions_fn`` (server OpenSearch
-    suggestions) so parameterized shortcuts stay discoverable.
+    After a space, prefers GitHub-aware parameter completions from key
+    metadata, then falls back to optional OpenSearch ``suggestions_fn``.
     """
 
     def __init__(
@@ -84,14 +106,25 @@ class ShortcutCompleter(Completer):
         theme: Theme | None = None,
         include_meta: bool = True,
         suggestions_fn: Callable[[str], list[str]] | None = None,
+        entries: Iterable[KeyEntry] | None = None,
+        param_suggest_fn: Callable[..., list[str]] | None = None,
     ) -> None:
         self._keys = sorted(keys)
         self._theme = theme or Theme(enabled=False)
         self._include_meta = include_meta
         self._suggestions_fn = suggestions_fn
+        self._entries_by_key: dict[str, KeyEntry] = {}
+        self._param_suggest_fn = param_suggest_fn or suggest_param_values
+        if entries is not None:
+            self.set_entries(entries)
 
     def set_keys(self, keys: Iterable[str]) -> None:
         self._keys = sorted(keys)
+
+    def set_entries(self, entries: Iterable[KeyEntry]) -> None:
+        mapping = {entry.key: entry for entry in entries}
+        self._entries_by_key = mapping
+        self._keys = sorted(mapping.keys()) if mapping else self._keys
 
     def get_completions(
         self,
@@ -124,28 +157,76 @@ class ShortcutCompleter(Completer):
 
         for key in self._keys:
             if key.lower().startswith(needle):
+                entry = self._entries_by_key.get(key)
+                meta = "shortcut"
+                if entry is not None:
+                    if entry.params:
+                        meta = " ".join(entry.params)
+                    elif entry.description:
+                        meta = entry.description[:40]
                 yield Completion(
                     key,
                     start_position=-len(partial),
                     style=key_style,
-                    display_meta="shortcut",
+                    display_meta=meta,
                 )
 
     def _param_completions(self, text: str):
-        if self._suggestions_fn is None:
-            # Still offer edit-mode subargs when completing that meta command.
-            parts = text.split(None, 1)
-            if len(parts) == 2 and parts[0].lower() == "edit-mode":
-                prefix = parts[1].lower()
-                style = self._theme.completion_param_style()
-                for alias in _EDIT_MODE_SUBARGS:
-                    if alias.startswith(prefix):
-                        yield Completion(
-                            alias,
-                            start_position=-len(parts[1]),
-                            style=style,
-                            display_meta="edit-mode",
-                        )
+        key, filled_args, prefix, arg_index = completion_token_state(text)
+        style = self._theme.completion_param_style()
+
+        key_set = {candidate.lower() for candidate in self._keys}
+        if key.lower() == "edit-mode" and "edit-mode" not in key_set:
+            needle = prefix.lower()
+            for alias in _EDIT_MODE_SUBARGS:
+                if alias.startswith(needle):
+                    yield Completion(
+                        alias,
+                        start_position=-len(prefix),
+                        style=style,
+                        display_meta="edit-mode",
+                    )
+            return
+
+        entry = self._entries_by_key.get(key)
+        if entry is None:
+            # Case-insensitive key lookup.
+            lowered = key.lower()
+            for candidate_key, candidate in self._entries_by_key.items():
+                if candidate_key.lower() == lowered:
+                    entry = candidate
+                    break
+
+        yielded = False
+        if entry is not None and entry.params and arg_index < len(entry.params):
+            param_name = entry.params[arg_index]
+            try:
+                values = self._param_suggest_fn(
+                    param_name=param_name,
+                    url_template=entry.url,
+                    filled_args=filled_args,
+                    prefix=prefix,
+                )
+            except OSError:
+                values = []
+            except ValueError:
+                values = []
+            except TypeError:
+                values = []
+            seen: set[str] = set()
+            for value in values:
+                if value in seen:
+                    continue
+                seen.add(value)
+                yielded = True
+                yield Completion(
+                    value,
+                    start_position=-len(prefix),
+                    style=style,
+                    display_meta=param_name,
+                )
+
+        if yielded or self._suggestions_fn is None:
             return
 
         try:
@@ -156,14 +237,11 @@ class ShortcutCompleter(Completer):
             return
         except ValueError:
             return
-        style = self._theme.completion_param_style()
-        seen: set[str] = set()
+        seen_suggestions: set[str] = set()
         for item in suggestions:
-            if item in seen:
+            if item in seen_suggestions:
                 continue
-            seen.add(item)
-            # Prefer completing the trailing fragment when the suggestion
-            # shares the typed prefix; otherwise replace the whole buffer.
+            seen_suggestions.add(item)
             if item.lower().startswith(text.lower()):
                 yield Completion(
                     item,
@@ -223,6 +301,7 @@ def create_repl_session(
     theme: Theme,
     editing_mode: EditingMode = EditingMode.VI,
     suggestions_fn: Callable[[str], list[str]] | None = None,
+    entries: Iterable[KeyEntry] | None = None,
     history_path: Path | None = None,
 ) -> tuple[PromptSession[str], ShortcutCompleter]:
     """
@@ -236,6 +315,7 @@ def create_repl_session(
         theme=theme,
         include_meta=True,
         suggestions_fn=suggestions_fn,
+        entries=entries,
     )
     # FuzzyCompleter makes Tab forgiving (domesti-bot uses prefix-only; we go further).
     completer: Completer = FuzzyCompleter(inner, enable_fuzzy=True)

--- a/app/usage.py
+++ b/app/usage.py
@@ -1,0 +1,49 @@
+"""Format structured shortcut entries for CLI short-usage listings."""
+
+from __future__ import annotations
+
+from app.client import KeyEntry
+from app.theme import Theme
+
+
+def format_params(params: tuple[str, ...] | list[str]) -> str:
+    return " ".join(params)
+
+
+def format_key_usage_lines(
+    entries: list[KeyEntry],
+    *,
+    theme: Theme | None = None,
+) -> list[str]:
+    """Aligned short-usage rows: key · params · description · target."""
+    active = theme or Theme(enabled=False)
+    if not entries:
+        return []
+
+    key_width = max(len(entry.key) for entry in entries)
+    params_width = max(
+        (len(format_params(entry.params)) for entry in entries),
+        default=0,
+    )
+    # Cap description column so long blurbs do not dominate the terminal.
+    desc_width = min(
+        40,
+        max((len(entry.description) for entry in entries), default=0),
+    )
+
+    lines: list[str] = []
+    for entry in entries:
+        params = format_params(entry.params)
+        description = entry.description
+        if len(description) > desc_width > 0:
+            description = (description[: desc_width - 1] + "…")[:desc_width]
+        key_col = entry.key.ljust(key_width)
+        params_col = params.ljust(params_width) if params_width else ""
+        desc_col = description.ljust(desc_width) if desc_width else ""
+        gap_params = f"  {params_col}" if params_width else ""
+        gap_desc = f"  {desc_col}" if desc_width else ""
+        target = entry.url
+        lines.append(
+            f"  {active.cmd(key_col)}{gap_params}{gap_desc}  {active.dim(target)}"
+        )
+    return lines

--- a/bookmarks/keys_catalog.py
+++ b/bookmarks/keys_catalog.py
@@ -1,0 +1,50 @@
+"""Structured shortcut catalog for the keys API and CLI usage listing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .models import Bookmark
+from .resolve import PLACEHOLDER_PATTERN
+
+SPECIAL_ENTRIES: tuple[tuple[str, str, str], ...] = (
+    ("h", "Show all bookmarks", "/list/"),
+    ("cmd", "Command palette", "/cmd/"),
+)
+
+
+def placeholders_for_url(url: str) -> list[str]:
+    """Ordered unique placeholder names from a bookmark URL template."""
+    return list(dict.fromkeys(PLACEHOLDER_PATTERN.findall(url)))
+
+
+def build_key_catalog() -> list[dict[str, Any]]:
+    """Return specials + bookmarks as JSON-ready key entries."""
+    entries: list[dict[str, Any]] = [
+        {
+            "key": key,
+            "description": description,
+            "url": url,
+            "params": [],
+        }
+        for key, description, url in SPECIAL_ENTRIES
+    ]
+    for bookmark in Bookmark.objects.order_by("key"):
+        entries.append(
+            {
+                "key": bookmark.key,
+                "description": bookmark.description or "",
+                "url": bookmark.url,
+                "params": placeholders_for_url(bookmark.url),
+            }
+        )
+    return entries
+
+
+def catalog_payload() -> dict[str, Any]:
+    """JSON payload for ``/api/keys/`` (string keys + structured entries)."""
+    entries = build_key_catalog()
+    return {
+        "keys": [entry["key"] for entry in entries],
+        "entries": entries,
+    }

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -11,7 +11,7 @@ from django.test import Client, TestCase, override_settings
 
 from app import interactive
 from app.cli import _run, matching_keys
-from app.client import ClientError, ResolvedShortcut
+from app.client import ClientError, KeyEntry, ResolvedShortcut, parse_keys_payload
 
 from .models import Bookmark
 
@@ -113,6 +113,13 @@ class ResolveApiTests(TestCase):
         self.assertIn("cmd", data["keys"])
         self.assertIn("gh", data["keys"])
         self.assertIn("pr", data["keys"])
+        entries = {item["key"]: item for item in data["entries"]}
+        self.assertEqual(entries["gh"]["description"], "GitHub")
+        self.assertEqual(entries["gh"]["url"], "https://github.com")
+        self.assertEqual(entries["gh"]["params"], [])
+        self.assertEqual(entries["pr"]["params"], ["repo", "pr_number"])
+        self.assertEqual(entries["h"]["url"], "/list/")
+        self.assertEqual(entries["cmd"]["description"], "Command palette")
 
 
 class CliUnitTests(TestCase):
@@ -158,13 +165,13 @@ class CliUnitTests(TestCase):
         )
 
     @patch("app.cli.resolve_shortcut")
-    @patch("app.cli.fetch_keys")
+    @patch("app.cli.fetch_key_entries")
     def test_interactive_open(
         self,
-        mock_fetch_keys,
+        mock_fetch_entries,
         mock_resolve,
     ) -> None:
-        mock_fetch_keys.return_value = ["gh"]
+        mock_fetch_entries.return_value = [KeyEntry(key="gh")]
         mock_resolve.return_value = ResolvedShortcut(
             url="https://github.com", kind="bookmark", key="gh"
         )
@@ -195,13 +202,16 @@ class CliUnitTests(TestCase):
         )
 
     @patch("app.cli.resolve_shortcut")
-    @patch("app.cli.fetch_keys")
+    @patch("app.cli.fetch_key_entries")
     def test_interactive_loop_runs_multiple_commands(
         self,
-        mock_fetch_keys,
+        mock_fetch_entries,
         mock_resolve,
     ) -> None:
-        mock_fetch_keys.return_value = ["gh", "pr"]
+        mock_fetch_entries.return_value = [
+            KeyEntry(key="gh"),
+            KeyEntry(key="pr"),
+        ]
         mock_resolve.side_effect = [
             ResolvedShortcut(url="https://github.com", kind="bookmark", key="gh"),
             ResolvedShortcut(
@@ -238,13 +248,13 @@ class CliUnitTests(TestCase):
         self.assertEqual(mock_resolve.call_count, 2)
 
     @patch("app.cli.resolve_shortcut")
-    @patch("app.cli.fetch_keys")
+    @patch("app.cli.fetch_key_entries")
     def test_interactive_error_continues_loop(
         self,
-        mock_fetch_keys,
+        mock_fetch_entries,
         mock_resolve,
     ) -> None:
-        mock_fetch_keys.return_value = ["gh"]
+        mock_fetch_entries.return_value = [KeyEntry(key="gh")]
         mock_resolve.side_effect = [
             ClientError("Unknown shortcut"),
             ResolvedShortcut(url="https://github.com", kind="bookmark", key="gh"),
@@ -437,9 +447,9 @@ class CliUnitTests(TestCase):
             "gh", base_url="http://127.0.0.1:8000", strict=True
         )
 
-    @patch("app.cli.fetch_keys")
-    def test_cancel_interactive(self, mock_fetch_keys) -> None:
-        mock_fetch_keys.return_value = ["gh"]
+    @patch("app.cli.fetch_key_entries")
+    def test_cancel_interactive(self, mock_fetch_entries) -> None:
+        mock_fetch_entries.return_value = [KeyEntry(key="gh")]
 
         def eof(_prompt: str) -> str:
             raise EOFError
@@ -458,9 +468,9 @@ class CliUnitTests(TestCase):
                     input_fn=eof,
                 )
 
-    @patch("app.cli.fetch_keys")
-    def test_interactive_skips_empty_lines(self, mock_fetch_keys) -> None:
-        mock_fetch_keys.return_value = ["gh"]
+    @patch("app.cli.fetch_key_entries")
+    def test_interactive_skips_empty_lines(self, mock_fetch_entries) -> None:
+        mock_fetch_entries.return_value = [KeyEntry(key="gh")]
         responses = iter(["", "   ", "quit"])
 
         with patch("sys.stdout", new_callable=StringIO):
@@ -590,13 +600,13 @@ class ConfigUnitTests(TestCase):
             )
 
     @patch("app.cli.resolve_shortcut")
-    @patch("app.cli.fetch_keys")
+    @patch("app.cli.fetch_key_entries")
     def test_repl_quit_key_collision_opens_shortcut(
         self,
-        mock_fetch_keys,
+        mock_fetch_entries,
         mock_resolve,
     ) -> None:
-        mock_fetch_keys.return_value = ["quit"]
+        mock_fetch_entries.return_value = [KeyEntry(key="quit")]
         mock_resolve.return_value = ResolvedShortcut(
             url="https://example.com/quit", kind="bookmark", key="quit"
         )
@@ -702,11 +712,11 @@ class ConfigUnitTests(TestCase):
         self.assertIn("yellow", help_c.style)
         self.assertIn("cyan", gh_c.style)
 
-    @patch("app.cli.fetch_keys")
-    def test_interactive_refresh_updates_keys(self, mock_fetch_keys) -> None:
-        mock_fetch_keys.side_effect = [
-            ["gh"],
-            ["gh", "pr"],
+    @patch("app.cli.fetch_key_entries")
+    def test_interactive_refresh_updates_keys(self, mock_fetch_entries) -> None:
+        mock_fetch_entries.side_effect = [
+            [KeyEntry(key="gh")],
+            [KeyEntry(key="gh"), KeyEntry(key="pr")],
         ]
         responses = iter(["refresh", "quit"])
         stdout = StringIO()
@@ -723,4 +733,292 @@ class ConfigUnitTests(TestCase):
                     input_fn=lambda _prompt: next(responses),
                 )
         self.assertIn("refreshed", stdout.getvalue())
-        self.assertEqual(mock_fetch_keys.call_count, 2)
+        self.assertEqual(mock_fetch_entries.call_count, 2)
+
+
+class KeyUsageAndCompletionTests(TestCase):
+    def test_parse_keys_payload_prefers_entries(self) -> None:
+        entries = parse_keys_payload(
+            {
+                "keys": ["old"],
+                "entries": [
+                    {
+                        "key": "pr",
+                        "description": "Pull Request",
+                        "url": "https://github.com/#{repo}/pull/#{pr_number}",
+                        "params": ["repo", "pr_number"],
+                    }
+                ],
+            }
+        )
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].key, "pr")
+        self.assertEqual(entries[0].params, ("repo", "pr_number"))
+
+    def test_format_key_usage_lines(self) -> None:
+        from app.usage import format_key_usage_lines
+
+        lines = format_key_usage_lines(
+            [
+                KeyEntry(
+                    key="pr",
+                    description="Pull Request",
+                    url="https://github.com/#{repo}/pull/#{pr_number}",
+                    params=("repo", "pr_number"),
+                ),
+                KeyEntry(key="gh", description="GitHub", url="https://github.com"),
+            ]
+        )
+        self.assertEqual(len(lines), 2)
+        self.assertIn("pr", lines[0])
+        self.assertIn("repo pr_number", lines[0])
+        self.assertIn("Pull Request", lines[0])
+        self.assertIn("https://github.com/#{repo}/pull/#{pr_number}", lines[0])
+        self.assertIn("gh", lines[1])
+
+    @patch("app.cli.fetch_key_entries")
+    def test_list_usage(self, mock_fetch_entries) -> None:
+        mock_fetch_entries.return_value = [
+            KeyEntry(
+                key="prh",
+                description="PRs",
+                url="https://github.com/the-hcma/#{repo}/pulls",
+                params=("repo",),
+            )
+        ]
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            _run(
+                shortcut_args=(),
+                base_url="http://127.0.0.1:8000",
+                list_keys=False,
+                list_usage=True,
+                use_fzf=False,
+                fzf_query="",
+                print_url=False,
+                open_browser=False,
+            )
+        text = stdout.getvalue()
+        self.assertIn("prh", text)
+        self.assertIn("repo", text)
+        self.assertIn("PRs", text)
+
+    @patch("app.cli.fetch_key_entries")
+    def test_repl_keys_prints_usage(self, mock_fetch_entries) -> None:
+        mock_fetch_entries.return_value = [
+            KeyEntry(
+                key="pr",
+                description="Pull Request",
+                url="https://github.com/#{repo}/pull/#{pr_number}",
+                params=("repo", "pr_number"),
+            )
+        ]
+        responses = iter(["keys", "quit"])
+        stdout = StringIO()
+        with patch("sys.stdout", stdout):
+            with patch("sys.stderr", new_callable=StringIO):
+                _run(
+                    shortcut_args=(),
+                    base_url="http://127.0.0.1:8000",
+                    list_keys=False,
+                    use_fzf=False,
+                    fzf_query="",
+                    print_url=False,
+                    open_browser=False,
+                    input_fn=lambda _prompt: next(responses),
+                )
+        text = stdout.getvalue()
+        self.assertIn("pr", text)
+        self.assertIn("repo pr_number", text)
+        self.assertIn("1 keys", text)
+
+    def test_completion_token_state(self) -> None:
+        from app.interactive import completion_token_state
+
+        self.assertEqual(
+            completion_token_state("pr "),
+            ("pr", [], "", 0),
+        )
+        self.assertEqual(
+            completion_token_state("pr the-hcma/bun"),
+            ("pr", [], "the-hcma/bun", 0),
+        )
+        self.assertEqual(
+            completion_token_state("pr the-hcma/bunnify "),
+            ("pr", ["the-hcma/bunnify"], "", 1),
+        )
+        self.assertEqual(
+            completion_token_state("pr the-hcma/bunnify 24"),
+            ("pr", ["the-hcma/bunnify"], "24", 1),
+        )
+
+    def test_infer_fixed_github_org(self) -> None:
+        from app.github_complete import infer_fixed_github_org
+
+        self.assertEqual(
+            infer_fixed_github_org("https://github.com/the-hcma/#{repo}/pulls"),
+            "the-hcma",
+        )
+        self.assertIsNone(
+            infer_fixed_github_org("https://github.com/#{repo}/pull/#{pr_number}")
+        )
+
+    def test_param_completer_repos_and_prs(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+
+        entry = KeyEntry(
+            key="pr",
+            description="Pull Request",
+            url="https://github.com/#{repo}/pull/#{pr_number}",
+            params=("repo", "pr_number"),
+        )
+
+        def fake_suggest(*, param_name, url_template, filled_args, prefix):
+            del url_template
+            if param_name == "repo":
+                return [
+                    name
+                    for name in ("the-hcma/bunnify", "the-hcma/other")
+                    if name.startswith(prefix)
+                ]
+            if param_name == "pr_number":
+                self.assertEqual(filled_args, ["the-hcma/bunnify"])
+                return [num for num in ("242", "245") if num.startswith(prefix)]
+            return []
+
+        completer = ShortcutCompleter(
+            ["pr"],
+            theme=Theme(enabled=False),
+            entries=[entry],
+            param_suggest_fn=fake_suggest,
+        )
+        repos = [
+            c.text
+            for c in completer.get_completions(
+                Document("pr the-hcma/bun"), complete_event=None
+            )  # type: ignore[arg-type]
+        ]
+        self.assertEqual(repos, ["the-hcma/bunnify"])
+        prs = [
+            c.text
+            for c in completer.get_completions(
+                Document("pr the-hcma/bunnify 24"), complete_event=None
+            )  # type: ignore[arg-type]
+        ]
+        self.assertEqual(prs, ["242", "245"])
+
+    def test_list_github_repos_uses_rest_api(self) -> None:
+        from app.github_complete import clear_github_completion_cache, list_github_repos
+
+        clear_github_completion_cache()
+        seen: list[str] = []
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return b'[{"name":"bunnify"},{"name":"fpdf"}]'
+
+        def opener(request, timeout=0):  # noqa: ARG001
+            seen.append(request.full_url)
+            return FakeResponse()
+
+        names = list_github_repos(
+            org="the-hcma",
+            prefix="bun",
+            token="test-token",
+            opener=opener,
+        )
+        self.assertEqual(names, ["bunnify"])
+        self.assertTrue(any("/orgs/the-hcma/repos" in url for url in seen))
+
+    def test_suggest_pr_numbers_for_fixed_org(self) -> None:
+        from app.github_complete import (
+            clear_github_completion_cache,
+            suggest_param_values,
+        )
+
+        clear_github_completion_cache()
+        seen: list[str] = []
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return b'[{"number":242,"title":"cli"},{"number":100,"title":"other"}]'
+
+        def opener(request, timeout=0):  # noqa: ARG001
+            seen.append(request.full_url)
+            return FakeResponse()
+
+        values = suggest_param_values(
+            param_name="pr_number",
+            url_template="https://github.com/the-hcma/#{repo}/pull/#{pr_number}",
+            filled_args=["bunnify"],
+            prefix="24",
+            token="test-token",
+            opener=opener,
+        )
+        self.assertEqual(values, ["242"])
+        self.assertTrue(any("/repos/the-hcma/bunnify/pulls" in url for url in seen))
+
+    def test_failed_api_fetch_does_not_poison_cache(self) -> None:
+        import urllib.error
+
+        from app.github_complete import clear_github_completion_cache, list_github_repos
+
+        clear_github_completion_cache()
+        calls = {"n": 0}
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return b'[{"name":"bunnify"}]'
+
+        def opener(_request, timeout=0):  # noqa: ARG001
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise urllib.error.URLError("boom")
+            return FakeResponse()
+
+        self.assertEqual(
+            list_github_repos(org="the-hcma", token="t", opener=opener),
+            [],
+        )
+        names = list_github_repos(
+            org="the-hcma", prefix="bun", token="t", opener=opener
+        )
+        self.assertEqual(names, ["bunnify"])
+        self.assertEqual(calls["n"], 2)
+
+    def test_desc_truncation_respects_width(self) -> None:
+        from app.usage import format_key_usage_lines
+
+        lines = format_key_usage_lines(
+            [
+                KeyEntry(key="a", description="A" * 40, url="u"),
+                KeyEntry(key="b", description="H" * 50, url="u"),
+            ]
+        )
+        # Cap is 40; truncated description must not exceed that width.
+        self.assertIn("…", lines[1])
+        # Extract the description column between padded key and URL.
+        body = lines[1].strip()
+        # "b" + spaces + desc(40) + spaces + "u"
+        self.assertRegex(body, r"^b\s+.{40}\s+u$")

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -15,6 +15,7 @@ from django.shortcuts import redirect, render
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_http_methods
 
+from .keys_catalog import catalog_payload
 from .models import Bookmark
 from .resolve import PLACEHOLDER_PATTERN, resolve_query, substitute_placeholder_values
 
@@ -313,11 +314,14 @@ def api_resolve(request: HttpRequest) -> JsonResponse:
 @never_cache
 @require_http_methods(["GET"])
 def api_keys(request: HttpRequest) -> JsonResponse:
-    """Return all bookmark keys (plus special commands) for CLI completion / fzf."""
-    keys = list(Bookmark.objects.order_by("key").values_list("key", flat=True))
-    # Special commands first for discoverability
-    special = ["h", "cmd"]
-    return JsonResponse({"keys": [*special, *keys]})
+    """Return shortcut keys plus structured usage entries for the CLI.
+
+    Payload always includes:
+      keys: list[str] — backward-compatible flat list for bash completion / fzf
+      entries: list[{key, description, url, params}] — short-usage metadata
+    """
+    del request
+    return JsonResponse(catalog_payload())
 
 
 @never_cache

--- a/etc/bunnify-completion
+++ b/etc/bunnify-completion
@@ -30,7 +30,7 @@ _bunnify_completion() {
     edit_mode_values=(emacs vim)
 
     if [[ "${cur}" == -* ]]; then
-        options=(--base-url --list-keys --fzf --query --print-url --dry-run --color --edit-mode --env-file --help)
+        options=(--base-url --list-keys --list-usage --fzf --query --print-url --dry-run --color --edit-mode --env-file --help)
         COMPREPLY=()
         while IFS= read -r reply; do
             COMPREPLY+=("${reply}")


### PR DESCRIPTION
## Summary
- Extend `/api/keys/` with structured `entries` (key, description, url, params) while keeping flat `keys` for bash/`--list-keys`
- Add CLI `--list-usage` and richer REPL `keys` short-usage rows
- Tab-complete parameterized placeholders (`repo`, `pr_number`, …) via `gh` (repos → open PRs), fail-soft when unauthenticated

Closes #245

## Test plan
- [x] `uv run ruff check .` / `ruff format --check` / `pyright --warnings`
- [x] `./test_bunnify`
- [x] `./test_integration`
- [x] `shellcheck` on touched scripts/completion
- [ ] Manual: REPL `keys` / `--list-usage`; `prh <Tab>` and `pr <repo> <Tab>` with `gh auth`