### PR TITLE
feat: add i/ih/ihh GitHub issue shortcuts

### DIFF
--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -23,11 +23,11 @@ _DEFAULT_TIMEOUT_SECONDS = 8.0
 _GH_TOKEN_TIMEOUT_SECONDS = 8.0
 _GH_LOGIN_TIMEOUT_SECONDS = 600.0
 _PERSIST_VERSION = 1
-_REPO_PARAM_NAMES = frozenset({"repo", "repository", "org_repo"})
+_REPO_PARAM_NAMES = frozenset({"org_repo", "repo", "repository"})
 _PR_PARAM_NAMES = frozenset(
-    {"pr_number", "pr_id", "pr", "pull", "pull_number", "number"}
+    {"number", "pr", "pr_id", "pr_number", "pull", "pull_number"}
 )
-_ISSUE_PARAM_NAMES = frozenset({"issue_number", "issue_id", "issue", "issue_num"})
+_ISSUE_PARAM_NAMES = frozenset({"issue", "issue_id", "issue_num", "issue_number"})
 _API_ROOT = "https://api.github.com"
 _UNSET = object()
 

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -27,6 +27,7 @@ _REPO_PARAM_NAMES = frozenset({"repo", "repository", "org_repo"})
 _PR_PARAM_NAMES = frozenset(
     {"pr_number", "pr_id", "pr", "pull", "pull_number", "number"}
 )
+_ISSUE_PARAM_NAMES = frozenset({"issue_number", "issue_id", "issue", "issue_num"})
 _API_ROOT = "https://api.github.com"
 _UNSET = object()
 
