### PR TITLE
feat: fuzzy Tab on descriptions; reject excess shortcut args

### DIFF
--- a/app/interactive.py
+++ b/app/interactive.py
@@ -420,16 +420,10 @@ class FirstTokenFuzzyCompleter(Completer):
         self._inner = inner
 
     def _match_haystacks(self, completion: Completion) -> tuple[str, str]:
-        """Return ``(key_text, description_or_blurb)`` for fuzzy matching."""
+        """Return ``(key_text, shortcut_description)`` for fuzzy matching."""
         key_text = completion.text
         entry = self._inner._lookup_entry(key_text)
-        if entry is not None and entry.description.strip():
-            return key_text, entry.description
-        meta = completion.display_meta_text or ""
-        # Meta rows store the blurb in display_meta; drop param prefixes if present.
-        if " — " in meta:
-            meta = meta.split(" — ", 1)[1]
-        return key_text, meta
+        return key_text, entry.description if entry is not None else ""
 
     def get_completions(
         self,

--- a/app/interactive.py
+++ b/app/interactive.py
@@ -489,7 +489,7 @@ class FirstTokenFuzzyCompleter(Completer):
             yield Completion(
                 text=match.completion.text,
                 start_position=-len(needle),
-                display_meta=match.completion._display_meta,
+                display_meta=match.completion.display_meta,
                 display=display,
                 style=match.completion.style,
             )

--- a/app/interactive.py
+++ b/app/interactive.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import NamedTuple
 
 from platformdirs import user_cache_dir
 from prompt_toolkit import HTML, PromptSession
@@ -14,11 +16,10 @@ from prompt_toolkit.completion import (
     CompleteEvent,
     Completer,
     Completion,
-    FuzzyCompleter,
 )
 from prompt_toolkit.document import Document
 from prompt_toolkit.enums import EditingMode
-from prompt_toolkit.formatted_text import AnyFormattedText
+from prompt_toolkit.formatted_text import AnyFormattedText, StyleAndTextTuples
 from prompt_toolkit.history import FileHistory, InMemoryHistory
 
 from app.client import ClientError, KeyEntry
@@ -352,12 +353,83 @@ class ShortcutCompleter(Completer):
                     )
 
 
+class _FuzzyMatch(NamedTuple):
+    match_length: int
+    start_pos: int
+    completion: Completion
+    from_key: bool
+
+
+def _best_fuzzy_match(needle: str, haystack: str) -> tuple[int, int] | None:
+    """Best prompt_toolkit-style subsequence match: ``(match_length, start_pos)``.
+
+    Matching is case-insensitive (``str.casefold``); positions refer to the
+    original ``haystack`` (ASCII-safe; same approach as prompt_toolkit's
+    ``re.IGNORECASE`` fuzzy completer).
+    """
+    if not needle:
+        return 0, 0
+    if not haystack:
+        return None
+    # Casefold both sides so "Translate" matches "Google Translate …".
+    folded_needle = needle.casefold()
+    folded_haystack = haystack.casefold()
+    pat = ".*?".join(map(re.escape, folded_needle))
+    pat = f"(?=({pat}))"
+    regex = re.compile(pat)
+    matches = list(regex.finditer(folded_haystack))
+    if not matches:
+        return None
+    best = min(matches, key=lambda match: (match.start(), len(match.group(1))))
+    return len(best.group(1)), best.start()
+
+
+def _fuzzy_highlight_display(
+    word: str,
+    *,
+    match_length: int,
+    start_pos: int,
+    needle: str,
+) -> AnyFormattedText:
+    """Highlight subsequence matches on a completion label (prompt_toolkit parity)."""
+    if match_length == 0:
+        return word
+
+    result: StyleAndTextTuples = []
+    result.append(("class:fuzzymatch.outside", word[:start_pos]))
+    characters = list(needle.casefold())
+    for char in word[start_pos : start_pos + match_length]:
+        classname = "class:fuzzymatch.inside"
+        if characters and char.casefold() == characters[0]:
+            classname += ".character"
+            del characters[0]
+        result.append((classname, char))
+    result.append(("class:fuzzymatch.outside", word[start_pos + match_length :]))
+    return result
+
+
 class FirstTokenFuzzyCompleter(Completer):
