### PR TITLE
fix: required/optional arg markup and param Tab after keys

### DIFF
--- a/app/client.py
+++ b/app/client.py
@@ -32,6 +32,7 @@ class KeyEntry:
     description: str = ""
     url: str = ""
     params: tuple[str, ...] = ()
+    optional_params: frozenset[str] = frozenset()
 
 
 def _request_json(
@@ -117,7 +118,21 @@ def parse_key_entry(raw: Any) -> KeyEntry | None:
     params: tuple[str, ...] = ()
     if isinstance(params_raw, list):
         params = tuple(str(item) for item in params_raw)
-    return KeyEntry(key=key, description=description, url=url, params=params)
+    optional: frozenset[str] = frozenset()
+    optional_raw = raw.get("optional_params")
+    defaults_raw = raw.get("defaults", {})
+    if isinstance(optional_raw, list):
+        optional = frozenset(str(name) for name in optional_raw)
+    elif isinstance(defaults_raw, dict):
+        # Backward compatible with older /api/keys/ payloads.
+        optional = frozenset(str(name) for name in defaults_raw)
+    return KeyEntry(
+        key=key,
+        description=description,
+        url=url,
+        params=params,
+        optional_params=optional,
+    )
 
 
 def parse_keys_payload(payload: Any) -> list[KeyEntry]:

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import time
@@ -10,6 +11,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 _CACHE_TTL_SECONDS = 60.0
 _DEFAULT_TIMEOUT_SECONDS = 8.0
@@ -98,15 +101,14 @@ def _github_get_json(
         with open_url(request, timeout=timeout) as response:
             body = response.read().decode("utf-8")
             return json.loads(body)
-    except urllib.error.HTTPError:
-        return None
-    except urllib.error.URLError:
-        return None
-    except TimeoutError:
-        return None
-    except json.JSONDecodeError:
-        return None
-    except OSError:
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        TimeoutError,
+        json.JSONDecodeError,
+        OSError,
+    ) as exc:
+        logger.debug("GitHub REST GET %s failed: %s", path, exc, exc_info=True)
         return None
 
 

--- a/app/interactive.py
+++ b/app/interactive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Callable, Iterable
 from pathlib import Path
@@ -23,11 +24,14 @@ from prompt_toolkit.history import FileHistory, InMemoryHistory
 from app.client import ClientError, KeyEntry
 from app.github_complete import suggest_param_values
 from app.theme import Theme
+from app.usage import format_params
 
 try:
     import readline as readline_module
 except ModuleNotFoundError:
     readline_module = None
+
+logger = logging.getLogger(__name__)
 
 REPL_META_COMMANDS: tuple[tuple[str, str], ...] = (
     ("edit-mode", "Switch Emacs vs Vim keys: edit-mode emacs | vim"),
@@ -95,8 +99,9 @@ class ShortcutCompleter(Completer):
     """
     Tab-complete the first token against meta-commands + shortcut keys.
 
-    After a space, prefers GitHub-aware parameter completions from key
-    metadata, then falls back to optional OpenSearch ``suggestions_fn``.
+    After a finished key (exact match with params, or a trailing space),
+    prefers GitHub-aware parameter completions from key metadata. Does not
+    fall back to OpenSearch key suggestions while completing params.
     """
 
     def __init__(
@@ -126,6 +131,34 @@ class ShortcutCompleter(Completer):
         self._entries_by_key = mapping
         self._keys = sorted(mapping.keys()) if mapping else self._keys
 
+    def _lookup_entry(self, key: str) -> KeyEntry | None:
+        entry = self._entries_by_key.get(key)
+        if entry is not None:
+            return entry
+        lowered = key.lower()
+        for candidate_key, candidate in self._entries_by_key.items():
+            if candidate_key.lower() == lowered:
+                return candidate
+        return None
+
+    def wants_param_completion(self, text: str) -> bool:
+        """True when Tab should complete shortcut/meta parameters, not keys."""
+        stripped = text.strip()
+        if not stripped:
+            return False
+        key = stripped.split(None, 1)[0]
+        key_set = {candidate.lower() for candidate in self._keys}
+        if key.lower() == "edit-mode" and "edit-mode" not in key_set:
+            return True
+        if any(ch.isspace() for ch in text):
+            entry = self._lookup_entry(key)
+            return entry is not None and bool(entry.params)
+        entry = self._lookup_entry(stripped)
+        return entry is not None and bool(entry.params)
+
+    def _has_separator(self, text: str) -> bool:
+        return any(ch.isspace() for ch in text)
+
     def get_completions(
         self,
         document: Document,
@@ -133,8 +166,18 @@ class ShortcutCompleter(Completer):
     ):
         del complete_event
         text = document.text_before_cursor
-        if " " in text:
+        if self.wants_param_completion(text):
             yield from self._param_completions(text)
+            # Still offer longer key names when the token is an exact key that
+            # is also a prefix of other keys (e.g. pr → prh).
+            if not self._has_separator(text):
+                yield from self._longer_key_completions(text)
+            return
+
+        if self._has_separator(text):
+            # Multi-token input that is not a known param slot (unknown key,
+            # or a no-arg shortcut with extra text): OpenSearch suggestions.
+            yield from self._suggestion_completions(text)
             return
 
         partial = text
@@ -161,7 +204,9 @@ class ShortcutCompleter(Completer):
                 meta = "shortcut"
                 if entry is not None:
                     if entry.params:
-                        meta = " ".join(entry.params)
+                        meta = format_params(
+                            entry.params, optional_params=entry.optional_params
+                        )
                     elif entry.description:
                         meta = entry.description[:40]
                 yield Completion(
@@ -171,8 +216,32 @@ class ShortcutCompleter(Completer):
                     display_meta=meta,
                 )
 
+    def _longer_key_completions(self, text: str):
+        needle = text.lower()
+        key_style = self._theme.completion_key_style()
+
+        for key in self._keys:
+            if key.lower().startswith(needle) and key.lower() != needle:
+                entry = self._entries_by_key.get(key)
+                meta = "shortcut"
+                if entry is not None and entry.params:
+                    meta = format_params(
+                        entry.params, optional_params=entry.optional_params
+                    )
+                elif entry is not None and entry.description:
+                    meta = entry.description[:40]
+                yield Completion(
+                    key,
+                    start_position=-len(text),
+                    style=key_style,
+                    display_meta=meta,
+                )
+
     def _param_completions(self, text: str):
-        key, filled_args, prefix, arg_index = completion_token_state(text)
+        # Exact finished key with no trailing whitespace → complete first arg.
+        insert_key_prefix = not self._has_separator(text)
+        effective = f"{text.rstrip()} " if insert_key_prefix else text
+        key, filled_args, prefix, arg_index = completion_token_state(effective)
         style = self._theme.completion_param_style()
 
         key_set = {candidate.lower() for candidate in self._keys}
@@ -180,45 +249,59 @@ class ShortcutCompleter(Completer):
             needle = prefix.lower()
             for alias in _EDIT_MODE_SUBARGS:
                 if alias.startswith(needle):
-                    yield Completion(
-                        alias,
-                        start_position=-len(prefix),
-                        style=style,
-                        display_meta="edit-mode",
-                    )
+                    if insert_key_prefix:
+                        yield Completion(
+                            f"{key} {alias}",
+                            start_position=-len(text),
+                            display=alias,
+                            style=style,
+                            display_meta="edit-mode",
+                        )
+                    else:
+                        yield Completion(
+                            alias,
+                            start_position=-len(prefix),
+                            style=style,
+                            display_meta="edit-mode",
+                        )
             return
 
-        entry = self._entries_by_key.get(key)
-        if entry is None:
-            # Case-insensitive key lookup.
-            lowered = key.lower()
-            for candidate_key, candidate in self._entries_by_key.items():
-                if candidate_key.lower() == lowered:
-                    entry = candidate
-                    break
-
-        yielded = False
-        if entry is not None and entry.params and arg_index < len(entry.params):
-            param_name = entry.params[arg_index]
-            try:
-                values = self._param_suggest_fn(
-                    param_name=param_name,
-                    url_template=entry.url,
-                    filled_args=filled_args,
-                    prefix=prefix,
+        entry = self._lookup_entry(key)
+        if entry is None or not entry.params:
+            return
+        if arg_index >= len(entry.params):
+            return
+        param_name = entry.params[arg_index]
+        try:
+            values = self._param_suggest_fn(
+                param_name=param_name,
+                url_template=entry.url,
+                filled_args=filled_args,
+                prefix=prefix,
+            )
+        except (OSError, ValueError, TypeError) as exc:
+            logger.debug(
+                "param suggestion failed for %r on key %r: %s",
+                param_name,
+                entry.key,
+                exc,
+                exc_info=True,
+            )
+            values = []
+        seen: set[str] = set()
+        for value in values:
+            if value in seen:
+                continue
+            seen.add(value)
+            if insert_key_prefix:
+                yield Completion(
+                    f"{entry.key} {value}",
+                    start_position=-len(text),
+                    display=value,
+                    style=style,
+                    display_meta=param_name,
                 )
-            except OSError:
-                values = []
-            except ValueError:
-                values = []
-            except TypeError:
-                values = []
-            seen: set[str] = set()
-            for value in values:
-                if value in seen:
-                    continue
-                seen.add(value)
-                yielded = True
+            else:
                 yield Completion(
                     value,
                     start_position=-len(prefix),
@@ -226,16 +309,19 @@ class ShortcutCompleter(Completer):
                     display_meta=param_name,
                 )
 
-        if yielded or self._suggestions_fn is None:
+    def _suggestion_completions(self, text: str):
+        if self._suggestions_fn is None:
             return
-
+        style = self._theme.completion_param_style()
         try:
             suggestions = self._suggestions_fn(text)
-        except ClientError:
-            return
-        except OSError:
-            return
-        except ValueError:
+        except (ClientError, OSError, ValueError) as exc:
+            logger.debug(
+                "OpenSearch suggestion failed for %r: %s",
+                text,
+                exc,
+                exc_info=True,
+            )
             return
         seen_suggestions: set[str] = set()
         for item in suggestions:
@@ -258,6 +344,25 @@ class ShortcutCompleter(Completer):
                         style=style,
                         display_meta="suggestion",
                     )
+
+
+class FirstTokenFuzzyCompleter(Completer):
+    """Apply fuzzy matching only while completing the first token (key/meta)."""
+
+    def __init__(self, inner: ShortcutCompleter) -> None:
+        self._inner = inner
+        self._fuzzy = FuzzyCompleter(inner, enable_fuzzy=True)
+
+    def get_completions(
+        self,
+        document: Document,
+        complete_event: CompleteEvent,
+    ):
+        text = document.text_before_cursor
+        if self._inner.wants_param_completion(text) or any(ch.isspace() for ch in text):
+            yield from self._inner.get_completions(document, complete_event)
+            return
+        yield from self._fuzzy.get_completions(document, complete_event)
 
 
 class ReadlineShortcutCompleter:
@@ -317,8 +422,8 @@ def create_repl_session(
         suggestions_fn=suggestions_fn,
         entries=entries,
     )
-    # FuzzyCompleter makes Tab forgiving (domesti-bot uses prefix-only; we go further).
-    completer: Completer = FuzzyCompleter(inner, enable_fuzzy=True)
+    # Fuzzy only on the first token so param values (repos / PRs) are not filtered.
+    completer: Completer = FirstTokenFuzzyCompleter(inner)
 
     path = history_path if history_path is not None else history_file_path()
     try:

--- a/app/usage.py
+++ b/app/usage.py
@@ -2,12 +2,28 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from app.client import KeyEntry
 from app.theme import Theme
 
 
-def format_params(params: tuple[str, ...] | list[str]) -> str:
-    return " ".join(params)
+def format_param_token(name: str, *, optional: bool) -> str:
+    """Render one arg as ``<name>`` (required) or ``[name]`` (optional)."""
+    if optional:
+        return f"[{name}]"
+    return f"<{name}>"
+
+
+def format_params(
+    params: tuple[str, ...] | list[str],
+    *,
+    optional_params: Iterable[str] | None = None,
+) -> str:
+    optional = frozenset(optional_params or ())
+    return " ".join(
+        format_param_token(name, optional=name in optional) for name in params
+    )
 
 
 def format_key_usage_lines(
@@ -20,11 +36,12 @@ def format_key_usage_lines(
     if not entries:
         return []
 
+    rendered = [
+        format_params(entry.params, optional_params=entry.optional_params)
+        for entry in entries
+    ]
     key_width = max(len(entry.key) for entry in entries)
-    params_width = max(
-        (len(format_params(entry.params)) for entry in entries),
-        default=0,
-    )
+    params_width = max((len(text) for text in rendered), default=0)
     # Cap description column so long blurbs do not dominate the terminal.
     desc_width = min(
         40,
@@ -32,8 +49,7 @@ def format_key_usage_lines(
     )
 
     lines: list[str] = []
-    for entry in entries:
-        params = format_params(entry.params)
+    for entry, params in zip(entries, rendered, strict=True):
         description = entry.description
         if len(description) > desc_width > 0:
             description = (description[: desc_width - 1] + "…")[:desc_width]

--- a/bookmarks/keys_catalog.py
+++ b/bookmarks/keys_catalog.py
@@ -26,16 +26,20 @@ def build_key_catalog() -> list[dict[str, Any]]:
             "description": description,
             "url": url,
             "params": [],
+            "optional_params": [],
         }
         for key, description, url in SPECIAL_ENTRIES
     ]
     for bookmark in Bookmark.objects.order_by("key"):
+        defaults = bookmark.defaults if isinstance(bookmark.defaults, dict) else {}
+        params = placeholders_for_url(bookmark.url)
         entries.append(
             {
                 "key": bookmark.key,
                 "description": bookmark.description or "",
                 "url": bookmark.url,
-                "params": placeholders_for_url(bookmark.url),
+                "params": params,
+                "optional_params": [name for name in params if name in defaults],
             }
         )
     return entries

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -118,6 +118,8 @@ class ResolveApiTests(TestCase):
         self.assertEqual(entries["gh"]["url"], "https://github.com")
         self.assertEqual(entries["gh"]["params"], [])
         self.assertEqual(entries["pr"]["params"], ["repo", "pr_number"])
+        self.assertEqual(entries["pr"]["optional_params"], ["repo"])
+        self.assertNotIn("defaults", entries["pr"])
         self.assertEqual(entries["h"]["url"], "/list/")
         self.assertEqual(entries["cmd"]["description"], "Command palette")
 
@@ -765,13 +767,14 @@ class KeyUsageAndCompletionTests(TestCase):
                     description="Pull Request",
                     url="https://github.com/#{repo}/pull/#{pr_number}",
                     params=("repo", "pr_number"),
+                    optional_params=frozenset({"repo"}),
                 ),
                 KeyEntry(key="gh", description="GitHub", url="https://github.com"),
             ]
         )
         self.assertEqual(len(lines), 2)
         self.assertIn("pr", lines[0])
-        self.assertIn("repo pr_number", lines[0])
+        self.assertIn("[repo] <pr_number>", lines[0])
         self.assertIn("Pull Request", lines[0])
         self.assertIn("https://github.com/#{repo}/pull/#{pr_number}", lines[0])
         self.assertIn("gh", lines[1])
@@ -829,7 +832,7 @@ class KeyUsageAndCompletionTests(TestCase):
                 )
         text = stdout.getvalue()
         self.assertIn("pr", text)
