### PR TITLE
refactor: prefer local installs; drop remote→local CLI fallback (#273)

### DIFF
--- a/CHROME_SETUP.md
+++ b/CHROME_SETUP.md
@@ -3,10 +3,15 @@
 Configure Bunnify as a Chrome search engine for fast bookmark access from the
 address bar.
 
-**Prerequisites:** Bunnify server running (via `bunnify setup`, `bunnify-server`,
-or a remote `BUNNIFY_BASE_URL`). `bunnify setup` prompts for a local port and
-saves the verified base URL to `~/.config/bunnify/config.env` as
-`BUNNIFY_BASE_URL`.
+**Prefer local on a laptop.** Point Chrome at the same machine’s managed server
+(`bunnify setup` → **local**). Use a remote URL only when you intentionally
+share a centralized/home-server install — and keep that host reachable whenever
+you use the address bar.
+
+**Prerequisites:** Bunnify server running (local `bunnify-server` / `bunnify setup`,
+or a reachable remote). Setup saves the verified base URL to
+`~/.config/bunnify/config.env` as `BUNNIFY_BASE_URL`. Chrome’s search-engine URL
+must match that value; if you change mode or port, update Chrome too.
 
 Read your base URL (use it in the steps below instead of hard-coded `:8000`):
 
@@ -42,7 +47,7 @@ Manual setup is more reliable across Chrome versions.
 
 If your server listens on a non-default host or port, adjust URLs accordingly.
 Re-run `bunnify setup` to change the saved port, or edit `BUNNIFY_BASE_URL` in
-`~/.config/bunnify/config.env`.
+`~/.config/bunnify/config.env`, then update the Chrome search-engine URL to match.
 
 ## Development checkout
 
@@ -56,7 +61,9 @@ Use the same URLs; start the server with:
 
 - **Engine missing:** visit the home page while the server is running
 - **404 on search:** confirm `<BUNNIFY_BASE_URL>/health` returns `ok`
-- **Wrong port:** read `BUNNIFY_BASE_URL` / `BUNNIFY_LOCAL_PORT` in
-  `config.env`, or `.bunnify.port` under the managed run directory
+- **Wrong port / remote down:** Chrome keeps a fixed URL. Align it with
+  `BUNNIFY_BASE_URL` in `config.env`, or switch to **local** with
+  `bunnify setup` and update the engine. There is no automatic remote→local
+  fallback in the CLI or the browser.
 
 More: [README](README.md), [docs/LOCAL.md](docs/LOCAL.md)

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,8 +1,12 @@
 # ⚡ Quick reference
 
-Assumes `pipx install bunnify`, a seeded `~/.config/bunnify/bookmarks.json`,
-and a completed `bunnify --setup`. Your base URL is in
-`~/.config/bunnify/config.env` as `BUNNIFY_BASE_URL`.
+# ⚡ Quick reference
+
+Assumes `pipx install bunnify`, `pipx ensurepath` (so `~/.local/bin` is on
+`PATH`), a seeded `~/.config/bunnify/bookmarks.json`, and a completed
+`bunnify --setup`. Prefer **local** mode on a laptop; use **remote** for a
+home-server install. Your base URL is in `~/.config/bunnify/config.env` as
+`BUNNIFY_BASE_URL` — Chrome must use the same URL.
 
 ## Bookmarks file
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,7 +1,5 @@
 # ⚡ Quick reference
 
-# ⚡ Quick reference
-
 Assumes `pipx install bunnify`, `pipx ensurepath` (so `~/.local/bin` is on
 `PATH`), a seeded `~/.config/bunnify/bookmarks.json`, and a completed
 `bunnify --setup`. Prefer **local** mode on a laptop; use **remote** for a

--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ palette, Chrome OpenSearch integration, and parameterized redirects.
 
 ```bash
 pipx install bunnify
+pipx ensurepath   # adds ~/.local/bin to PATH if needed (restart the shell)
 bunnify --version
 ```
+
+pipx installs `bunnify` and `bunnify-server` under **`~/.local/bin`** by default
+(or `$PIPX_BIN_DIR` when set). Ensure that directory is on your `PATH` before
+running either command.
 
 The wheel installs **`bunnify`** (CLI) and **`bunnify-server`** (Django
 server). No repository checkout or `uv` is required at runtime.
@@ -38,11 +43,18 @@ See [Configuration](docs/CONFIG.md) for overrides (`BUNNIFY_BOOKMARKS`,
 bunnify setup
 ```
 
-Setup defaults to a **local** managed server: it verifies `/health`, records
-the port, and saves settings to `~/.config/bunnify/config.env`. Choose
-**remote** to point at an existing server URL instead.
+**Laptop / daily machine:** choose **local** (default). Setup starts a managed
+server, verifies `/health`, records the port, and saves settings to
+`~/.config/bunnify/config.env`. Point Chrome at the same `BUNNIFY_BASE_URL`
+([Chrome setup](CHROME_SETUP.md)).
+
+**Home server / always-on host:** choose **remote** on client devices and enter
+that host’s URL. Prefer a centralized remote install when several machines share
+one server — not as a laptop’s only dependency if you often go offline.
 
 One-time override without saving: `bunnify --base-url https://… shortcut`.
+
+Details: [Local and remote setup](docs/LOCAL.md).
 
 ### 3. Run shortcuts
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -103,49 +103,22 @@ def ensure_ready_base_url(
             )
         return DEFAULT_BASE_URL
 
-    persist_local_preferences = preferences.mode == "local"
     if preferences.mode == "remote":
         if not preferences.base_url:
             raise ClientError("Remote mode requires BUNNIFY_BASE_URL")
-        if check_health(preferences.base_url):
-            return preferences.base_url
-        if not interactive:
-            return _wait_for_healthy_remote(
-                preferences.base_url,
-                prompt_fn=ask,
-                interactive=False,
-                print_fn=log,
-            )
-        log(f"Cannot reach a healthy Bunnify server at {preferences.base_url}")
-        try:
-            answer = ask("Use the managed local server for this run instead? [Y/n]: ")
-        except EOFError as exc:
-            raise ClientError("Connection aborted") from exc
-        if answer.strip().lower() in {"n", "no"}:
-            return _wait_for_healthy_remote(
-                preferences.base_url,
-                prompt_fn=ask,
-                interactive=True,
-                print_fn=log,
-            )
-        bookmarks = ensure_user_bookmarks(
-            environ=environ,
+        return _wait_for_healthy_remote(
+            preferences.base_url,
             prompt_fn=ask,
-            allow_prompt=True,
+            interactive=interactive,
             print_fn=log,
         )
-        preferences = ServerPreferences(
-            mode="local",
-            base_url=None,
-            local_port=None,
-        )
-    else:
-        bookmarks = ensure_user_bookmarks(
-            environ=environ,
-            prompt_fn=ask,
-            allow_prompt=interactive,
-            print_fn=log,
-        )
+
+    bookmarks = ensure_user_bookmarks(
+        environ=environ,
+        prompt_fn=ask,
+        allow_prompt=interactive,
+        print_fn=log,
+    )
     preferred_port = preferences.local_port
     while True:
         try:
@@ -168,9 +141,7 @@ def ensure_ready_base_url(
             ):
                 raise ClientError(message)
             continue
-        if persist_local_preferences and (
-            actual_port != preferences.local_port or base_url != preferences.base_url
-        ):
+        if actual_port != preferences.local_port or base_url != preferences.base_url:
             path = env_path if env_path is not None else env_file_path(environ=environ)
             save_preferences(
                 ServerPreferences(

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -670,45 +670,73 @@ class ConfigUnitTests(TestCase):
                 print_fn=ANY,
             )
 
-    def test_ensure_ready_base_url_falls_back_from_remote_to_local(self) -> None:
+    def test_ensure_ready_base_url_remote_unreachable_raises(self) -> None:
         import tempfile
         from pathlib import Path
 
         from app.cli import ensure_ready_base_url
-        from app.config import (
-            ServerPreferences,
-            load_preferences,
-            save_preferences,
-        )
+        from app.client import ClientError
+        from app.config import ServerPreferences, save_preferences
 
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "config.env"
-            bookmarks = Path(tmp) / "bookmarks.json"
-            remote_preferences = ServerPreferences(
-                mode="remote",
-                base_url="https://unavailable.example",
-                local_port=None,
-            )
-            save_preferences(remote_preferences, env_path=path)
-            with (
-                patch("app.cli.check_health", side_effect=[False, True]),
-                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
-                patch(
-                    "app.cli.ensure_local_server",
-                    return_value=("http://127.0.0.1:8123", 8123),
+            save_preferences(
+                ServerPreferences(
+                    mode="remote",
+                    base_url="https://unavailable.example",
+                    local_port=None,
                 ),
+                env_path=path,
+            )
+            with (
+                patch("app.cli.check_health", return_value=False),
+                patch("app.cli.ensure_local_server") as ensure_server,
             ):
-                result = ensure_ready_base_url(
-                    environ={"XDG_CONFIG_HOME": tmp},
-                    env_path=path,
-                    prompt_fn=lambda _message: "",
-                    allow_prompt=True,
-                    print_fn=lambda _message: None,
-                )
+                with self.assertRaises(ClientError) as raised:
+                    ensure_ready_base_url(
+                        environ={"XDG_CONFIG_HOME": tmp},
+                        env_path=path,
+                        allow_prompt=False,
+                        print_fn=lambda _message: None,
+                    )
 
-            self.assertEqual(result, "http://127.0.0.1:8123")
-            preferences = load_preferences(environ={}, env_path=path)
-            self.assertEqual(preferences, remote_preferences)
+            self.assertIn("unavailable.example", str(raised.exception))
+            ensure_server.assert_not_called()
+
+    def test_ensure_ready_base_url_remote_retry_then_abort(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.client import ClientError
+        from app.config import ServerPreferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            save_preferences(
+                ServerPreferences(
+                    mode="remote",
+                    base_url="https://unavailable.example",
+                    local_port=None,
+                ),
+                env_path=path,
+            )
+            responses = iter(["n"])
+            with (
+                patch("app.cli.check_health", return_value=False),
+                patch("app.cli.ensure_local_server") as ensure_server,
+            ):
+                with self.assertRaises(ClientError) as raised:
+                    ensure_ready_base_url(
+                        environ={"XDG_CONFIG_HOME": tmp},
+                        env_path=path,
+                        prompt_fn=lambda _message: next(responses),
+                        allow_prompt=True,
+                        print_fn=lambda _message: None,
+                    )
+
+            self.assertEqual(str(raised.exception), "Connection aborted")
+            ensure_server.assert_not_called()
 
     def test_ensure_ready_base_url_retries_with_ephemeral_port(self) -> None:
         import tempfile

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -1,6 +1,22 @@
 # Local and remote server setup
 
-Run the interactive setup after installing with pipx:
+## Which mode to choose
+
+| Situation | Mode |
+|-----------|------|
+| Laptop / desktop you carry or use daily | **local** (default) — run `bunnify-server` on the same machine as Chrome and the CLI |
+| Always-on home lab or shared household host | **remote** — one centralized server; other devices point at its URL |
+
+On a laptop, prefer **local**. Chrome OpenSearch and the CLI both talk to the same
+base URL from `~/.config/bunnify/config.env`. If that URL is a remote host and
+the host is unreachable, both the CLI and the browser fail — there is no
+automatic fallback to a local server. Re-run `bunnify setup` and choose local
+(or restore the remote) when that happens.
+
+Remote mode fits a **home server** (or similar) that stays up on the LAN/VPN so
+phones, desktops, and laptops can share one bookmark install.
+
+## Setup
 
 ```bash
 bunnify setup
@@ -15,10 +31,9 @@ Setup defaults to **local** mode. It requires an existing bookmarks file (see
 [Configuration](CONFIG.md)), prompts for a free non-privileged listening port
 (default `8000`, or `0` for an OS-assigned port), starts a managed server,
 verifies `/health`, and records the selected port in `config.env` and under
-`$BUNNIFY_DATA_DIR/run/` (for example `~/scratch/bunnify/run` on service hosts). Remote mode prompts for a URL and saves it only
-after its `/health` response is HTTP 200 with body `ok`. If a configured remote
-server later becomes unavailable, the interactive CLI offers to use the managed
-local server for that run without replacing the saved remote preference.
+`$BUNNIFY_DATA_DIR/run/` (for example `~/scratch/bunnify/run` on service hosts).
+Remote mode prompts for a URL and saves it only after its `/health` response is
+HTTP 200 with body `ok`.
 
 Verified settings are stored in `~/.config/bunnify/config.env` (or
 `$XDG_CONFIG_HOME/bunnify/config.env`):
@@ -80,3 +95,7 @@ port 8000 is free unless you override `--port`.
   ephemeral port. Noninteractive mode never kills an unrelated process.
 - Stale managed process: run the manual `--stop --pid-dir` command above and
   rerun setup.
+- Remote unreachable: the CLI does not switch to local automatically. Fix the
+  network/server or run `bunnify setup` and choose **local** (laptop) or a
+  healthy remote URL. Update Chrome’s search engine to the same
+  `BUNNIFY_BASE_URL` (see [CHROME_SETUP](../CHROME_SETUP.md)).


### PR DESCRIPTION
## Summary
- Document laptop → **local** vs home/always-on host → **remote**; Chrome must match `BUNNIFY_BASE_URL`
- Remove CLI remote→local “use managed server for this run” fallback (unreachable remotes fail/retry only)
- Document pipx `ensurepath` / `~/.local/bin` on `PATH`

Closes #273

## Test plan
- [x] `uv run ruff check .` / `format --check` / `pyright --warnings`
- [x] `./test_bunnify` (incl. new remote-unreachable tests)
- [x] `./test_integration`
- [ ] Confirm remote mode no longer offers local fallback when remote is down
- [ ] Confirm docs read clearly for laptop vs home-server install


Made with [Cursor](https://cursor.com)