-    """Apply fuzzy matching only while completing the first token (key/meta)."""
+    """Fuzzy-match the first token against shortcut keys *and* descriptions.
+
+    Matching is case-insensitive. Offered completions always insert/display the
+    command key (or meta name); descriptions are used only for matching and
+    ranking.
+    """
 
     def __init__(self, inner: ShortcutCompleter) -> None:
         self._inner = inner
-        self._fuzzy = FuzzyCompleter(inner, enable_fuzzy=True)
+
+    def _match_haystacks(self, completion: Completion) -> tuple[str, str]:
+        """Return ``(key_text, description_or_blurb)`` for fuzzy matching."""
+        key_text = completion.text
+        entry = self._inner._lookup_entry(key_text)
+        if entry is not None and entry.description.strip():
+            return key_text, entry.description
+        meta = completion.display_meta_text or ""
+        # Meta rows store the blurb in display_meta; drop param prefixes if present.
+        if " — " in meta:
+            meta = meta.split(" — ", 1)[1]
+        return key_text, meta
 
     def get_completions(
         self,
@@ -368,7 +440,59 @@ class FirstTokenFuzzyCompleter(Completer):
         if self._inner.wants_param_completion(text) or any(ch.isspace() for ch in text):
             yield from self._inner.get_completions(document, complete_event)
             return
-        yield from self._fuzzy.get_completions(document, complete_event)
+
+        needle = text
+        # Ask the inner completer for the full candidate set (empty first token).
+        empty = Document(text="", cursor_position=0)
+        candidates = list(self._inner.get_completions(empty, complete_event))
+
+        if needle == "":
+            yield from candidates
+            return
+
+        fuzzy_matches: list[_FuzzyMatch] = []
+        for completion in candidates:
+            key_text, description = self._match_haystacks(completion)
+            key_hit = _best_fuzzy_match(needle, key_text)
+            if key_hit is not None:
+                match_length, start_pos = key_hit
+                fuzzy_matches.append(
+                    _FuzzyMatch(match_length, start_pos, completion, True)
+                )
+                continue
+            desc_hit = _best_fuzzy_match(needle, description)
+            if desc_hit is not None:
+                match_length, start_pos = desc_hit
+                fuzzy_matches.append(
+                    _FuzzyMatch(match_length, start_pos, completion, False)
+                )
+
+        fuzzy_matches.sort(
+            key=lambda match: (
+                0 if match.from_key else 1,
+                match.start_pos,
+                match.match_length,
+            )
+        )
+
+        for match in fuzzy_matches:
+            if match.from_key:
+                display: AnyFormattedText = _fuzzy_highlight_display(
+                    match.completion.text,
+                    match_length=match.match_length,
+                    start_pos=match.start_pos,
+                    needle=needle,
+                )
+            else:
+                # Description-only hit: keep the plain command key as the label.
+                display = match.completion.display
+            yield Completion(
+                text=match.completion.text,
+                start_position=-len(needle),
+                display_meta=match.completion._display_meta,
+                display=display,
+                style=match.completion.style,
+            )
 
 
 class ReadlineShortcutCompleter:

--- a/bookmarks/resolve.py
+++ b/bookmarks/resolve.py
@@ -12,6 +12,17 @@ from .models import Bookmark
 PLACEHOLDER_PATTERN = re.compile(r"#\{(\w+)\}")
 GOOGLE_SEARCH_URL = "https://www.google.com/search?q=#{search_terms}"
 _DIRECT_URL_PREFIXES = ("http://", "https://", "chrome://", "about://", "file://")
+# Single placeholders that intentionally consume the rest of the query
+# (spaces included). Token-shaped placeholders like ``repo`` take one
+# whitespace-separated argument and reject extras.
+_REST_OF_LINE_PLACEHOLDERS = frozenset(
+    {
+        "search_terms",
+        "query",
+        "phrase",
+        "keywords",
+    }
+)
 
 ResolveKind = Literal["bookmark", "special", "direct_url", "google_fallback"]
 
@@ -85,6 +96,41 @@ def google_search_url(query: str) -> str:
     return substitute_placeholder_values(GOOGLE_SEARCH_URL, {"search_terms": query})
 
 
+def format_shortcut_usage(
+    key: str,
+    placeholders: list[str],
+    defaults: dict[str, str] | None = None,
+) -> str:
+    """Build a ``Usage: key <required> [optional]`` line for error messages."""
+    defaults = defaults or {}
+    if not placeholders:
+        return f"Usage: {key}"
+    if len(placeholders) == 1 and placeholders[0] in _REST_OF_LINE_PLACEHOLDERS:
+        name = placeholders[0]
+        token = f"[{name}]" if name in defaults else f"<{name}>"
+        return f"Usage: {key} {token}"
+    parts: list[str] = []
+    for name in placeholders:
+        if name in defaults:
+            parts.append(f"[{name}]")
+        else:
+            parts.append(f"<{name}>")
+    return f"Usage: {key} {' '.join(parts)}"
+
+
+def _too_many_parameters_error(
+    key: str,
+    placeholders: list[str],
+    defaults: dict[str, str] | None = None,
+) -> ResolveResult:
+    usage = format_shortcut_usage(key, placeholders, defaults)
+    return ResolveResult(
+        ok=False,
+        error=f"Too many parameters for bookmark '{key}'.\n{usage}",
+        key=key,
+    )
+
+
 def resolve_query(query: str, *, strict: bool = False) -> ResolveResult:
     """
     Resolve a shortcut query (``key [params...]``) to a URL.
@@ -92,6 +138,10 @@ def resolve_query(query: str, *, strict: bool = False) -> ResolveResult:
     Special keys ``h`` / ``help`` / ``cmd`` return site-relative paths (``/list/``,
     ``/cmd/``). When ``strict`` is true, unknown keys are errors instead of a
     Google search fallback.
+
+    Extra whitespace-separated arguments beyond what the shortcut accepts are
+    rejected with a usage line (free-text placeholders like ``search_terms``
+    still consume the remainder of the query as a single value).
     """
     query = query.strip()
     if not query:
@@ -130,57 +180,72 @@ def resolve_query(query: str, *, strict: bool = False) -> ResolveResult:
 
     url = bookmark.url
     placeholders = list(dict.fromkeys(PLACEHOLDER_PATTERN.findall(url)))
+    defaults = bookmark.defaults or {}
 
     if not placeholders:
+        if param_string:
+            return _too_many_parameters_error(key, placeholders, defaults)
         return ResolveResult(ok=True, url=url, kind="bookmark", key=key)
 
     param_mapping: dict[str, str] = {}
 
     if len(placeholders) == 1:
-        if param_string or (bookmark.defaults and placeholders[0] in bookmark.defaults):
-            param_mapping[placeholders[0]] = (
-                param_string if param_string else bookmark.defaults[placeholders[0]]
-            )
+        placeholder = placeholders[0]
+        if placeholder in _REST_OF_LINE_PLACEHOLDERS:
+            if param_string or placeholder in defaults:
+                param_mapping[placeholder] = (
+                    param_string if param_string else defaults[placeholder]
+                )
+            else:
+                return ResolveResult(
+                    ok=False,
+                    error=(
+                        f"Bookmark '{key}' requires a parameter.\n"
+                        f"{format_shortcut_usage(key, placeholders, defaults)}"
+                    ),
+                    key=key,
+                )
         else:
-            return ResolveResult(
-                ok=False,
-                error=(f"Bookmark '{key}' requires a parameter.\nUsage: {key} <value>"),
-                key=key,
-            )
+            # Token placeholder (e.g. ``repo``): one arg only — do not join
+            # trailing tokens into the value (avoids ``prh repo 476`` →
+            # ``…/repo%20476/pulls``).
+            param_values = param_string.split() if param_string else []
+            if len(param_values) > 1:
+                return _too_many_parameters_error(key, placeholders, defaults)
+            if len(param_values) == 1:
+                param_mapping[placeholder] = param_values[0]
+            elif placeholder in defaults:
+                param_mapping[placeholder] = defaults[placeholder]
+            else:
+                return ResolveResult(
+                    ok=False,
+                    error=(
+                        f"Bookmark '{key}' requires a parameter.\n"
+                        f"{format_shortcut_usage(key, placeholders, defaults)}"
+                    ),
+                    key=key,
+                )
     else:
         param_values = param_string.split() if param_string else []
 
         if len(param_values) > len(placeholders):
-            return ResolveResult(
-                ok=False,
-                error=f"Too many parameters for bookmark '{key}'.",
-                key=key,
-            )
+            return _too_many_parameters_error(key, placeholders, defaults)
 
         arg_offset = len(placeholders) - len(param_values)
         for i, placeholder in enumerate(placeholders):
             arg_idx = i - arg_offset
             if arg_idx >= 0:
                 param_mapping[placeholder] = param_values[arg_idx]
-            elif placeholder in (bookmark.defaults or {}):
-                param_mapping[placeholder] = bookmark.defaults[placeholder]
+            elif placeholder in defaults:
+                param_mapping[placeholder] = defaults[placeholder]
             else:
-                required_params = [
-                    p for p in placeholders if p not in (bookmark.defaults or {})
-                ]
-                optional_params = [
-                    p for p in placeholders if p in (bookmark.defaults or {})
-                ]
+                required_params = [p for p in placeholders if p not in defaults]
                 required = ", ".join(required_params)
-                usage_args = " ".join(f"<{p}>" for p in required_params)
-                optional_suffix = (
-                    f" [{' '.join(optional_params)}]" if optional_params else ""
-                )
                 return ResolveResult(
                     ok=False,
                     error=(
                         f"Bookmark '{key}' requires parameter(s): {required}\n"
-                        f"Usage: {key} {usage_args}{optional_suffix}"
+                        f"{format_shortcut_usage(key, placeholders, defaults)}"
                     ),
                     key=key,
                 )

--- a/bookmarks/resolve.py
+++ b/bookmarks/resolve.py
@@ -140,8 +140,9 @@ def resolve_query(query: str, *, strict: bool = False) -> ResolveResult:
     Google search fallback.
 
     Extra whitespace-separated arguments beyond what the shortcut accepts are
-    rejected with a usage line (free-text placeholders like ``search_terms``
-    still consume the remainder of the query as a single value).
+    rejected with a usage line. When a shortcut has a single free-text
+    placeholder like ``search_terms``, it consumes the remainder of the query
+    as one value.
     """
     query = query.strip()
     if not query:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -750,6 +750,90 @@ class ConfigUnitTests(TestCase):
         ]
         self.assertEqual(metas, ["<repo> — Open org pull requests"])
 
+    def test_fuzzy_completer_matches_description_shows_keys(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import FirstTokenFuzzyCompleter, ShortcutCompleter
+        from app.theme import Theme
+
+        entries = [
+            KeyEntry(
+                key="gtre",
+                description="Google Translate - English to Portuguese",
+                url="https://translate.google.com/?sl=en&tl=pt&text=#{phrase}",
+                params=("phrase",),
+            ),
+            KeyEntry(
+                key="gtrp",
+                description="Google Translate - Portuguese to English",
+                url="https://translate.google.com/?sl=pt&tl=en&text=#{phrase}",
+                params=("phrase",),
+            ),
+            KeyEntry(
+                key="gh",
+                description="GitHub",
+                url="https://github.com",
+            ),
+        ]
+        completer = FirstTokenFuzzyCompleter(
+            ShortcutCompleter(
+                [entry.key for entry in entries],
+                theme=Theme(enabled=False),
+                include_meta=False,
+                entries=entries,
+            )
+        )
+        completions = list(
+            completer.get_completions(Document("translate"), complete_event=None)  # type: ignore[arg-type]
+        )
+        texts = sorted(c.text for c in completions)
+        self.assertEqual(texts, ["gtre", "gtrp"])
+        # Alternatives must be command keys only (never description text).
+        self.assertTrue(all(c.text in {"gtre", "gtrp"} for c in completions))
+
+        for needle in ("Translate", "TRANSLATE", "TrAnSlAtE"):
+            cased = list(
+                completer.get_completions(Document(needle), complete_event=None)  # type: ignore[arg-type]
+            )
+            self.assertEqual(
+                sorted(c.text for c in cased),
+                ["gtre", "gtrp"],
+                msg=f"expected case-insensitive match for {needle!r}",
+            )
+
+    def test_fuzzy_completer_prefers_key_matches(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import FirstTokenFuzzyCompleter, ShortcutCompleter
+        from app.theme import Theme
+
+        entries = [
+            KeyEntry(
+                key="tr",
+                description="Something else",
+                url="https://example.com/tr",
+            ),
+            KeyEntry(
+                key="gtre",
+                description="Google Translate",
+                url="https://translate.google.com/",
+            ),
+        ]
+        completer = FirstTokenFuzzyCompleter(
+            ShortcutCompleter(
+                [entry.key for entry in entries],
+                theme=Theme(enabled=False),
+                include_meta=False,
+                entries=entries,
+            )
+        )
+        completions = list(
+            completer.get_completions(Document("tr"), complete_event=None)  # type: ignore[arg-type]
+        )
+        texts = [c.text for c in completions]
+        self.assertEqual(texts[0], "tr")
+        self.assertIn("gtre", texts)
+
     @patch("app.cli.fetch_key_entries")
     def test_interactive_refresh_updates_keys(self, mock_fetch_entries) -> None:
         mock_fetch_entries.side_effect = [

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -750,6 +750,24 @@ class ConfigUnitTests(TestCase):
         ]
         self.assertEqual(metas, ["<repo> — Open org pull requests"])
 
+    def test_fuzzy_completer_excludes_meta_blurbs(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import FirstTokenFuzzyCompleter, ShortcutCompleter
+        from app.theme import Theme
+
+        completer = FirstTokenFuzzyCompleter(
+            ShortcutCompleter(
+                ["gh"],
+                theme=Theme(enabled=False),
+                entries=[KeyEntry(key="gh", description="GitHub")],
+            )
+        )
+        completions = list(
+            completer.get_completions(Document("vim"), complete_event=None)  # type: ignore[arg-type]
+        )
+        self.assertNotIn("edit-mode", [completion.text for completion in completions])
+
     def test_fuzzy_completer_matches_description_shows_keys(self) -> None:
         from prompt_toolkit.document import Document
 

--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -214,6 +214,49 @@ class SmokeTests(TestCase):
             response["Location"], "https://github.com/the-hcma/bunnify/issues"
         )
 
+    def test_single_token_placeholder_rejects_extra_args(self):
+        """``prh repo 476`` must not glue extras into ``#{repo}`` (broken %20 URL)."""
+        Bookmark.objects.create(
+            key="prh",
+            description="the-hcma GitHub Pull Requests",
+            url="https://github.com/the-hcma/#{repo}/pulls",
+        )
+        response = self.client.get("/search/", {"q": "prh repository-helpers 476"})
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response, "Too many parameters for bookmark 'prh'", status_code=400
+        )
+        self.assertContains(response, "Usage: prh <repo>", status_code=400)
+
+    def test_zero_arg_shortcut_rejects_extra_args(self):
+        response = self.client.get("/search/", {"q": "gh extra"})
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response, "Too many parameters for bookmark 'gh'", status_code=400
+        )
+        self.assertContains(response, "Usage: gh", status_code=400)
+
+    def test_multi_param_rejects_extra_args_with_usage(self):
+        response = self.client.get("/search/", {"q": "pr org/repo 1 leftover"})
+        self.assertEqual(response.status_code, 400)
+        self.assertContains(
+            response, "Too many parameters for bookmark 'pr'", status_code=400
+        )
+        self.assertContains(response, "Usage: pr [repo] <pr_number>", status_code=400)
+
+    def test_single_token_placeholder_accepts_one_arg(self):
+        Bookmark.objects.create(
+            key="prh",
+            description="the-hcma GitHub Pull Requests",
+            url="https://github.com/the-hcma/#{repo}/pulls",
+        )
+        response = self.client.get("/search/", {"q": "prh repository-helpers"})
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response["Location"],
+            "https://github.com/the-hcma/repository-helpers/pulls",
+        )
+
     def test_health_check_loads(self):
         """Test that the health check endpoint loads successfully"""
         response = self.client.get("/health")