-        self.assertIn("repo pr_number", text)
+        self.assertIn("<repo> <pr_number>", text)
         self.assertIn("1 keys", text)
 
     def test_completion_token_state(self) -> None:
@@ -909,6 +912,144 @@ class KeyUsageAndCompletionTests(TestCase):
             )  # type: ignore[arg-type]
         ]
         self.assertEqual(prs, ["242", "245"])
+
+    def test_exact_key_tab_completes_first_param(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+
+        entry = KeyEntry(
+            key="prh",
+            description="PRs",
+            url="https://github.com/the-hcma/#{repo}/pulls",
+            params=("repo",),
+        )
+
+        def fake_suggest(*, param_name, url_template, filled_args, prefix):
+            del url_template, filled_args
+            self.assertEqual(param_name, "repo")
+            self.assertEqual(prefix, "")
+            return ["bunnify", "fpdf"]
+
+        completer = ShortcutCompleter(
+            ["prh", "prhh"],
+            theme=Theme(enabled=False),
+            entries=[
+                entry,
+                KeyEntry(
+                    key="prhh",
+                    description="other",
+                    url="https://github.com/x/#{repo}/pulls",
+                    params=("repo",),
+                ),
+            ],
+            param_suggest_fn=fake_suggest,
+            suggestions_fn=lambda _q: ["should-not-appear"],
+        )
+        texts = [
+            c.text
+            for c in completer.get_completions(Document("prh"), complete_event=None)  # type: ignore[arg-type]
+        ]
+        self.assertIn("prh bunnify", texts)
+        self.assertIn("prh fpdf", texts)
+        self.assertIn("prhh", texts)
+        self.assertNotIn("should-not-appear", texts)
+
+    def test_param_slot_does_not_fallback_to_key_suggestions(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+
+        entry = KeyEntry(
+            key="prh",
+            description="PRs",
+            url="https://github.com/the-hcma/#{repo}/pulls",
+            params=("repo",),
+        )
+        completer = ShortcutCompleter(
+            ["prh", "gh"],
+            theme=Theme(enabled=False),
+            entries=[entry, KeyEntry(key="gh")],
+            param_suggest_fn=lambda **_kwargs: [],
+            suggestions_fn=lambda _q: ["gh", "prh"],
+        )
+        texts = [
+            c.text
+            for c in completer.get_completions(Document("prh "), complete_event=None)  # type: ignore[arg-type]
+        ]
+        self.assertEqual(texts, [])
+
+    def test_edit_mode_subarg_completion(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+
+        completer = ShortcutCompleter(
+            ["gh"],
+            theme=Theme(enabled=False),
+            entries=[KeyEntry(key="gh")],
+        )
+        texts = [
+            c.text
+            for c in completer.get_completions(
+                Document("edit-mode e"), complete_event=None
+            )  # type: ignore[arg-type]
+        ]
+        self.assertEqual(texts, ["emacs"])
+
+    def test_suggestions_fallback_outside_param_slot(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+
+        completer = ShortcutCompleter(
+            ["gh"],
+            theme=Theme(enabled=False),
+            entries=[KeyEntry(key="gh")],
+            suggestions_fn=lambda _q: ["foobar"],
+        )
+        texts = [
+            c.text
+            for c in completer.get_completions(Document("ggg foo"), complete_event=None)  # type: ignore[arg-type]
+        ]
+        self.assertEqual(texts, ["foobar"])
+
+    def test_param_suggest_exceptions_are_logged(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+
+        entry = KeyEntry(
+            key="prh",
+            url="https://github.com/the-hcma/#{repo}/pulls",
+            params=("repo",),
+        )
+
+        def boom(**_kwargs):
+            raise OSError("network down")
+
+        completer = ShortcutCompleter(
+            ["prh"],
+            theme=Theme(enabled=False),
+            entries=[entry],
+            param_suggest_fn=boom,
+        )
+        with self.assertLogs("app.interactive", level="DEBUG") as captured:
+            texts = [
+                c.text
+                for c in completer.get_completions(
+                    Document("prh "), complete_event=None
+                )  # type: ignore[arg-type]
+            ]
+        self.assertEqual(texts, [])
+        self.assertTrue(
+            any("param suggestion failed" in line for line in captured.output)
+        )
 
     def test_list_github_repos_uses_rest_api(self) -> None:
         from app.github_complete import clear_github_completion_cache, list_github_repos


### PR DESCRIPTION
## Summary
- Show shortcut parameters as \`<required>\` / \`[optional]\` (optional when the bookmark has a default)
- After a finished parameterized key (e.g. \`prh\` or \`prh \`), Tab completes the next GitHub param instead of other keys
- Avoid OpenSearch key-suggestion fallback while in a param slot; fuzzy matching only applies to the first token

## Test plan
- [x] Unit tests for usage markup and exact-key / param-slot completion
- [x] \`ruff\` / \`pyright\` / \`./test_bunnify\` / \`./test_integration\`
- [ ] Manual: REPL \`keys\`; Tab on \`prh\` / \`prh \` with \`GITHUB_TOKEN\` set