### PR TITLE
fix: use @.name.value jsonpath so Release Please bumps uv.lock

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name=='bunnify')].version"
+          "jsonpath": "$.package[?(@.name.value=='bunnify')].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- Today's `github-repo-lint` enforcer failed on `the-hcma/bunnify` after Release Please landed in #269.
- GitHub squash-only merge settings were applied via `scripts/github-repo-lint --apply-fix`.
- This PR fixes the remaining check: Release Please's TOML updater only matches `uv.lock` package versions when the jsonpath uses `@.name.value` ([googleapis/release-please#2561](https://github.com/googleapis/release-please/issues/2561)). Plain `@.name=='bunnify'` is a silent no-op.

## Test plan

- [x] `scripts/checks` passed in the stack worktree (ruff, pyright, shellcheck, unit, packaging smoke, integration)
- [ ] CI green on this PR
- [ ] After merge, `scripts/github-repo-lint --repo the-hcma/bunnify --strict-onboarding --compact` passes