@@ -226,7 +269,7 @@ class SmokeTests(TestCase):
         Bookmark.objects.create(
             key="dual",
             description="Path and query reuse",
-            url="https://example.com/#{id}?q=#{id}",
+            url="https://example.com/#{phrase}?q=#{phrase}",
         )
         response = self.client.get("/search/", {"q": "dual a/b c"})
         self.assertEqual(response.status_code, 302)

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -52,8 +52,9 @@ def search_redirect(request: HttpRequest) -> HttpResponse:
     Example: "pr 12345" or "pr 12345 Shopify/shopify-build" or "g django tutorial"
     Special: "h" shows all bookmarks
 
-    For bookmarks with multiple parameters, splits by space.
-    For bookmarks with single parameter, passes everything after key as the value.
+    Token placeholders are whitespace-separated; free-text placeholders
+    (``search_terms``, ``phrase``, …) take the remainder of the query.
+    Extra arguments beyond what the shortcut accepts return HTTP 400 with usage.
     """
     query_param = request.GET.get("q", "")
     query = str(query_param).strip() if query_param else ""

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -52,8 +52,9 @@ def search_redirect(request: HttpRequest) -> HttpResponse:
     Example: "pr 12345" or "pr 12345 Shopify/shopify-build" or "g django tutorial"
     Special: "h" shows all bookmarks
 
-    Token placeholders are whitespace-separated; free-text placeholders
-    (``search_terms``, ``phrase``, …) take the remainder of the query.
+    Token placeholders are whitespace-separated. When a shortcut has a single
+    free-text placeholder (``search_terms``, ``phrase``, …), it takes the
+    remainder of the query.
     Extra arguments beyond what the shortcut accepts return HTTP 400 with usage.
     """
     query_param = request.GET.get("q", "")


### PR DESCRIPTION
## Summary
- First-token Tab completion fuzzy-matches shortcut keys and descriptions (case-insensitive); suggestions still show command keys only (e.g. `translate` → `gtre`/`gtrp`)
- Reject extra whitespace-separated args for all shortcuts with a usage line (fixes `prh repo 476` gluing into `repo%20476`)
- Free-text placeholders (`search_terms`, `phrase`, …) still take the rest of the line as one value

## Test plan
- [x] Unit/smoke tests for description fuzzy match + arity errors with usage
- [x] `./test_bunnify` / ruff / pyright
- [x] `./test_integration`
- [ ] Manually: Tab on `translate`; `prh repository-helpers 476` errors with Usage

Made with [Cursor](https://cursor.com)