### PR TITLE
feat: add ghh/ghhi GitHub status shortcuts, rename repo to ghrh

### DIFF
--- a/bunnify.json
+++ b/bunnify.json
@@ -79,17 +79,21 @@
     "description": "GitHub",
     "url": "https://github.com"
   },
-  "ghealth": {
-    "description": "GitHub Status",
+  "ghh": {
+    "description": "GitHub Health",
     "url": "https://www.githubstatus.com"
   },
-  "ghh": {
-    "description": "the-hcma's GitHub repo",
-    "url": "https://github.com/the-hcma/#{repo}/"
+  "ghhi": {
+    "description": "GitHub Incidents",
+    "url": "https://www.githubstatus.com/history"
   },
   "ghp": {
     "description": "GitHub Profile",
     "url": "https://github.com/settings/profile"
+  },
+  "ghrh": {
+    "description": "the-hcma's GitHub repo",
+    "url": "https://github.com/the-hcma/#{repo}/"
   },
   "gk": {
     "description": "Google Keep",


### PR DESCRIPTION
## Summary
- Replace `ghealth` with shorter `ghh` for GitHub Health (githubstatus.com)
- Add `ghhi` for GitHub incident history (githubstatus.com/history)
- Rename the-hcma repo shortcut from `ghh` to `ghrh` to free the shorter key

## Test plan
- [x] `uv run ruff` / `pyright` / `./test_bunnify`
- [x] `./test_integration`
- [ ] Confirm `ghh` → status, `ghhi` → history, `ghrh <repo>` → org repo


Made with [Cursor](https://cursor.com)