### PR TITLE
feat: show shortcut help alongside args in Tab completion

### DIFF
--- a/app/interactive.py
+++ b/app/interactive.py
@@ -24,7 +24,7 @@ from prompt_toolkit.history import FileHistory, InMemoryHistory
 from app.client import ClientError, KeyEntry
 from app.github_complete import suggest_param_values
 from app.theme import Theme
-from app.usage import format_params
+from app.usage import format_completion_meta
 
 try:
     import readline as readline_module
@@ -201,14 +201,14 @@ class ShortcutCompleter(Completer):
         for key in self._keys:
             if key.lower().startswith(needle):
                 entry = self._entries_by_key.get(key)
-                meta = "shortcut"
                 if entry is not None:
-                    if entry.params:
-                        meta = format_params(
-                            entry.params, optional_params=entry.optional_params
-                        )
-                    elif entry.description:
-                        meta = entry.description[:40]
+                    meta = format_completion_meta(
+                        params=entry.params,
+                        optional_params=entry.optional_params,
+                        description=entry.description,
+                    )
+                else:
+                    meta = "shortcut"
                 yield Completion(
                     key,
                     start_position=-len(partial),
@@ -223,13 +223,14 @@ class ShortcutCompleter(Completer):
         for key in self._keys:
             if key.lower().startswith(needle) and key.lower() != needle:
                 entry = self._entries_by_key.get(key)
-                meta = "shortcut"
-                if entry is not None and entry.params:
-                    meta = format_params(
-                        entry.params, optional_params=entry.optional_params
+                if entry is not None:
+                    meta = format_completion_meta(
+                        params=entry.params,
+                        optional_params=entry.optional_params,
+                        description=entry.description,
                     )
-                elif entry is not None and entry.description:
-                    meta = entry.description[:40]
+                else:
+                    meta = "shortcut"
                 yield Completion(
                     key,
                     start_position=-len(text),
@@ -289,6 +290,11 @@ class ShortcutCompleter(Completer):
             )
             values = []
         seen: set[str] = set()
+        # Value rows keep the command blurb so Tab still shows what the shortcut does.
+        value_meta = format_completion_meta(
+            description=entry.description,
+            fallback=param_name,
+        )
         for value in values:
             if value in seen:
                 continue
@@ -299,14 +305,14 @@ class ShortcutCompleter(Completer):
                     start_position=-len(text),
                     display=value,
                     style=style,
-                    display_meta=param_name,
+                    display_meta=value_meta,
                 )
             else:
                 yield Completion(
                     value,
                     start_position=-len(prefix),
                     style=style,
-                    display_meta=param_name,
+                    display_meta=value_meta,
                 )
 
     def _suggestion_completions(self, text: str):

--- a/app/usage.py
+++ b/app/usage.py
@@ -26,6 +26,35 @@ def format_params(
     )
 
 
+_COMPLETION_META_DESC_MAX = 40
+
+
+def format_completion_meta(
+    *,
+    params: tuple[str, ...] | list[str] = (),
+    optional_params: Iterable[str] | None = None,
+    description: str = "",
+    fallback: str = "shortcut",
+    desc_max: int = _COMPLETION_META_DESC_MAX,
+) -> str:
+    """
+    Tab-completion sidebar text: args and/or help blurb.
+
+    Examples: ``<repo> — Open org PRs``, ``[query]``, or a truncated description.
+    """
+    args = format_params(params, optional_params=optional_params)
+    blurb = description.strip()
+    if len(blurb) > desc_max > 0:
+        blurb = (blurb[: desc_max - 1] + "…")[:desc_max]
+    if args and blurb:
+        return f"{args} — {blurb}"
+    if args:
+        return args
+    if blurb:
+        return blurb
+    return fallback
+
+
 def format_key_usage_lines(
     entries: list[KeyEntry],
     *,

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -714,6 +714,42 @@ class ConfigUnitTests(TestCase):
         self.assertIn("yellow", help_c.style)
         self.assertIn("cyan", gh_c.style)
 
+    def test_completer_meta_includes_args_and_description(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+        from app.usage import format_completion_meta
+
+        self.assertEqual(
+            format_completion_meta(
+                params=("repo",),
+                description="Open org pull requests",
+            ),
+            "<repo> — Open org pull requests",
+        )
+        self.assertEqual(
+            format_completion_meta(description="Just help"),
+            "Just help",
+        )
+
+        entry = KeyEntry(
+            key="prh",
+            description="Open org pull requests",
+            url="https://github.com/the-hcma/#{repo}/pulls",
+            params=("repo",),
+        )
+        completer = ShortcutCompleter(
+            ["prh"],
+            theme=Theme(enabled=False),
+            entries=[entry],
+        )
+        metas = [
+            c.display_meta_text
+            for c in completer.get_completions(Document("pr"), complete_event=None)  # type: ignore[arg-type]
+        ]
+        self.assertEqual(metas, ["<repo> — Open org pull requests"])
+
     @patch("app.cli.fetch_key_entries")
     def test_interactive_refresh_updates_keys(self, mock_fetch_entries) -> None:
         mock_fetch_entries.side_effect = [


### PR DESCRIPTION
## Summary
- Tab completion meta for shortcuts now shows both arg markup and the bookmark description (e.g. \`<repo> — Open org pull requests\`).
- While completing param values, the sidebar keeps the command help blurb.

## Test plan
- [x] Unit tests for \`format_completion_meta\` and completer display meta
- [x] Full \`./test_bunnify\`
- [ ] REPL: type \`pr\` / \`prh\` and confirm Tab shows args + description