### PR TITLE
ci: add job timeouts to fail zombie Actions checks faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       pull-requests: read
     name: Guard
     runs-on: ubuntu-latest
+    # Fail fast if the runner never finalizes the job (zombie in_progress checks
+    # leave the merge queue in AWAITING_CHECKS until check_response_timeout).
+    timeout-minutes: 5
     outputs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
@@ -92,6 +95,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v7.0.1
 
@@ -108,6 +112,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v7.0.1
 
@@ -125,6 +130,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v7.0.1
 


### PR DESCRIPTION
## Summary
- Add `timeout-minutes` to all Bunnify CI jobs (Guard 5, lint/shell/secret-scan 10, tests 15) so zombie hosted-runner jobs fail closed instead of hanging forever.
- Separately applied on `protect-main` ruleset (not in this diff): lowered merge-queue `check_response_timeout_minutes` from **60 → 15**, so `AWAITING_CHECKS` recovers faster when GitHub never finalizes a required check.

## Context
PR #255 (and the prior MQ attempt) got stuck because required checks finished every step including "Complete job" but stayed `in_progress` with null conclusion. MQ waited up to the check-response timeout.

## Test plan
- [x] Local ruff / pyright / unit tests
- [x] Local `./test_integration` (after migrate on fresh worktree)
- [ ] CI green on this PR
- [ ] Confirm MQ ruleset shows `check_response_timeout_minutes: 15`