@@ -168,8 +169,8 @@ def load_github_completion_cache(
         for key, values in entries.items():
             if not isinstance(key, str) or not isinstance(values, list):
                 continue
-            # PR lists are session-volatile; never restore them from disk.
-            if key.startswith("prs:"):
+            # PR/issue lists are session-volatile; never restore them from disk.
+            if key.startswith(("prs:", "issues:")):
                 continue
             names = [item for item in values if isinstance(item, str)]
             _cache[key] = (time.monotonic() + _CACHE_TTL_SECONDS, names)
@@ -183,7 +184,7 @@ def save_github_completion_cache(
 ) -> Path | None:
     """Persist org/repo completion snapshot under ``~/scratch/bunnify/``."""
     cache_path = path if path is not None else default_github_completion_cache_path()
-    # Only orgs/repos belong on disk; PR numbers go stale across sessions.
+    # Only orgs/repos belong on disk; PR/issue numbers go stale across sessions.
     snapshot = {
         key: values
         for key, values in _cache_snapshot().items()
@@ -515,6 +516,56 @@ def list_open_pull_requests(
     return [num for num in cached if num.startswith(needle)]
 
 
+def list_open_issues(
+    repo: str,
+    *,
+    prefix: str = "",
+    limit: int = 50,
+    token: str | None = None,
+    opener: Any | None = None,
+    runner: GhRunner | None = None,
+) -> list[str]:
+    """List open issue numbers (as strings) for ``owner/name`` (excludes PRs)."""
+    if not repo or "/" not in repo:
+        return []
+    owner, name = repo.split("/", 1)
+    if not owner or not name:
+        return []
+    cache_key = f"issues:{repo}:{limit}"
+    cached = _cache_get(cache_key)
+    if cached is None:
+        per_page = min(max(limit, 1), 100)
+        payload = _github_get_json(
+            f"/repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(name)}/issues",
+            query={
+                "state": "open",
+                "per_page": str(per_page),
+                "sort": "updated",
+                "direction": "desc",
+            },
+            token=token,
+            opener=opener,
+            runner=runner,
+        )
+        if payload is None:
+            return []
+        numbers: list[str] = []
+        if isinstance(payload, list):
+            for item in payload:
+                if not isinstance(item, dict):
+                    continue
+                # The issues endpoint also returns PRs; skip those.
+                if "pull_request" in item:
+                    continue
+                if isinstance(item.get("number"), int):
+                    numbers.append(str(item["number"]))
+        cached = numbers[:limit]
+        _cache_set(cache_key, cached)
+
+    needle = prefix.lower()
+    return [num for num in cached if num.startswith(needle)]
+
+
 def resolve_repo_for_pr(
     *,
     url_template: str,
@@ -732,6 +783,14 @@ def suggest_param_values(
         if full_repo is None:
             return []
         return list_open_pull_requests(
+            full_repo, prefix=prefix, token=token, opener=opener, runner=runner
+        )
+    if name in _ISSUE_PARAM_NAMES:
+        repo_token = filled_args[-1] if filled_args else ""
+        full_repo = resolve_repo_for_pr(url_template=url_template, repo_arg=repo_token)
+        if full_repo is None:
+            return []
+        return list_open_issues(
             full_repo, prefix=prefix, token=token, opener=opener, runner=runner
         )
     return []

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -949,6 +949,95 @@ class KeyUsageAndCompletionTests(TestCase):
         ]
         self.assertEqual(prs, ["242", "245"])
 
+    def test_param_completer_repos_and_issues(self) -> None:
+        """Issue shortcuts complete repo + issue_number the same way as PRs."""
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+
+        entry = KeyEntry(
+            key="i",
+            description="GitHub Issue",
+            url="https://github.com/#{repo}/issues/#{issue_number}",
+            params=("repo", "issue_number"),
+        )
+
+        def fake_suggest(*, param_name, url_template, filled_args, prefix):
+            del url_template
+            if param_name == "repo":
+                return [
+                    name
+                    for name in ("the-hcma/bunnify", "the-hcma/other")
+                    if name.startswith(prefix)
+                ]
+            if param_name == "issue_number":
+                self.assertEqual(filled_args, ["the-hcma/bunnify"])
+                return [num for num in ("42", "45") if num.startswith(prefix)]
+            return []
+
+        completer = ShortcutCompleter(
+            ["i"],
+            theme=Theme(enabled=False),
+            entries=[entry],
+            param_suggest_fn=fake_suggest,
+        )
+        repos = [
+            c.text
+            for c in completer.get_completions(
+                Document("i the-hcma/bun"), complete_event=None
+            )  # type: ignore[arg-type]
+        ]
+        self.assertEqual(repos, ["the-hcma/bunnify"])
+        issues = [
+            c.text
+            for c in completer.get_completions(
+                Document("i the-hcma/bunnify 4"), complete_event=None
+            )  # type: ignore[arg-type]
+        ]
+        self.assertEqual(issues, ["42", "45"])
+
+    def test_exact_key_tab_completes_first_param_for_issues_list(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import ShortcutCompleter
+        from app.theme import Theme
+
+        entry = KeyEntry(
+            key="ih",
+            description="Issues",
+            url="https://github.com/the-hcma/#{repo}/issues",
+            params=("repo",),
+        )
+
+        def fake_suggest(*, param_name, url_template, filled_args, prefix):
+            del url_template, filled_args
+            self.assertEqual(param_name, "repo")
+            self.assertEqual(prefix, "")
+            return ["bunnify", "fpdf"]
+
+        completer = ShortcutCompleter(
+            ["ih", "ihh"],
+            theme=Theme(enabled=False),
+            entries=[
+                entry,
+                KeyEntry(
+                    key="ihh",
+                    description="other",
+                    url="https://github.com/x/#{repo}/issues",
+                    params=("repo",),
+                ),
+            ],
+            param_suggest_fn=fake_suggest,
+        )
+        texts = [
+            c.text
+            for c in completer.get_completions(Document("ih"), complete_event=None)  # type: ignore[arg-type]
+        ]
+        self.assertIn("ih bunnify", texts)
+        self.assertIn("ih fpdf", texts)
+        self.assertIn("ihh", texts)
+
     def test_exact_key_tab_completes_first_param(self) -> None:
         from prompt_toolkit.document import Document
 
@@ -1174,6 +1263,44 @@ class KeyUsageAndCompletionTests(TestCase):
         )
         self.assertEqual(values, ["242"])
         self.assertTrue(any("/repos/the-hcma/bunnify/pulls" in url for url in seen))
+
+    def test_suggest_issue_numbers_for_fixed_org(self) -> None:
+        from app.github_complete import (
+            clear_github_completion_cache,
+            suggest_param_values,
+        )
+
+        clear_github_completion_cache()
+        seen: list[str] = []
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return (
+                    b'[{"number":242,"title":"bug"},'
+                    b'{"number":100,"title":"pr","pull_request":{}},'
+                    b'{"number":99,"title":"docs"}]'
+                )
+
+        def opener(request, timeout=0):  # noqa: ARG001
+            seen.append(request.full_url)
+            return FakeResponse()
+
+        values = suggest_param_values(
+            param_name="issue_number",
+            url_template="https://github.com/the-hcma/#{repo}/issues/#{issue_number}",
+            filled_args=["bunnify"],
+            prefix="2",
+            token="test-token",
+            opener=opener,
+        )
+        self.assertEqual(values, ["242"])
+        self.assertTrue(any("/repos/the-hcma/bunnify/issues" in url for url in seen))
 
     def test_failed_api_fetch_does_not_poison_cache(self) -> None:
         import urllib.error
@@ -1440,6 +1567,60 @@ class KeyUsageAndCompletionTests(TestCase):
                     opener=lambda *_a, **_k: FakeResponse(),
                 ),
                 ["42"],
+            )
+
+    def test_completion_cache_does_not_persist_issue_keys(self) -> None:
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from app.github_complete import (
+            clear_github_completion_cache,
+            list_open_issues,
+            load_github_completion_cache,
+            save_github_completion_cache,
+        )
+
+        clear_github_completion_cache()
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return b'[{"number":7}]'
+
+        list_open_issues(
+            "the-hcma/bunnify", token="t", opener=lambda *_a, **_k: FakeResponse()
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scratch" / "bunnify" / "github-completions.json"
+            save_github_completion_cache(path=path)
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            self.assertTrue(
+                all(not key.startswith("issues:") for key in payload["entries"])
+            )
+            clear_github_completion_cache()
+            path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "entries": {"issues:the-hcma/bunnify:50": ["99"]},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            load_github_completion_cache(path=path)
+            self.assertEqual(
+                list_open_issues(
+                    "the-hcma/bunnify",
+                    token="t",
+                    opener=lambda *_a, **_k: FakeResponse(),
+                ),
+                ["7"],
             )
 
     def test_bootstrap_loads_disk_across_invocations_without_blocking(self) -> None:

--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -188,6 +188,32 @@ class SmokeTests(TestCase):
             response["Location"], "https://github.com/Shopify/shopify-build/pull/12345"
         )
 
+    def test_issue_shortcut_redirect(self):
+        """Test GitHub issue bookmark parameter substitution"""
+        Bookmark.objects.create(
+            key="i",
+            description="GitHub Issue",
+            url="https://github.com/#{repo}/issues/#{issue_number}",
+        )
+        response = self.client.get("/search/", {"q": "i the-hcma/bunnify 42"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"], "https://github.com/the-hcma/bunnify/issues/42"
+        )
+
+    def test_org_issues_list_shortcut(self):
+        """Test org-scoped issues list bookmark (ih)"""
+        Bookmark.objects.create(
+            key="ih",
+            description="the-hcma GitHub Issues",
+            url="https://github.com/the-hcma/#{repo}/issues",
+        )
+        response = self.client.get("/search/", {"q": "ih bunnify"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"], "https://github.com/the-hcma/bunnify/issues"
+        )
+
     def test_health_check_loads(self):
         """Test that the health check endpoint loads successfully"""
         response = self.client.get("/health")

--- a/bunnify.json
+++ b/bunnify.json
@@ -147,6 +147,18 @@
     "description": "the-hcma GitHub Pull Request (Usage: hpr <repo> <pr_number>)",
     "url": "https://github.com/the-hcma/#{repo}/pull/#{pr_number}"
   },
+  "i": {
+    "description": "GitHub Issue (Usage: i <org/repo> <issue_number>)",
+    "url": "https://github.com/#{repo}/issues/#{issue_number}"
+  },
+  "ih": {
+    "description": "the-hcma GitHub Issues (Usage: ih <repo>)",
+    "url": "https://github.com/the-hcma/#{repo}/issues"
+  },
+  "ihh": {
+    "description": "thehcma GitHub Issues (Usage: ihh <repo>)",
+    "url": "https://github.com/thehcma/#{repo}/issues"
+  },
   "dl": {
     "description": "Downloads",
     "url": "https://downloads.hcma.info"

--- a/bunnify.json.example
+++ b/bunnify.json.example
@@ -23,6 +23,18 @@
     "description": "GitHub Pull Request (Usage: pr <org/repo> <pr_number>)",
     "url": "https://github.com/#{repo}/pull/#{pr_number}"
   },
+  "i": {
+    "description": "GitHub Issue (Usage: i <org/repo> <issue_number>)",
+    "url": "https://github.com/#{repo}/issues/#{issue_number}"
+  },
+  "ih": {
+    "description": "the-hcma GitHub Issues (Usage: ih <repo>)",
+    "url": "https://github.com/the-hcma/#{repo}/issues"
+  },
+  "ihh": {
+    "description": "thehcma GitHub Issues (Usage: ihh <repo>)",
+    "url": "https://github.com/thehcma/#{repo}/issues"
+  },
   "rpr": {
     "description": "Request Copilot review for PR",
     "url": "http://127.0.0.1:8000/review-pr/?pr=#{pr_id}"

--- a/test_integration
+++ b/test_integration
@@ -119,6 +119,9 @@ assert_redirect "/search/?q=http%3A%2F%2Fexample.com" "http://example.com"
 # Test multi parameter substitution PR bookmark
 assert_redirect "/search/?q=pr%20the-hcma%2Fbunnify%20123" "https://github.com/the-hcma/bunnify/pull/123"
 
+# Test multi parameter substitution issue bookmark
+assert_redirect "/search/?q=i%20the-hcma%2Fbunnify%2042" "https://github.com/the-hcma/bunnify/issues/42"
+
 # EXIT trap handles shutdown and cleanup
 if [ "$failed" -eq 0 ]; then
     echo "🎉 All integration tests passed!"


### PR DESCRIPTION
## Summary
- Add `i`, `ih`, and `ihh` bookmarks mirroring `pr` / `prh` / `prhh` for GitHub issues
- Wire Tab completion for `issue_number` (open issues, PRs filtered out) the same way PR numbers work
- Cover redirects, completer parity, and issue suggestion caching in tests

## Test plan
- [x] `./test_bunnify` (includes issue completer + redirect smoke tests)
- [x] `./test_integration` (issue redirect assertion)
- [ ] CLI: `i the-hcma/bunnify <Tab>` suggests open issue numbers
- [ ] CLI: `ih <Tab>` / `ihh <Tab>` suggest repos in the fixed org
- [ ] Reload bookmarks and open `i the-hcma/bunnify 1` from search/CLI


Made with [Cursor](https://cursor.com)