### PR TITLE
feat: local/remote setup with health verification (#264)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ uv run python manage.py load_bookmarks
 
 Personal bookmarks live in `~/.config/bunnify` (or `$XDG_CONFIG_HOME/bunnify`);
 the repository-root `bunnify.json` is no longer tracked. See
-[Configuration](docs/CONFIG.md) for migration and environment overrides.
+[Configuration](docs/CONFIG.md) for migration and environment overrides, and
+[Local and remote setup](docs/LOCAL.md) for managed startup and macOS launchd.
 
 ### 2. Start the Server
 
@@ -156,6 +157,9 @@ With the server running (`./scripts/bunnify-server`) and dependencies synced (`u
 run the CLI via the repo wrapper (no manual `uv run` needed):
 
 ```bash
+# Configure a managed local server (default) or a remote server
+./scripts/bunnify setup
+
 # Interactive REPL with Tab completion (loops until quit/exit)
 ./scripts/bunnify
 
@@ -173,9 +177,10 @@ run the CLI via the repo wrapper (no manual `uv run` needed):
 ./scripts/bunnify --print-url gh
 ```
 
-Base URL resolution (first match wins): `--base-url` → `BUNNIFY_BASE_URL` →
-`~/.config/bunnify/config.env` → legacy gitignored `bunnify.env` → interactive
-prompt (persisted to the XDG config file). The REPL defaults to **Vim** keys
+On first interactive use, setup defaults to a managed local server; remote
+servers can be selected with `bunnify setup`. Only health-verified preferences
+are persisted in `~/.config/bunnify/config.env`. `--base-url` is a one-time
+override. The REPL defaults to **Vim** keys
 (`--edit-mode emacs` or `BUNNIFY_EDIT_MODE=emacs`; switch mid-session with
 `edit-mode`). Tab uses fuzzy completion with colored meta vs shortcut matches,
 persistent history, and history auto-suggest. Unknown shortcuts exit non-zero in

--- a/app/cli.py
+++ b/app/cli.py
@@ -14,14 +14,26 @@ from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.shortcuts import CompleteStyle
 
 from app.client import (
+    DEFAULT_BASE_URL,
     ClientError,
     KeyEntry,
+    check_health,
     fetch_key_entries,
     fetch_keys,
     fetch_suggestions,
     resolve_shortcut,
 )
-from app.config import ENV_VAR, resolve_base_url
+from app.config import (
+    ENV_VAR,
+    ServerPreferences,
+    default_bookmarks_path,
+    ensure_user_bookmarks,
+    env_file_path,
+    load_preferences,
+    resolve_base_url,
+    run_dir,
+    save_preferences,
+)
 from app.github_complete import (
     bootstrap_github_completion_cache,
     ensure_github_authenticated,
@@ -36,8 +48,87 @@ from app.interactive import (
     read_shortcut_query,
     repl_prompt_message,
 )
+from app.local_server import ensure_local_server
 from app.theme import Theme, stdout_color_enabled
 from app.usage import format_key_usage_lines
+
+
+def ensure_ready_base_url(
+    *,
+    cli_value: str | None = None,
+    environ: dict[str, str] | None = None,
+    env_path: Path | None = None,
+    prompt_fn: Callable[[str], str] | None = None,
+    allow_prompt: bool | None = None,
+    print_fn: Callable[[str], None] | None = None,
+) -> str:
+    """Resolve preferences and return a verified or explicitly overridden URL."""
+    ask = prompt_fn or input
+    log = print_fn or click.echo
+    interactive = (
+        allow_prompt
+        if allow_prompt is not None
+        else sys.stdin.isatty() and sys.stdout.isatty()
+    )
+    if cli_value is not None and cli_value.strip():
+        base_url = resolve_base_url(cli_value=cli_value, persist=False)
+        if not check_health(base_url):
+            log(f"warning: Bunnify health check failed for {base_url}")
+        return base_url
+
+    preferences = load_preferences(environ=environ, env_path=env_path)
+    if preferences is None:
+        if interactive:
+            return run_setup(
+                prompt_fn=ask,
+                environ=environ,
+                env_path=env_path,
+                print_fn=log,
+            )
+        return DEFAULT_BASE_URL
+
+    if preferences.mode == "remote":
+        if not preferences.base_url:
+            raise ClientError("Remote mode requires BUNNIFY_BASE_URL")
+        return _wait_for_healthy_remote(
+            preferences.base_url,
+            prompt_fn=ask,
+            interactive=interactive,
+            print_fn=log,
+        )
+
+    bookmarks = default_bookmarks_path(environ=environ)
+    while True:
+        try:
+            base_url, actual_port = ensure_local_server(
+                port=preferences.local_port,
+                pid_dir=run_dir(environ=environ),
+                bookmarks=bookmarks,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            if not interactive or not _retry_requested(
+                ask, f"Local server failed: {exc}\nRetry? [Y/n]: "
+            ):
+                raise ClientError(str(exc)) from exc
+            continue
+        if not check_health(base_url):
+            message = f"Local server health check failed for {base_url}"
+            if not interactive or not _retry_requested(
+                ask, f"{message}\nRetry? [Y/n]: "
+            ):
+                raise ClientError(message)
+            continue
+        if actual_port != preferences.local_port or base_url != preferences.base_url:
+            path = env_path if env_path is not None else env_file_path(environ=environ)
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url=base_url,
+                    local_port=actual_port,
+                ),
+                env_path=path,
+            )
+        return base_url
 
 
 def open_url(url: str, *, opener: Callable[[str], bool] | None = None) -> None:
@@ -86,6 +177,101 @@ def pick_key_with_fzf(
     return selected or None
 
 
+def run_setup(
+    *,
+    prompt_fn: Callable[[str], str] | None = None,
+    environ: dict[str, str] | None = None,
+    env_path: Path | None = None,
+    print_fn: Callable[[str], None] | None = None,
+) -> str:
+    """Interactively configure a verified local or remote Bunnify server."""
+    ask = prompt_fn or input
+    log = print_fn or click.echo
+    path = env_path if env_path is not None else env_file_path(environ=environ)
+    existing = load_preferences(environ=environ, env_path=path)
+
+    while True:
+        try:
+            answer = ask("Server mode, local or remote? [local]: ")
+        except EOFError as exc:
+            raise ClientError("Setup aborted") from exc
+        mode = answer.strip().lower() or "local"
+        if mode in {"l", "local"}:
+            mode = "local"
+            break
+        if mode in {"r", "remote"}:
+            mode = "remote"
+            break
+        log("Please enter 'local' or 'remote'.")
+
+    if mode == "local":
+        bookmarks = ensure_user_bookmarks(
+            environ=environ,
+            prompt_fn=ask,
+            allow_prompt=True,
+            print_fn=log,
+        )
+        preferred_port = (
+            existing.local_port
+            if existing is not None and existing.mode == "local"
+            else None
+        )
+        while True:
+            try:
+                base_url, actual_port = ensure_local_server(
+                    port=preferred_port,
+                    pid_dir=run_dir(environ=environ),
+                    bookmarks=bookmarks,
+                )
+            except (OSError, RuntimeError, ValueError) as exc:
+                if _retry_requested(ask, f"Local server failed: {exc}\nRetry? [Y/n]: "):
+                    continue
+                raise ClientError("Setup aborted; settings were not changed") from exc
+            if check_health(base_url):
+                preferences = ServerPreferences(
+                    mode="local",
+                    base_url=base_url,
+                    local_port=actual_port,
+                )
+                save_preferences(preferences, env_path=path)
+                log(f"Configured local Bunnify server at {base_url}")
+                return base_url
+            if not _retry_requested(
+                ask,
+                f"Health check failed for {base_url}.\nRetry? [Y/n]: ",
+            ):
+                raise ClientError("Setup aborted; settings were not changed")
+
+    suggestion = (
+        existing.base_url
+        if existing is not None and existing.mode == "remote" and existing.base_url
+        else DEFAULT_BASE_URL
+    )
+    while True:
+        try:
+            answer = ask(f"Remote Bunnify URL [{suggestion}]: ")
+        except EOFError as exc:
+            raise ClientError("Setup aborted; settings were not changed") from exc
+        base_url = resolve_base_url(
+            cli_value=answer.strip() or suggestion,
+            persist=False,
+        )
+        if check_health(base_url):
+            preferences = ServerPreferences(
+                mode="remote",
+                base_url=base_url,
+                local_port=None,
+            )
+            save_preferences(preferences, env_path=path)
+            log(f"Configured remote Bunnify server at {base_url}")
+            return base_url
+        if not _retry_requested(
+            ask,
+            f"Health check failed for {base_url}.\nTry another URL? [Y/n]: ",
+        ):
+            raise ClientError("Setup aborted; settings were not changed")
+
+
 def matching_keys(keys: list[str], prefix: str) -> list[str]:
     """Return keys that start with ``prefix`` (case-insensitive)."""
     needle = prefix.lower()
@@ -94,6 +280,31 @@ def matching_keys(keys: list[str], prefix: str) -> list[str]:
 
 def build_query_from_args(args: tuple[str, ...]) -> str:
     return " ".join(args).strip()
+
+
+def _retry_requested(prompt_fn: Callable[[str], str], message: str) -> bool:
+    try:
+        answer = prompt_fn(message)
+    except EOFError:
+        return False
+    return answer.strip().lower() not in {"abort", "n", "no", "q", "quit"}
+
+
+def _wait_for_healthy_remote(
+    base_url: str,
+    *,
+    prompt_fn: Callable[[str], str],
+    interactive: bool,
+    print_fn: Callable[[str], None],
+) -> str:
+    while not check_health(base_url):
+        message = f"Cannot reach a healthy Bunnify server at {base_url}"
+        if not interactive:
+            raise ClientError(message)
+        print_fn(message)
+        if not _retry_requested(prompt_fn, "Retry connection? [Y/n]: "):
+            raise ClientError("Connection aborted")
+    return base_url
 
 
 def _print_repl_help(theme: Theme) -> None:
@@ -531,6 +742,12 @@ def _run(
         "XDG-aware; legacy repo-root bunnify.env is a fallback)."
     ),
 )
+@click.option(
+    "--setup",
+    "setup_requested",
+    is_flag=True,
+    help="Configure a verified local or remote server (also: `bunnify setup`).",
+)
 def main(
     shortcut_args: tuple[str, ...],
     base_url_option: str | None,
@@ -543,6 +760,7 @@ def main(
     color_mode: str,
     edit_mode: str | None,
     env_file: Path | None,
+    setup_requested: bool,
 ) -> None:
     """
     Open a Bunnify shortcut in your default browser.
@@ -557,27 +775,42 @@ def main(
       ./scripts/bunnify pr 12345
 
     \b
+    Server setup (`setup` is a reserved shortcut name):
+      ./scripts/bunnify setup
+      ./scripts/bunnify --setup
+
+    \b
     Fuzzy pick (fzf) for argv / shell completion workflows:
       ./scripts/bunnify --fzf
       ./scripts/bunnify --list-keys | fzf
       ./scripts/bunnify --list-usage
     """
     theme = Theme(enabled=stdout_color_enabled(color_mode.lower()))
+
+    def prompt_fn(message: str) -> str:
+        return click.prompt(
+            message.rstrip(": "),
+            default="",
+            show_default=False,
+        )
+
     mode_name = (
         normalize_edit_mode_choice(edit_mode)
         if edit_mode is not None
         else default_edit_mode_from_environ()
     )
     try:
-        resolved_url = resolve_base_url(
+        if setup_requested or shortcut_args == ("setup",):
+            run_setup(
+                prompt_fn=prompt_fn,
+                env_path=env_file,
+                print_fn=click.echo,
+            )
+            return
+        resolved_url = ensure_ready_base_url(
             cli_value=base_url_option,
-            persist=base_url_option is None,
             env_path=env_file,
-            prompt_fn=lambda message: click.prompt(
-                message.rstrip(": "),
-                default="",
-                show_default=False,
-            ),
+            prompt_fn=prompt_fn,
         )
         _run(
             shortcut_args=shortcut_args,
@@ -591,7 +824,7 @@ def main(
             theme=theme,
             editing_mode=editing_mode_enum(mode_name),
         )
-    except (ClientError, ValueError, OSError) as exc:
+    except (ClientError, ValueError, OSError, RuntimeError) as exc:
         click.echo(theme.err(f"error: {exc}"), err=True)
         sys.exit(1)
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -90,14 +90,40 @@ def ensure_ready_base_url(
     if preferences.mode == "remote":
         if not preferences.base_url:
             raise ClientError("Remote mode requires BUNNIFY_BASE_URL")
-        return _wait_for_healthy_remote(
-            preferences.base_url,
+        if check_health(preferences.base_url):
+            return preferences.base_url
+        if not interactive:
+            return _wait_for_healthy_remote(
+                preferences.base_url,
+                prompt_fn=ask,
+                interactive=False,
+                print_fn=log,
+            )
+        log(f"Cannot reach a healthy Bunnify server at {preferences.base_url}")
+        try:
+            answer = ask("Use the managed local server instead? [Y/n]: ")
+        except EOFError as exc:
+            raise ClientError("Connection aborted") from exc
+        if answer.strip().lower() in {"n", "no"}:
+            return _wait_for_healthy_remote(
+                preferences.base_url,
+                prompt_fn=ask,
+                interactive=True,
+                print_fn=log,
+            )
+        bookmarks = ensure_user_bookmarks(
+            environ=environ,
             prompt_fn=ask,
-            interactive=interactive,
+            allow_prompt=True,
             print_fn=log,
         )
-
-    bookmarks = default_bookmarks_path(environ=environ)
+        preferences = ServerPreferences(
+            mode="local",
+            base_url=None,
+            local_port=None,
+        )
+    else:
+        bookmarks = default_bookmarks_path(environ=environ)
     while True:
         try:
             base_url, actual_port = ensure_local_server(

--- a/app/cli.py
+++ b/app/cli.py
@@ -99,6 +99,7 @@ def ensure_ready_base_url(
             )
         return DEFAULT_BASE_URL
 
+    persist_local_preferences = preferences.mode == "local"
     if preferences.mode == "remote":
         if not preferences.base_url:
             raise ClientError("Remote mode requires BUNNIFY_BASE_URL")
@@ -113,7 +114,7 @@ def ensure_ready_base_url(
             )
         log(f"Cannot reach a healthy Bunnify server at {preferences.base_url}")
         try:
-            answer = ask("Use the managed local server instead? [Y/n]: ")
+            answer = ask("Use the managed local server for this run instead? [Y/n]: ")
         except EOFError as exc:
             raise ClientError("Connection aborted") from exc
         if answer.strip().lower() in {"n", "no"}:
@@ -161,7 +162,9 @@ def ensure_ready_base_url(
             ):
                 raise ClientError(message)
             continue
-        if actual_port != preferences.local_port or base_url != preferences.base_url:
+        if persist_local_preferences and (
+            actual_port != preferences.local_port or base_url != preferences.base_url
+        ):
             path = env_path if env_path is not None else env_file_path(environ=environ)
             save_preferences(
                 ServerPreferences(

--- a/app/cli.py
+++ b/app/cli.py
@@ -26,10 +26,11 @@ from app.client import (
 from app.config import (
     ENV_VAR,
     ServerPreferences,
-    default_bookmarks_path,
     ensure_user_bookmarks,
     env_file_path,
+    legacy_env_file_path,
     load_preferences,
+    read_base_url_from_env_file,
     resolve_base_url,
     run_dir,
     save_preferences,
@@ -77,6 +78,17 @@ def ensure_ready_base_url(
         return base_url
 
     preferences = load_preferences(environ=environ, env_path=env_path)
+    if preferences is None and env_path is None:
+        legacy_base_url = read_base_url_from_env_file(legacy_env_file_path())
+        if legacy_base_url:
+            preferences = ServerPreferences(
+                mode="remote",
+                base_url=resolve_base_url(
+                    cli_value=legacy_base_url,
+                    persist=False,
+                ),
+                local_port=None,
+            )
     if preferences is None:
         if interactive:
             return run_setup(
@@ -123,7 +135,12 @@ def ensure_ready_base_url(
             local_port=None,
         )
     else:
-        bookmarks = default_bookmarks_path(environ=environ)
+        bookmarks = ensure_user_bookmarks(
+            environ=environ,
+            prompt_fn=ask,
+            allow_prompt=interactive,
+            print_fn=log,
+        )
     while True:
         try:
             base_url, actual_port = ensure_local_server(

--- a/app/cli.py
+++ b/app/cli.py
@@ -142,10 +142,11 @@ def ensure_ready_base_url(
             allow_prompt=interactive,
             print_fn=log,
         )
+    preferred_port = preferences.local_port
     while True:
         try:
             base_url, actual_port = ensure_local_server(
-                port=preferences.local_port,
+                port=preferred_port,
                 pid_dir=run_dir(environ=environ),
                 bookmarks=bookmarks,
             )
@@ -154,6 +155,7 @@ def ensure_ready_base_url(
                 ask, f"Local server failed: {exc}\nRetry? [Y/n]: "
             ):
                 raise ClientError(str(exc)) from exc
+            preferred_port = None
             continue
         if not check_health(base_url):
             message = f"Local server health check failed for {base_url}"
@@ -271,6 +273,7 @@ def run_setup(
                 )
             except (OSError, RuntimeError, ValueError) as exc:
                 if _retry_requested(ask, f"Local server failed: {exc}\nRetry? [Y/n]: "):
+                    preferred_port = None
                     continue
                 raise ClientError("Setup aborted; settings were not changed") from exc
             if check_health(base_url):

--- a/app/client.py
+++ b/app/client.py
@@ -35,6 +35,30 @@ class KeyEntry:
     optional_params: frozenset[str] = frozenset()
 
 
+def check_health(base_url: str, *, timeout: float = 2.0) -> bool:
+    """Return whether ``base_url`` serves Bunnify's healthy ``/health`` response."""
+    request = urllib.request.Request(
+        f"{base_url.rstrip('/')}/health",
+        headers={"Accept": "text/plain", "User-Agent": "bunnify-cli"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = getattr(response, "status", None)
+            if status is None:
+                status = response.getcode()
+            body = response.read().decode("utf-8")
+            return status == 200 and body.strip().lower() == "ok"
+    except (
+        OSError,
+        TimeoutError,
+        UnicodeDecodeError,
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+    ):
+        return False
+
+
 def _request_json(
     url: str,
     *,

--- a/app/config.py
+++ b/app/config.py
@@ -7,23 +7,29 @@ import re
 import shutil
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
+from typing import Literal
 
 from app.client import DEFAULT_BASE_URL
 
-ENV_VAR = "BUNNIFY_BASE_URL"
 BOOKMARKS_ENV_VAR = "BUNNIFY_BOOKMARKS"
-ENV_FILE_NAME = "config.env"
-LEGACY_ENV_FILE_NAME = "bunnify.env"
 BOOKMARKS_FILE_NAME = "bookmarks.json"
+ENV_FILE_NAME = "config.env"
+ENV_VAR = "BUNNIFY_BASE_URL"
 EXAMPLE_BOOKMARKS_NAME = "bunnify.json.example"
+LEGACY_ENV_FILE_NAME = "bunnify.env"
 LEGACY_BOOKMARKS_PATH = Path.home() / "work" / "bunnify" / "bunnify.json"
+LOCAL_PORT_ENV_VAR = "BUNNIFY_LOCAL_PORT"
+MODE_ENV_VAR = "BUNNIFY_MODE"
 
-_BASE_URL_LINE = re.compile(
-    rf"^\s*{re.escape(ENV_VAR)}\s*=\s*(.*)$",
-    re.MULTILINE,
-)
+
+@dataclass(frozen=True)
+class ServerPreferences:
+    mode: Literal["local", "remote"]
+    base_url: str
+    local_port: int | None
 
 
 def repo_root() -> Path:
@@ -72,51 +78,110 @@ def legacy_bookmarks_path() -> Path:
     return LEGACY_BOOKMARKS_PATH
 
 
+def load_preferences(
+    *,
+    environ: dict[str, str] | None = None,
+    env_path: Path | None = None,
+) -> ServerPreferences | None:
+    """Load server preferences from the process environment and XDG config."""
+    env = environ if environ is not None else os.environ
+    path = env_path if env_path is not None else env_file_path(environ=env)
+
+    def value(key: str) -> str | None:
+        from_environment = (env.get(key) or "").strip()
+        return from_environment or read_env_value(path, key)
+
+    mode_raw = value(MODE_ENV_VAR)
+    base_url_raw = value(ENV_VAR)
+    local_port_raw = value(LOCAL_PORT_ENV_VAR)
+    if not any((mode_raw, base_url_raw, local_port_raw)):
+        return None
+
+    if mode_raw:
+        mode = mode_raw.lower()
+        if mode not in {"local", "remote"}:
+            raise ValueError(f"{MODE_ENV_VAR} must be 'local' or 'remote'")
+    else:
+        mode = "local" if local_port_raw else "remote"
+
+    local_port = None
+    if local_port_raw:
+        try:
+            local_port = int(local_port_raw)
+        except ValueError as exc:
+            raise ValueError(f"{LOCAL_PORT_ENV_VAR} must be an integer") from exc
+        if not 1 <= local_port <= 65535:
+            raise ValueError(f"{LOCAL_PORT_ENV_VAR} must be between 1 and 65535")
+
+    base_url = normalize_base_url(base_url_raw or "")
+    if base_url:
+        base_url = _ensure_http_scheme(base_url)
+    elif mode == "local" and local_port is not None:
+        base_url = f"http://127.0.0.1:{local_port}"
+
+    return ServerPreferences(
+        mode=mode,
+        base_url=base_url,
+        local_port=local_port,
+    )
+
+
 def normalize_base_url(value: str) -> str:
     return value.strip().rstrip("/")
 
 
-def _ensure_http_scheme(url: str) -> str:
-    """Require or prepend an http(s) scheme for CLI base URLs."""
-    lowered = url.lower()
-    if lowered.startswith(("http://", "https://")):
-        return url
-    if "://" in url:
-        raise ValueError(f"Base URL must use http:// or https:// (got {url!r})")
-    return f"http://{url}"
-
-
-def read_base_url_from_env_file(path: Path) -> str | None:
-    """Return ``BUNNIFY_BASE_URL`` from ``path``, or ``None`` if unset/missing."""
+def read_env_value(path: Path, key: str) -> str | None:
+    """Return one value from an env file, or ``None`` when missing or empty."""
     if not path.is_file():
         return None
     try:
         text = path.read_text(encoding="utf-8")
     except OSError:
         return None
-    match = _BASE_URL_LINE.search(text)
+    match = _env_line_pattern(key).search(text)
     if match is None:
         return None
     raw = match.group(1).strip()
-    # Drop unquoted inline comments (``.env`` style: ``URL  # note``).
-    # Require whitespace before ``#`` so URL fragments are preserved.
     raw = re.sub(r"\s+#.*$", "", raw).strip().strip("'").strip('"')
-    return normalize_base_url(raw) if raw else None
+    return raw or None
 
 
-def write_base_url_to_env_file(path: Path, base_url: str) -> None:
-    """Create or update ``BUNNIFY_BASE_URL`` in ``path`` (preserves other lines)."""
-    normalized = normalize_base_url(base_url)
-    if not normalized:
-        raise ValueError(f"{ENV_VAR} cannot be empty")
-    line = f"{ENV_VAR}={normalized}\n"
+def run_dir(*, environ: dict[str, str] | None = None) -> Path:
+    """Return the XDG directory used for managed server PID and port files."""
+    return config_dir(environ=environ) / "run"
+
+
+def save_preferences(
+    preferences: ServerPreferences,
+    *,
+    env_path: Path | None = None,
+) -> None:
+    """Persist a complete, verified server preference set."""
+    path = env_path if env_path is not None else env_file_path()
+    write_env_value(path, ENV_VAR, normalize_base_url(preferences.base_url))
+    write_env_value(
+        path,
+        LOCAL_PORT_ENV_VAR,
+        str(preferences.local_port) if preferences.local_port is not None else "",
+    )
+    write_env_value(path, MODE_ENV_VAR, preferences.mode)
+
+
+def write_env_value(path: Path, key: str, value: str) -> None:
+    """Create or update one env value while preserving all other lines."""
+    if "\n" in key or "=" in key or not key.strip():
+        raise ValueError("Environment key must be a non-empty single name")
+    if "\n" in value:
+        raise ValueError(f"{key} cannot contain a newline")
+    pattern = _env_line_pattern(key)
+    line = f"{key}={value}\n"
     if path.is_file():
         try:
             text = path.read_text(encoding="utf-8")
         except OSError as exc:
             raise OSError(f"Cannot read {path}: {exc}") from exc
-        if _BASE_URL_LINE.search(text):
-            text = _BASE_URL_LINE.sub(f"{ENV_VAR}={normalized}", text, count=1)
+        if pattern.search(text):
+            text = pattern.sub(lambda _match: f"{key}={value}", text, count=1)
             if not text.endswith("\n"):
                 text += "\n"
         else:
@@ -131,6 +196,20 @@ def write_base_url_to_env_file(path: Path, base_url: str) -> None:
         )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def read_base_url_from_env_file(path: Path) -> str | None:
+    """Return ``BUNNIFY_BASE_URL`` from ``path``, or ``None`` if unset/missing."""
+    value = read_env_value(path, ENV_VAR)
+    return normalize_base_url(value) if value else None
+
+
+def write_base_url_to_env_file(path: Path, base_url: str) -> None:
+    """Create or update ``BUNNIFY_BASE_URL`` in ``path`` (preserves other lines)."""
+    normalized = normalize_base_url(base_url)
+    if not normalized:
+        raise ValueError(f"{ENV_VAR} cannot be empty")
+    write_env_value(path, ENV_VAR, normalized)
 
 
 def example_bookmarks_bytes() -> bytes | None:
@@ -286,3 +365,20 @@ def resolve_base_url(
     if persist:
         write_base_url_to_env_file(primary, chosen)
     return chosen
+
+
+def _ensure_http_scheme(url: str) -> str:
+    """Require or prepend an http(s) scheme for CLI base URLs."""
+    lowered = url.lower()
+    if lowered.startswith(("http://", "https://")):
+        return url
+    if "://" in url:
+        raise ValueError(f"Base URL must use http:// or https:// (got {url!r})")
+    return f"http://{url}"
+
+
+def _env_line_pattern(key: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"^[^\S\r\n]*{re.escape(key)}[^\S\r\n]*=[^\S\r\n]*(.*)$",
+        re.MULTILINE,
+    )

--- a/app/local_server.py
+++ b/app/local_server.py
@@ -1,0 +1,135 @@
+"""Start and stop the checkout-provided Bunnify server for the CLI."""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+from app.client import check_health
+from app.config import repo_root
+
+
+def ensure_local_server(
+    *,
+    port: int | None,
+    pid_dir: Path,
+    bookmarks: Path | None = None,
+    timeout_s: float = 60,
+) -> tuple[str, int]:
+    """Return a healthy local server URL, starting the server when necessary."""
+    if port is not None and not 0 <= port <= 65535:
+        raise ValueError("Local server port must be between 0 and 65535")
+
+    selected_port = port
+    if selected_port is None:
+        default_url = "http://127.0.0.1:8000"
+        if check_health(default_url):
+            return default_url, 8000
+        selected_port = 8000 if _port_is_free(8000) else 0
+
+    if selected_port:
+        base_url = f"http://127.0.0.1:{selected_port}"
+        if check_health(base_url):
+            return base_url, selected_port
+
+    script = find_bunnify_server_script()
+    if script is None:
+        raise RuntimeError(
+            "Cannot start a local Bunnify server: scripts/bunnify-server was not "
+            "found or is not executable. Local managed mode currently requires "
+            "a development checkout."
+        )
+
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    port_file = pid_dir / ".bunnify.port"
+    if selected_port == 0:
+        port_file.unlink(missing_ok=True)
+
+    command = [
+        str(script),
+        "--port",
+        str(selected_port),
+        "--pid-dir",
+        str(pid_dir),
+        "--noninteractive",
+    ]
+    if bookmarks is not None:
+        command.extend(["--bookmarks", str(bookmarks)])
+
+    deadline = time.monotonic() + timeout_s
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=max(0.1, deadline - time.monotonic()),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"Timed out starting the local Bunnify server after {timeout_s:g}s"
+        ) from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"Local Bunnify server failed to start{suffix}")
+
+    actual_port = selected_port
+    while actual_port == 0 and time.monotonic() < deadline:
+        try:
+            actual_port = int(port_file.read_text(encoding="utf-8").strip())
+        except OSError, ValueError:
+            time.sleep(0.1)
+
+    if not actual_port:
+        raise RuntimeError(
+            f"Local Bunnify server did not report its port in {port_file}"
+        )
+
+    base_url = f"http://127.0.0.1:{actual_port}"
+    while time.monotonic() < deadline:
+        if check_health(base_url):
+            return base_url, actual_port
+        time.sleep(0.1)
+    raise RuntimeError(
+        f"Local Bunnify server at {base_url} did not become healthy "
+        f"within {timeout_s:g}s"
+    )
+
+
+def find_bunnify_server_script() -> Path | None:
+    """Return the executable development-checkout server script, if available."""
+    script = repo_root() / "scripts" / "bunnify-server"
+    return script if script.is_file() and script.stat().st_mode & 0o111 else None
+
+
+def stop_local_server(pid_dir: Path) -> None:
+    """Stop the managed local server associated with ``pid_dir``."""
+    script = find_bunnify_server_script()
+    if script is None:
+        raise RuntimeError(
+            "Cannot stop the local Bunnify server: scripts/bunnify-server was "
+            "not found or is not executable."
+        )
+    completed = subprocess.run(
+        [str(script), "--stop", "--pid-dir", str(pid_dir)],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(f"Failed to stop the local Bunnify server{suffix}")
+
+
+def _port_is_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+        try:
+            candidate.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -7,6 +7,7 @@ import sys
 from io import StringIO
 from unittest.mock import patch
 
+from click.testing import CliRunner
 from django.test import Client, TestCase, override_settings
 
 from app import interactive
@@ -14,6 +15,42 @@ from app.cli import _run, matching_keys
 from app.client import ClientError, KeyEntry, ResolvedShortcut, parse_keys_payload
 
 from .models import Bookmark
+
+
+class ClientHealthTests(TestCase):
+    def test_check_health_accepts_exact_ok_body_case_insensitively(self) -> None:
+        from app.client import check_health
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self) -> bytes:
+                return b" OK \n"
+
+        with patch("urllib.request.urlopen", return_value=Response()) as urlopen:
+            self.assertTrue(check_health("https://bunnify.example/"))
+
+        self.assertEqual(
+            urlopen.call_args.args[0].full_url, "https://bunnify.example/health"
+        )
+        self.assertEqual(urlopen.call_args.kwargs["timeout"], 2.0)
+
+    def test_check_health_returns_false_for_network_errors(self) -> None:
+        import urllib.error
+
+        from app.client import check_health
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("offline"),
+        ):
+            self.assertFalse(check_health("https://bunnify.example"))
 
 
 class ResolveApiTests(TestCase):
@@ -560,6 +597,35 @@ class ConfigUnitTests(TestCase):
                 "http://from-xdg:9000",
             )
 
+    def test_preferences_round_trip_under_xdg(self) -> None:
+        import tempfile
+
+        from app.config import (
+            ServerPreferences,
+            env_file_path,
+            load_preferences,
+            save_preferences,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            environ = {"XDG_CONFIG_HOME": tmp}
+            path = env_file_path(environ=environ)
+            expected = ServerPreferences(
+                mode="local",
+                base_url="http://127.0.0.1:8765",
+                local_port=8765,
+            )
+            save_preferences(expected, env_path=path)
+
+            self.assertEqual(
+                load_preferences(environ=environ, env_path=path),
+                expected,
+            )
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("BUNNIFY_MODE=local", text)
+            self.assertIn("BUNNIFY_BASE_URL=http://127.0.0.1:8765", text)
+            self.assertIn("BUNNIFY_LOCAL_PORT=8765", text)
+
     def test_ensure_user_bookmarks_copies_legacy_noninteractive(self) -> None:
         import tempfile
         from pathlib import Path
@@ -717,6 +783,89 @@ class ConfigUnitTests(TestCase):
                 "http://127.0.0.1:8000",
             )
 
+    def test_setup_failure_does_not_overwrite_preferences(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import run_setup
+        from app.client import ClientError
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            original = ServerPreferences(
+                mode="remote",
+                base_url="https://working.example",
+                local_port=None,
+            )
+            save_preferences(original, env_path=path)
+            responses = iter(["remote", "https://broken.example", "n"])
+            with patch("app.cli.check_health", return_value=False):
+                with self.assertRaises(ClientError):
+                    run_setup(
+                        prompt_fn=lambda _message: next(responses),
+                        env_path=path,
+                        print_fn=lambda _message: None,
+                    )
+
+            self.assertEqual(load_preferences(environ={}, env_path=path), original)
+
+    def test_setup_local_persists_only_after_health(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import run_setup
+        from app.config import load_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8123", 8123),
+                ),
+                patch("app.cli.check_health", return_value=True),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: "",
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8123")
+            preferences = load_preferences(environ={}, env_path=path)
+            self.assertIsNotNone(preferences)
+            assert preferences is not None
+            self.assertEqual(preferences.mode, "local")
+            self.assertEqual(preferences.local_port, 8123)
+
+    def test_setup_remote_persists_verified_url(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import run_setup
+        from app.config import load_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            responses = iter(["remote", "https://remote.example/"])
+            with patch("app.cli.check_health", return_value=True):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    env_path=path,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "https://remote.example")
+            preferences = load_preferences(environ={}, env_path=path)
+            self.assertIsNotNone(preferences)
+            assert preferences is not None
+            self.assertEqual(preferences.mode, "remote")
+            self.assertEqual(preferences.base_url, "https://remote.example")
+
     @patch("app.cli.resolve_shortcut")
     @patch("app.cli.fetch_key_entries")
     def test_repl_quit_key_collision_opens_shortcut(
@@ -778,6 +927,15 @@ class ConfigUnitTests(TestCase):
             )
             self.assertEqual(url, DEFAULT_BASE_URL)
             self.assertIsNone(read_base_url_from_env_file(path))
+
+    def test_setup_shortcut_invokes_setup(self) -> None:
+        from app.cli import main
+
+        with patch("app.cli.run_setup", return_value="http://127.0.0.1:8000") as setup:
+            result = CliRunner().invoke(main, ["setup"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        setup.assert_called_once()
 
     def test_base_url_prepends_http_scheme(self) -> None:
         from app.config import resolve_base_url

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -710,6 +710,57 @@ class ConfigUnitTests(TestCase):
             preferences = load_preferences(environ={}, env_path=path)
             self.assertEqual(preferences, remote_preferences)
 
+    def test_ensure_ready_base_url_retries_with_ephemeral_port(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.config import (
+            ServerPreferences,
+            load_preferences,
+            save_preferences,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli.ensure_local_server",
+                    side_effect=[
+                        RuntimeError("port unavailable"),
+                        ("http://127.0.0.1:9123", 9123),
+                    ],
+                ) as ensure_server,
+                patch("app.cli.check_health", return_value=True),
+            ):
+                result = ensure_ready_base_url(
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    prompt_fn=lambda _message: "",
+                    allow_prompt=True,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:9123")
+            self.assertEqual(
+                [call.kwargs["port"] for call in ensure_server.call_args_list],
+                [8123, None],
+            )
+            preferences = load_preferences(environ={}, env_path=path)
+            self.assertIsNotNone(preferences)
+            assert preferences is not None
+            self.assertEqual(preferences.local_port, 9123)
+
     def test_ensure_ready_base_url_uses_legacy_remote_url(self) -> None:
         import tempfile
         from pathlib import Path
@@ -948,6 +999,57 @@ class ConfigUnitTests(TestCase):
             assert preferences is not None
             self.assertEqual(preferences.mode, "local")
             self.assertEqual(preferences.local_port, 8123)
+
+    def test_setup_local_retry_uses_ephemeral_port(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import run_setup
+        from app.config import (
+            ServerPreferences,
+            load_preferences,
+            save_preferences,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            responses = iter(["local", ""])
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli.ensure_local_server",
+                    side_effect=[
+                        RuntimeError("port unavailable"),
+                        ("http://127.0.0.1:9123", 9123),
+                    ],
+                ) as ensure_server,
+                patch("app.cli.check_health", return_value=True),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:9123")
+            self.assertEqual(
+                [call.kwargs["port"] for call in ensure_server.call_args_list],
+                [8123, None],
+            )
+            preferences = load_preferences(environ={}, env_path=path)
+            self.assertIsNotNone(preferences)
+            assert preferences is not None
+            self.assertEqual(preferences.local_port, 9123)
 
     def test_setup_remote_persists_verified_url(self) -> None:
         import tempfile

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -626,6 +626,51 @@ class ConfigUnitTests(TestCase):
             self.assertIn("BUNNIFY_BASE_URL=http://127.0.0.1:8765", text)
             self.assertIn("BUNNIFY_LOCAL_PORT=8765", text)
 
+    def test_ensure_ready_base_url_falls_back_from_remote_to_local(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.config import (
+            ServerPreferences,
+            load_preferences,
+            save_preferences,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="remote",
+                    base_url="https://unavailable.example",
+                    local_port=None,
+                ),
+                env_path=path,
+            )
+            with (
+                patch("app.cli.check_health", side_effect=[False, True]),
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8123", 8123),
+                ),
+            ):
+                result = ensure_ready_base_url(
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    prompt_fn=lambda _message: "",
+                    allow_prompt=True,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8123")
+            preferences = load_preferences(environ={}, env_path=path)
+            self.assertIsNotNone(preferences)
+            assert preferences is not None
+            self.assertEqual(preferences.mode, "local")
+            self.assertEqual(preferences.local_port, 8123)
+
     def test_ensure_user_bookmarks_copies_legacy_noninteractive(self) -> None:
         import tempfile
         from pathlib import Path

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import sys
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from click.testing import CliRunner
 from django.test import Client, TestCase, override_settings
@@ -626,6 +626,50 @@ class ConfigUnitTests(TestCase):
             self.assertIn("BUNNIFY_BASE_URL=http://127.0.0.1:8765", text)
             self.assertIn("BUNNIFY_LOCAL_PORT=8765", text)
 
+    def test_ensure_ready_base_url_ensures_local_bookmarks(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.config import ServerPreferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            with (
+                patch(
+                    "app.cli.ensure_user_bookmarks",
+                    return_value=bookmarks,
+                ) as ensure_bookmarks,
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8123", 8123),
+                ),
+                patch("app.cli.check_health", return_value=True),
+            ):
+                result = ensure_ready_base_url(
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    allow_prompt=False,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8123")
+            ensure_bookmarks.assert_called_once_with(
+                environ={"XDG_CONFIG_HOME": tmp},
+                prompt_fn=input,
+                allow_prompt=False,
+                print_fn=ANY,
+            )
+
     def test_ensure_ready_base_url_falls_back_from_remote_to_local(self) -> None:
         import tempfile
         from pathlib import Path
@@ -670,6 +714,29 @@ class ConfigUnitTests(TestCase):
             assert preferences is not None
             self.assertEqual(preferences.mode, "local")
             self.assertEqual(preferences.local_port, 8123)
+
+    def test_ensure_ready_base_url_uses_legacy_remote_url(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+
+        with tempfile.TemporaryDirectory() as tmp:
+            legacy = Path(tmp) / "bunnify.env"
+            legacy.write_text(
+                "BUNNIFY_BASE_URL=legacy.example:9000\n",
+                encoding="utf-8",
+            )
+            with (
+                patch("app.cli.legacy_env_file_path", return_value=legacy),
+                patch("app.cli.check_health", return_value=True),
+            ):
+                result = ensure_ready_base_url(
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    allow_prompt=False,
+                )
+
+            self.assertEqual(result, "http://legacy.example:9000")
 
     def test_ensure_user_bookmarks_copies_legacy_noninteractive(self) -> None:
         import tempfile

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -684,14 +684,12 @@ class ConfigUnitTests(TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "config.env"
             bookmarks = Path(tmp) / "bookmarks.json"
-            save_preferences(
-                ServerPreferences(
-                    mode="remote",
-                    base_url="https://unavailable.example",
-                    local_port=None,
-                ),
-                env_path=path,
+            remote_preferences = ServerPreferences(
+                mode="remote",
+                base_url="https://unavailable.example",
+                local_port=None,
             )
+            save_preferences(remote_preferences, env_path=path)
             with (
                 patch("app.cli.check_health", side_effect=[False, True]),
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
@@ -710,10 +708,7 @@ class ConfigUnitTests(TestCase):
 
             self.assertEqual(result, "http://127.0.0.1:8123")
             preferences = load_preferences(environ={}, env_path=path)
-            self.assertIsNotNone(preferences)
-            assert preferences is not None
-            self.assertEqual(preferences.mode, "local")
-            self.assertEqual(preferences.local_port, 8123)
+            self.assertEqual(preferences, remote_preferences)
 
     def test_ensure_ready_base_url_uses_legacy_remote_url(self) -> None:
         import tempfile

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -8,7 +8,9 @@ Bunnify stores user configuration under `$XDG_CONFIG_HOME/bunnify`, defaulting
 to `~/.config/bunnify` when `XDG_CONFIG_HOME` is unset:
 
 - `bookmarks.json` contains personal shortcuts.
-- `config.env` contains persistent CLI settings such as `BUNNIFY_BASE_URL`.
+- `config.env` contains persistent CLI server preferences:
+  `BUNNIFY_MODE`, `BUNNIFY_BASE_URL`, and `BUNNIFY_LOCAL_PORT`.
+- `run/` contains PID and selected-port files for the CLI-managed local server.
 
 The server creates `bookmarks.json` from the packaged example on first use.
 These files are user data and are not tracked by Git.
@@ -21,14 +23,16 @@ may instead copy it, symlink it, or seed the example. The previously tracked
 repository-root `bunnify.json` has been removed; copy any personal version to
 `~/.config/bunnify/bookmarks.json` or set `BUNNIFY_BOOKMARKS`.
 
-For the server URL, Bunnify reads the XDG `config.env` first and falls back to
-the legacy repository-root `bunnify.env`.
+Run `bunnify setup` to write verified settings. Existing base-URL-only files
+remain supported; they are interpreted as remote mode.
 
 ## Environment variables
 
 - `XDG_CONFIG_HOME` changes the configuration root.
 - `BUNNIFY_BOOKMARKS` overrides the bookmarks file path.
 - `BUNNIFY_BASE_URL` overrides the server URL.
+- `BUNNIFY_LOCAL_PORT` remembers the managed local server's listening port.
+- `BUNNIFY_MODE` selects `local` or `remote`.
 - `BUNNIFY_EDIT_MODE` selects `vim` or `emacs` CLI editing keys.
 - `BUNNIFY_LOG_LEVEL`, `BUNNIFY_LOG_CONSOLE`, and `BUNNIFY_LOG_FILE` configure
   server logging.

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -1,0 +1,71 @@
+# Local and remote server setup
+
+Run the interactive setup from a development checkout:
+
+```bash
+./scripts/bunnify setup
+# equivalent: ./scripts/bunnify --setup
+```
+
+Setup defaults to **local** mode. It creates the user bookmarks file when
+needed, starts a managed server, verifies `/health`, and records the selected
+port. Remote mode prompts for a URL and saves it only after its `/health`
+response is HTTP 200 with body `ok`.
+
+Verified settings are stored in `~/.config/bunnify/config.env` (or
+`$XDG_CONFIG_HOME/bunnify/config.env`):
+
+```dotenv
+BUNNIFY_MODE=local
+BUNNIFY_BASE_URL=http://127.0.0.1:8000
+BUNNIFY_LOCAL_PORT=8000
+```
+
+`setup` is a reserved CLI shortcut name. Use `--base-url URL` for a one-time
+server override that is not persisted.
+
+## Manual local workflow
+
+```bash
+mkdir -p ~/.config/bunnify/run
+./scripts/bunnify-server \
+  --port 8000 \
+  --pid-dir ~/.config/bunnify/run \
+  --bookmarks ~/.config/bunnify/bookmarks.json \
+  --noninteractive
+
+curl --max-time 2 http://127.0.0.1:8000/health
+
+./scripts/bunnify-server --stop --pid-dir ~/.config/bunnify/run
+```
+
+If port 8000 belongs to another service, use `--port 0`; the chosen port is
+written to `~/.config/bunnify/run/.bunnify.port`.
+
+## macOS LaunchAgent
+
+Copy `etc/launchd/com.thehcma.bunnify.plist.example` to
+`~/Library/LaunchAgents/com.thehcma.bunnify.plist`, replace every placeholder
+with an absolute path, then load it:
+
+```bash
+launchctl bootstrap "gui/$(id -u)" \
+  ~/Library/LaunchAgents/com.thehcma.bunnify.plist
+launchctl kickstart -k "gui/$(id -u)/com.thehcma.bunnify"
+
+# Unload before editing or removing it:
+launchctl bootout "gui/$(id -u)/com.thehcma.bunnify"
+```
+
+The template runs the server in the foreground with `KeepAlive` enabled.
+
+## Troubleshooting
+
+- `scripts/bunnify-server` missing: managed local mode is not packaged in the
+  CLI wheel yet; run from a development checkout.
+- Health check fails: inspect `/tmp/bunnify.log` and
+  `/tmp/bunnify_startup.log`, then retry `bunnify setup`.
+- Port occupied: stop that service or choose an unused port. Noninteractive
+  mode never kills an unrelated process.
+- Stale managed process: run the manual `--stop --pid-dir` command above and
+  rerun setup.

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -11,8 +11,8 @@ Setup defaults to **local** mode. It creates the user bookmarks file when
 needed, starts a managed server, verifies `/health`, and records the selected
 port. Remote mode prompts for a URL and saves it only after its `/health`
 response is HTTP 200 with body `ok`. If a configured remote server later
-becomes unavailable, the interactive CLI offers to start and switch to the
-managed local server.
+becomes unavailable, the interactive CLI offers to use the managed local
+server for that run without replacing the saved remote preference.
 
 Verified settings are stored in `~/.config/bunnify/config.env` (or
 `$XDG_CONFIG_HOME/bunnify/config.env`):

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -68,7 +68,7 @@ example when needed. Confirm that port 8000 is free before loading the agent.
   CLI wheel yet; run from a development checkout.
 - Health check fails: inspect `/tmp/bunnify.log` and
   `/tmp/bunnify_startup.log`, then retry `bunnify setup`.
-- Port occupied: stop that service or choose an unused port. Noninteractive
-  mode never kills an unrelated process.
+- Port occupied: stop that service or accept the interactive retry to choose an
+  ephemeral port. Noninteractive mode never kills an unrelated process.
 - Stale managed process: run the manual `--stop --pid-dir` command above and
   rerun setup.

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -31,7 +31,6 @@ mkdir -p ~/.config/bunnify/run
 ./scripts/bunnify-server \
   --port 8000 \
   --pid-dir ~/.config/bunnify/run \
-  --bookmarks ~/.config/bunnify/bookmarks.json \
   --noninteractive
 
 curl --max-time 2 http://127.0.0.1:8000/health
@@ -57,7 +56,9 @@ launchctl kickstart -k "gui/$(id -u)/com.thehcma.bunnify"
 launchctl bootout "gui/$(id -u)/com.thehcma.bunnify"
 ```
 
-The template runs the server in the foreground with `KeepAlive` enabled.
+The template runs the server in the foreground with `KeepAlive` enabled. It
+uses the default user bookmarks path, seeding the file from the packaged
+example when needed. Confirm that port 8000 is free before loading the agent.
 
 ## Troubleshooting
 

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -10,7 +10,9 @@ Run the interactive setup from a development checkout:
 Setup defaults to **local** mode. It creates the user bookmarks file when
 needed, starts a managed server, verifies `/health`, and records the selected
 port. Remote mode prompts for a URL and saves it only after its `/health`
-response is HTTP 200 with body `ok`.
+response is HTTP 200 with body `ok`. If a configured remote server later
+becomes unavailable, the interactive CLI offers to start and switch to the
+managed local server.
 
 Verified settings are stored in `~/.config/bunnify/config.env` (or
 `$XDG_CONFIG_HOME/bunnify/config.env`):

--- a/etc/launchd/com.thehcma.bunnify.plist.example
+++ b/etc/launchd/com.thehcma.bunnify.plist.example
@@ -15,8 +15,6 @@
     <string>8000</string>
     <string>--pid-dir</string>
     <string>__HOME__/.config/bunnify/run</string>
-    <string>--bookmarks</string>
-    <string>__HOME__/.config/bunnify/bookmarks.json</string>
   </array>
 
   <key>KeepAlive</key>

--- a/etc/launchd/com.thehcma.bunnify.plist.example
+++ b/etc/launchd/com.thehcma.bunnify.plist.example
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.thehcma.bunnify</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__REPOSITORY_ROOT__/scripts/bunnify-server</string>
+    <string>--foreground</string>
+    <string>--noninteractive</string>
+    <string>--port</string>
+    <string>8000</string>
+    <string>--pid-dir</string>
+    <string>__HOME__/.config/bunnify/run</string>
+    <string>--bookmarks</string>
+    <string>__HOME__/.config/bunnify/bookmarks.json</string>
+  </array>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/bunnify.err.log</string>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/bunnify.out.log</string>
+</dict>
+</plist>

--- a/scripts/bunnify-server
+++ b/scripts/bunnify-server
@@ -73,6 +73,11 @@ OPTIONS:
         Directory for PID and port files (default: script directory).
         Use a unique temp directory in tests/CI to avoid interfering
         with a concurrently running production server.
+        CLI managed mode uses ~/.config/bunnify/run (XDG-aware).
+
+    -y, --noninteractive
+        Never prompt. Automatically initialize an unready database and fail
+        instead of offering to kill a non-Bunnify process using the port.
 
 EXAMPLES:
     # Start with default settings (WARNING level, file logging only)
@@ -217,6 +222,7 @@ bookmarks_file=""
 do_stop=false
 foreground=false
 listen_all=false
+noninteractive=false
 server_port="8000"
 pid_dir_override=""
 
@@ -270,6 +276,10 @@ while [[ $# -gt 0 ]]; do
             listen_all=true
             shift
             ;;
+        -y|--noninteractive)
+            noninteractive=true
+            shift
+            ;;
         --log-level)
             if [ -z "$2" ]; then
                 echo "Error: --log-level requires a value"
@@ -304,14 +314,15 @@ if [ -n "$pid_dir_override" ]; then
     watcher_pid_file="$pid_dir/.bunnify_watcher.pid"
     port_file="$pid_dir/.bunnify.port"
 fi
+mkdir -p "$pid_dir"
 
 # If server_port is 0, ask the OS for a free ephemeral port, then hand that fixed port to Django.
 # We close the socket immediately so Django can bind to it; there is a brief TOCTOU window
 # but this is acceptable for local development and CI.
 if [ "$server_port" = "0" ]; then
     server_port=$($uv_cmd run python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
-    echo "$server_port" > "$port_file"
 fi
+echo "$server_port" > "$port_file"
 
 # Function to check if process is running
 is_running() {
@@ -467,6 +478,11 @@ stop_server() {
                 echo "   PID: $port_pid"
                 echo "   Command: $proc_cmd"
                 echo ""
+                if $noninteractive; then
+                    echo "❌ Aborted: noninteractive mode will not kill another process."
+                    echo "   Free port $check_port or choose another port."
+                    exit 1
+                fi
                 echo -n "Kill this process and continue? (y/N): "
                 read -r response
                 if [[ "$response" =~ ^[Yy]$ ]]; then
@@ -501,7 +517,7 @@ if [ -f "$pid_file" ]; then
         rm -f "$pid_file" "$watcher_pid_file" "$port_file"
     fi
 elif is_port_in_use; then
-    port_pid=$(lsof -ti:8000 2>/dev/null | head -1)
+    port_pid=$(lsof -ti:"$server_port" 2>/dev/null | head -1)
     if is_bunnify_process "$port_pid"; then
         echo "⚠️  Port 8000 is in use by another Bunnify process"
         echo "🔄 Stopping existing process and starting fresh..."
@@ -515,6 +531,7 @@ elif is_port_in_use; then
     fi
 fi
 
+echo "$server_port" > "$port_file"
 echo "🐰 Starting Bunnify server..."
 echo "Directory: $script_dir"
 
@@ -570,13 +587,19 @@ else
     echo ""
     echo "$db_check_output"
     echo ""
-    echo -n "Would you like me to initialize the database now? (y/N): "
-    read -r response
+    if $noninteractive; then
+        response="y"
+        echo "Initializing the database (--noninteractive)..."
+    else
+        echo -n "Would you like me to initialize the database now? (y/N): "
+        read -r response
+    fi
     if [[ "$response" =~ ^[Yy]$ ]]; then
         echo ""
         $uv_cmd run python manage.py check_database --fix
         fix_exit=$?
         if [ $fix_exit -ne 0 ]; then
+            echo "❌ Database initialization failed."
             exit 1
         fi
     else


### PR DESCRIPTION
## Summary
- Interactive `bunnify setup` / first-run defaults to managed **local** server; optional **remote** base URL
- Health check (`/health` body `ok`) with retry until success or abort; persist only verified prefs to `~/.config/bunnify/config.env`
- Local mode remembers port; managed pid-dir under config; `bunnify-server --noninteractive`
- Docs: `docs/LOCAL.md` + LaunchAgent example under `etc/launchd/`

## Test plan
- [x] Unit/integration tests
- [ ] `bunnify setup` local then resolve a shortcut
- [ ] Remote mode against https://bunnify.hcma.info

Fixes #264

Made with [Cursor](https://cursor.com)