### PR TITLE
feat: use gh auth for GitHub repo Tab completion

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -22,6 +22,10 @@ from app.client import (
     resolve_shortcut,
 )
 from app.config import ENV_VAR, env_file_path, resolve_base_url
+from app.github_complete import (
+    ensure_github_authenticated,
+    warm_github_completion_cache,
+)
 from app.interactive import (
     REPL_META_COMMANDS,
     REPL_META_NAMES,
@@ -230,6 +234,27 @@ def _run_repl(
             ):
                 break
         return
+
+    interactive_auth = sys.stdin.isatty() and sys.stdout.isatty()
+    github_token = ensure_github_authenticated(interactive=interactive_auth)
+    if github_token:
+        warmed = warm_github_completion_cache(
+            url_templates=[entry.url for entry in entries],
+            token=github_token,
+        )
+        click.echo(
+            theme.dim(
+                f"GitHub completion · {warmed['orgs']} orgs · "
+                f"{warmed['repos']} repos cached"
+            )
+        )
+    else:
+        click.echo(
+            theme.meta(
+                "GitHub not authenticated — set GITHUB_TOKEN / GH_TOKEN "
+                "or run `gh auth login` for repo Tab completion"
+            )
+        )
 
     def suggestions_fn(query: str) -> list[str]:
         return fetch_suggestions(query, base_url=base_url)

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -6,28 +6,36 @@ import json
 import logging
 import os
 import re
+import subprocess
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_CACHE_TTL_SECONDS = 60.0
+_CACHE_TTL_SECONDS = 300.0
 _DEFAULT_TIMEOUT_SECONDS = 8.0
+_GH_TOKEN_TIMEOUT_SECONDS = 8.0
+_GH_LOGIN_TIMEOUT_SECONDS = 600.0
 _REPO_PARAM_NAMES = frozenset({"repo", "repository", "org_repo"})
 _PR_PARAM_NAMES = frozenset(
     {"pr_number", "pr_id", "pr", "pull", "pull_number", "number"}
 )
 _API_ROOT = "https://api.github.com"
+_UNSET = object()
 
 _cache: dict[str, tuple[float, list[str]]] = {}
+_token_cache: Any = _UNSET
 
 _GITHUB_ORG_REPO = re.compile(
     r"(?:github\.com|graphite\.com/github/pr)/([^/#{}]+)/#\{repo\}",
     re.IGNORECASE,
 )
+
+GhRunner = Callable[..., subprocess.CompletedProcess[str]]
 
 
 def infer_fixed_github_org(url_template: str) -> str | None:
@@ -54,8 +62,10 @@ def _cache_set(key: str, values: list[str]) -> None:
 
 
 def clear_github_completion_cache() -> None:
-    """Test helper: drop in-process completion cache."""
+    """Test helper: drop in-process completion + token caches."""
+    global _token_cache
     _cache.clear()
+    _token_cache = _UNSET
 
 
 def github_token_from_environ(
@@ -70,6 +80,116 @@ def github_token_from_environ(
     return None
 
 
+def _run_gh(
+    args: Sequence[str],
+    *,
+    timeout: float,
+    runner: GhRunner | None = None,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    run = runner or subprocess.run
+    kwargs: dict[str, Any] = {
+        "args": ["gh", *args],
+        "text": True,
+        "timeout": timeout,
+        "check": False,
+    }
+    if capture_output:
+        kwargs["capture_output"] = True
+    return run(**kwargs)
+
+
+def github_token_from_gh(
+    *,
+    runner: GhRunner | None = None,
+    timeout: float = _GH_TOKEN_TIMEOUT_SECONDS,
+) -> str | None:
+    """Return the token from ``gh auth token`` when the CLI is logged in."""
+    try:
+        completed = _run_gh(
+            ["auth", "token"],
+            timeout=timeout,
+            runner=runner,
+            capture_output=True,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("gh auth token failed: %s", exc, exc_info=True)
+        return None
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        logger.debug("gh auth token exited %s: %s", completed.returncode, stderr)
+        return None
+    token = (completed.stdout or "").strip()
+    return token or None
+
+
+def resolve_github_token(
+    *,
+    environ: dict[str, str] | None = None,
+    runner: GhRunner | None = None,
+    use_cache: bool = True,
+) -> str | None:
+    """
+    Resolve a GitHub token for completion API calls.
+
+    Precedence: ``GITHUB_TOKEN`` / ``GH_TOKEN`` → ``gh auth token``.
+    """
+    global _token_cache
+    env_token = github_token_from_environ(environ)
+    if env_token:
+        return env_token
+    if use_cache and _token_cache is not _UNSET:
+        return _token_cache if isinstance(_token_cache, str) else None
+    token = github_token_from_gh(runner=runner)
+    if use_cache:
+        _token_cache = token
+    return token
+
+
+def ensure_github_authenticated(
+    *,
+    interactive: bool = False,
+    environ: dict[str, str] | None = None,
+    runner: GhRunner | None = None,
+) -> str | None:
+    """
+    Return a usable GitHub token, optionally running ``gh auth login`` first.
+
+    When ``interactive`` is true and no token is available, launches the
+    browser-oriented ``gh auth login`` flow (stdin/stdout inherited).
+    """
+    global _token_cache
+    token = resolve_github_token(environ=environ, runner=runner)
+    if token:
+        return token
+    if not interactive:
+        return None
+    logger.info("No GitHub token found; starting gh auth login")
+    try:
+        completed = _run_gh(
+            [
+                "auth",
+                "login",
+                "--hostname",
+                "github.com",
+                "--git-protocol",
+                "https",
+                "--web",
+            ],
+            timeout=_GH_LOGIN_TIMEOUT_SECONDS,
+            runner=runner,
+            capture_output=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("gh auth login failed: %s", exc, exc_info=True)
+        return None
+    if completed.returncode != 0:
+        logger.debug("gh auth login exited %s", completed.returncode)
+        return None
+    _token_cache = _UNSET
+    return resolve_github_token(environ=environ, runner=runner, use_cache=True)
+
+
 def _github_get_json(
     path: str,
     *,
@@ -77,9 +197,10 @@ def _github_get_json(
     token: str | None = None,
     timeout: float = _DEFAULT_TIMEOUT_SECONDS,
     opener: Any | None = None,
+    runner: GhRunner | None = None,
 ) -> Any | None:
     """GET a GitHub REST path. Return parsed JSON, or ``None`` on failure."""
-    auth = token if token is not None else github_token_from_environ()
+    auth = token if token is not None else resolve_github_token(runner=runner)
     if not auth:
         return None
     params = urllib.parse.urlencode(query or {})
@@ -112,6 +233,40 @@ def _github_get_json(
         return None
 
 
+def list_github_orgs(
+    *,
+    prefix: str = "",
+    limit: int = 100,
+    token: str | None = None,
+    opener: Any | None = None,
+    runner: GhRunner | None = None,
+) -> list[str]:
+    """List organization logins visible to the authenticated user."""
+    cache_key = f"orgs:{limit}"
+    cached = _cache_get(cache_key)
+    if cached is None:
+        per_page = min(max(limit, 1), 100)
+        payload = _github_get_json(
+            "/user/orgs",
+            query={"per_page": str(per_page)},
+            token=token,
+            opener=opener,
+            runner=runner,
+        )
+        if payload is None:
+            return []
+        names: list[str] = []
+        if isinstance(payload, list):
+            for item in payload:
+                if isinstance(item, dict) and isinstance(item.get("login"), str):
+                    names.append(item["login"])
+        cached = names[:limit]
+        _cache_set(cache_key, cached)
+
+    needle = prefix.lower()
+    return [name for name in cached if name.lower().startswith(needle)]
+
+
 def list_github_repos(
     *,
     org: str | None = None,
@@ -119,6 +274,7 @@ def list_github_repos(
     limit: int = 100,
     token: str | None = None,
     opener: Any | None = None,
+    runner: GhRunner | None = None,
 ) -> list[str]:
     """List repo names (short when ``org`` set, else ``owner/name``)."""
     cache_key = f"repos:{org or '*'}:{limit}"
@@ -135,6 +291,7 @@ def list_github_repos(
                 },
                 token=token,
                 opener=opener,
+                runner=runner,
             )
             if payload is None:
                 return []
@@ -154,6 +311,7 @@ def list_github_repos(
                 },
                 token=token,
                 opener=opener,
+                runner=runner,
             )
             if payload is None:
                 return []
@@ -178,6 +336,7 @@ def list_open_pull_requests(
     limit: int = 50,
     token: str | None = None,
     opener: Any | None = None,
+    runner: GhRunner | None = None,
 ) -> list[str]:
     """List open PR numbers (as strings) for ``owner/name``."""
     if not repo or "/" not in repo:
@@ -199,6 +358,7 @@ def list_open_pull_requests(
             },
             token=token,
             opener=opener,
+            runner=runner,
         )
         if payload is None:
             return []
@@ -231,6 +391,61 @@ def resolve_repo_for_pr(
     return None
 
 
+def orgs_from_url_templates(url_templates: Iterable[str]) -> list[str]:
+    """Unique fixed orgs inferred from bookmark URL templates."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for template in url_templates:
+        org = infer_fixed_github_org(template)
+        if org is None or org.lower() in seen:
+            continue
+        seen.add(org.lower())
+        ordered.append(org)
+    return ordered
+
+
+def warm_github_completion_cache(
+    *,
+    url_templates: Iterable[str] | None = None,
+    token: str | None = None,
+    opener: Any | None = None,
+    runner: GhRunner | None = None,
+) -> dict[str, int]:
+    """
+    Prefetch orgs/repos the authenticated user can see.
+
+    Warms:
+    - ``/user/orgs``
+    - ``/user/repos``
+    - ``/orgs/{org}/repos`` for bookmark-fixed orgs and visible memberships
+    """
+    auth = token if token is not None else resolve_github_token(runner=runner)
+    if not auth:
+        return {"orgs": 0, "repos": 0}
+
+    orgs = list_github_orgs(token=auth, opener=opener, runner=runner)
+    fixed = orgs_from_url_templates(url_templates or ())
+    targets: list[str] = []
+    seen: set[str] = set()
+    for org in [*fixed, *orgs]:
+        key = org.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        targets.append(org)
+
+    repo_count = 0
+    # Always warm the cross-org user repo list (owner/name form).
+    repo_count += len(
+        list_github_repos(org=None, token=auth, opener=opener, runner=runner)
+    )
+    for org in targets:
+        repo_count += len(
+            list_github_repos(org=org, token=auth, opener=opener, runner=runner)
+        )
+    return {"orgs": len(orgs), "repos": repo_count}
+
+
 def suggest_param_values(
     *,
     param_name: str,
@@ -239,18 +454,21 @@ def suggest_param_values(
     prefix: str,
     token: str | None = None,
     opener: Any | None = None,
+    runner: GhRunner | None = None,
 ) -> list[str]:
     """Return completion candidates for the next unresolved placeholder."""
     name = param_name.lower()
     if name in _REPO_PARAM_NAMES:
         org = infer_fixed_github_org(url_template)
-        return list_github_repos(org=org, prefix=prefix, token=token, opener=opener)
+        return list_github_repos(
+            org=org, prefix=prefix, token=token, opener=opener, runner=runner
+        )
     if name in _PR_PARAM_NAMES:
         repo_token = filled_args[-1] if filled_args else ""
         full_repo = resolve_repo_for_pr(url_template=url_template, repo_arg=repo_token)
         if full_repo is None:
             return []
         return list_open_pull_requests(
-            full_repo, prefix=prefix, token=token, opener=opener
+            full_repo, prefix=prefix, token=token, opener=opener, runner=runner
         )
     return []

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1148,6 +1148,122 @@ class KeyUsageAndCompletionTests(TestCase):
         self.assertEqual(names, ["bunnify"])
         self.assertEqual(calls["n"], 2)
 
+    def test_resolve_github_token_prefers_env_over_gh(self) -> None:
+        import subprocess
+
+        from app.github_complete import (
+            clear_github_completion_cache,
+            resolve_github_token,
+        )
+
+        clear_github_completion_cache()
+
+        def boom_runner(**_kwargs):
+            raise AssertionError("gh should not be called when env token is set")
+
+        token = resolve_github_token(
+            environ={"GITHUB_TOKEN": "env-token", "PATH": "/usr/bin"},
+            runner=boom_runner,
+        )
+        self.assertEqual(token, "env-token")
+
+        clear_github_completion_cache()
+
+        def gh_runner(*, args, **_kwargs):
+            self.assertEqual(args[:3], ["gh", "auth", "token"])
+            return subprocess.CompletedProcess(
+                args=list(args), returncode=0, stdout="gh-token\n", stderr=""
+            )
+
+        token = resolve_github_token(
+            environ={"PATH": "/usr/bin"},
+            runner=gh_runner,
+        )
+        self.assertEqual(token, "gh-token")
+
+    def test_ensure_github_authenticated_runs_login_when_needed(self) -> None:
+        import subprocess
+
+        from app.github_complete import (
+            clear_github_completion_cache,
+            ensure_github_authenticated,
+        )
+
+        clear_github_completion_cache()
+        calls: list[list[str]] = []
+
+        def runner(*, args, **_kwargs):
+            calls.append(list(args))
+            if args[1:3] == ["auth", "token"]:
+                # First probe: logged out. After login: token available.
+                if any(c[1:3] == ["auth", "login"] for c in calls):
+                    return subprocess.CompletedProcess(
+                        args=list(args),
+                        returncode=0,
+                        stdout="fresh-token\n",
+                        stderr="",
+                    )
+                return subprocess.CompletedProcess(
+                    args=list(args), returncode=1, stdout="", stderr="not logged in"
+                )
+            if args[1:3] == ["auth", "login"]:
+                return subprocess.CompletedProcess(
+                    args=list(args), returncode=0, stdout="", stderr=""
+                )
+            raise AssertionError(args)
+
+        token = ensure_github_authenticated(
+            interactive=True,
+            environ={"PATH": "/usr/bin"},
+            runner=runner,
+        )
+        self.assertEqual(token, "fresh-token")
+        self.assertTrue(any(c[1:3] == ["auth", "login"] for c in calls))
+
+    def test_warm_github_completion_cache_lists_orgs_and_repos(self) -> None:
+        from app.github_complete import (
+            clear_github_completion_cache,
+            warm_github_completion_cache,
+        )
+
+        clear_github_completion_cache()
+        seen: list[str] = []
+
+        class FakeResponse:
+            def __init__(self, body: bytes) -> None:
+                self._body = body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return self._body
+
+        def opener(request, timeout=0):  # noqa: ARG001
+            url = request.full_url
+            seen.append(url)
+            if "/user/orgs" in url:
+                return FakeResponse(b'[{"login":"the-hcma"}]')
+            if "/user/repos" in url:
+                return FakeResponse(b'[{"full_name":"me/dotfiles"}]')
+            if "/orgs/the-hcma/repos" in url:
+                return FakeResponse(b'[{"name":"bunnify"},{"name":"fpdf"}]')
+            raise AssertionError(url)
+
+        warmed = warm_github_completion_cache(
+            url_templates=["https://github.com/the-hcma/#{repo}/pulls"],
+            token="test-token",
+            opener=opener,
+        )
+        self.assertEqual(warmed["orgs"], 1)
+        self.assertGreaterEqual(warmed["repos"], 3)
+        self.assertTrue(any("/user/orgs" in url for url in seen))
+        self.assertTrue(any("/user/repos" in url for url in seen))
+        self.assertTrue(any("/orgs/the-hcma/repos" in url for url in seen))
+
     def test_desc_truncation_respects_width(self) -> None:
         from app.usage import format_key_usage_lines
 


### PR DESCRIPTION
## Summary
- Resolve GitHub tokens from `GITHUB_TOKEN` / `GH_TOKEN`, then fall back to `gh auth token` (covers already-logged-in `gh` users with no env vars).
- On interactive REPL start, run `gh auth login --web` when no token is available.
- Warm org/repo completion caches (`/user/orgs`, `/user/repos`, fixed bookmark orgs) so keys like `prh` have Tab candidates ready.

## Test plan
- [x] Unit tests for token precedence, login ensure, and cache warming
- [x] Live smoke: `gh auth` logged in, no env token → resolves token and lists `the-hcma` repos (`bunnify`)
- [ ] REPL: start interactive session, confirm “GitHub completion · N orgs · M repos cached”, then `prh` + Tab shows repos