### PR TITLE
feat: bunnify onboard + PyPI next-step docs

### DIFF
--- a/CHROME_SETUP.md
+++ b/CHROME_SETUP.md
@@ -1,17 +1,18 @@
-# Chrome search engine setup
+# Chrome / Edge search engine setup
 
-Configure Bunnify as a Chrome search engine for fast bookmark access from the
-address bar.
+Configure Bunnify as a Chrome or Edge search engine for fast bookmark access
+from the address bar. Both browsers use the same OpenSearch / site-search URL
+pattern.
 
-**Prefer local on a laptop.** Point Chrome at the same machine’s managed server
-(`bunnify setup` → **local**). Use a remote URL only when you intentionally
+**Prefer local on a laptop.** Point the browser at the same machine’s managed
+server (`bunnify setup` → **local**). Use a remote URL only when you intentionally
 share a centralized/home-server install — and keep that host reachable whenever
 you use the address bar.
 
 **Prerequisites:** Bunnify server running (local `bunnify-server` / `bunnify setup`,
 or a reachable remote). Setup saves the verified base URL to
-`~/.config/bunnify/config.env` as `BUNNIFY_BASE_URL`. Chrome’s search-engine URL
-must match that value; if you change mode or port, update Chrome too.
+`~/.config/bunnify/config.env` as `BUNNIFY_BASE_URL`. The browser search-engine
+URL must match that value; if you change mode or port, update the engine too.
 
 Read your base URL (use it in the steps below instead of hard-coded `:8000`):
 
@@ -21,7 +22,9 @@ grep '^BUNNIFY_BASE_URL=' ~/.config/bunnify/config.env | cut -d= -f2-
 
 ## Recommended: manual OpenSearch URL
 
-1. Open `chrome://settings/searchEngines`
+1. Open search-engine settings:
+   - Chrome: `chrome://settings/searchEngines`
+   - Edge: `edge://settings/searchEngines`
 2. Add a site search entry:
    - **Search engine:** `Bunnify`
    - **Keyword:** `b` (or your preference)
@@ -38,10 +41,10 @@ Examples in the address bar (with keyword `b`):
 ## Automatic detection
 
 1. Start the server
-2. Visit `<BUNNIFY_BASE_URL>/` in Chrome (same value as above)
-3. Chrome may offer to add the engine from `/opensearch.xml`
+2. Visit `<BUNNIFY_BASE_URL>/` in Chrome or Edge (same value as above)
+3. The browser may offer to add the engine from `/opensearch.xml`
 
-Manual setup is more reliable across Chrome versions.
+Manual setup is more reliable across browser versions.
 
 ## IPv6 / localhost
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -18,6 +18,7 @@ curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.
 
 ```bash
 bunnify                         # interactive REPL
+bunnify onboard                 # post-install / upgrade checklist
 bunnify --setup                 # configure local or remote server
 bunnify gh                      # open a shortcut (example key from bunnify.json.example)
 bunnify pr the-hcma/bunnify 272 # parameterized shortcut (repo + PR number)

--- a/README.md
+++ b/README.md
@@ -15,10 +15,21 @@ bunnify --version
 
 pipx installs `bunnify` and `bunnify-server` under **`~/.local/bin`** by default
 (or `$PIPX_BIN_DIR` when set). Ensure that directory is on your `PATH` before
-running either command.
+running either command. Prefer the pipx apps over any checkout
+`./scripts/bunnify` still on `PATH`.
 
 The wheel installs **`bunnify`** (CLI) and **`bunnify-server`** (Django
 server). No repository checkout or `uv` is required at runtime.
+
+### After install
+
+1. **Seed bookmarks and run setup** (starts or points at a server) — follow
+   [Quick start](#quick-start) below, or the full guide:
+   [Local and remote server setup](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md)
+2. **Configure Chrome or Edge** as a site search / OpenSearch engine:
+   [Chrome / Edge setup](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md)
+
+Source and docs: [github.com/the-hcma/bunnify](https://github.com/the-hcma/bunnify).
 
 ## Quick start
 
@@ -45,8 +56,9 @@ bunnify setup
 
 **Laptop / daily machine:** choose **local** (default). Setup starts a managed
 server, verifies `/health`, records the port, and saves settings to
-`~/.config/bunnify/config.env`. Point Chrome at the same `BUNNIFY_BASE_URL`
-([Chrome setup](CHROME_SETUP.md)).
+`~/.config/bunnify/config.env`. Point Chrome or Edge at the same
+`BUNNIFY_BASE_URL`
+([Chrome / Edge setup](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md)).
 
 **Home server / always-on host:** choose **remote** on client devices and enter
 that host’s URL. Prefer a centralized remote install when several machines share
@@ -54,7 +66,8 @@ one server — not as a laptop’s only dependency if you often go offline.
 
 One-time override without saving: `bunnify --base-url https://… shortcut`.
 
-Details: [Local and remote setup](docs/LOCAL.md).
+Details:
+[Local and remote setup](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md).
 
 ### 3. Run shortcuts
 
@@ -72,7 +85,8 @@ Unknown keys exit non-zero in direct mode (no search-engine fallback).
 
 - **CLI / REPL** — fuzzy Tab completion, fzf mode, Vim/Emacs edit keys
 - **Web** — `/cmd/` command palette, `/list/` browser, smart `/search/`
-- **Chrome** — OpenSearch at `/opensearch.xml` ([setup guide](CHROME_SETUP.md))
+- **Chrome / Edge** — OpenSearch at `/opensearch.xml`
+  ([setup guide](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md))
 - **Parameters** — URLs with `#{name}` placeholders and optional defaults
 - **Copilot reviews** — `rpr` shortcut streams in-app PR reviews
 - **Validation** — JSON Schema on load; reserved keys `h` / `help`
@@ -92,7 +106,7 @@ curl --max-time 2 http://127.0.0.1:8000/health
 ```
 
 `bunnify setup` starts a managed local server for daily CLI use. Details:
-[Local and remote setup](docs/LOCAL.md).
+[Local and remote setup](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md).
 
 **Linux production:** [systemd user service](docs/SYSTEMD.md) via
 `setup-service` from [repository-helpers](https://github.com/the-hcma/repository-helpers).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ palette, Chrome OpenSearch integration, and parameterized redirects.
 pipx install bunnify
 pipx ensurepath   # adds ~/.local/bin to PATH if needed (restart the shell)
 bunnify --version
+bunnify onboard   # print bookmarks / setup / Chrome next steps
 ```
 
 pipx installs `bunnify` and `bunnify-server` under **`~/.local/bin`** by default
@@ -21,44 +22,38 @@ running either command. Prefer the pipx apps over any checkout
 The wheel installs **`bunnify`** (CLI) and **`bunnify-server`** (Django
 server). No repository checkout or `uv` is required at runtime.
 
-### After install
+### After install or upgrade
 
-Do these once so the CLI, server, and browser all work together:
+pipx does not print package docs after install. Run:
 
-1. **Create your bookmarks file** at
-   `~/.config/bunnify/bookmarks.json` (required before the server starts):
+```bash
+bunnify onboard
+```
 
-   ```bash
-   mkdir -p ~/.config/bunnify
-   curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.example \
-     -o ~/.config/bunnify/bookmarks.json
-   # edit ~/.config/bunnify/bookmarks.json with your shortcuts
-   ```
+That prints the ready-to-go checklist (bookmarks path, `bunnify setup`,
+Chrome/Edge, and upgrade). Same text:
 
-   Override path with `BUNNIFY_BOOKMARKS` or `XDG_CONFIG_HOME` — see
-   [Configuration](https://github.com/the-hcma/bunnify/blob/main/docs/CONFIG.md).
+```bash
+bunnify --onboard
+```
 
-2. **Configure and start the server** (local on a laptop; remote only for a
-   home/always-on host):
+Summary of what it covers:
 
-   ```bash
-   bunnify setup
-   ```
-
-   Full guide:
-   [Local and remote server setup](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md)
-
-3. **Configure Chrome or Edge** as a site search engine using the same
-   `BUNNIFY_BASE_URL` from `~/.config/bunnify/config.env`:
-   [Chrome / Edge setup](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md)
-
-4. **Try it:** `bunnify gh` or type `b gh` in the address bar (if keyword is `b`).
+1. **Bookmarks** at `~/.config/bunnify/bookmarks.json` (required before the
+   server starts) — seed from
+   [bunnify.json.example](https://github.com/the-hcma/bunnify/blob/main/bunnify.json.example)
+2. **`bunnify setup`** — local on a laptop; remote for a home/always-on host  
+   [LOCAL.md](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md)
+3. **Chrome / Edge** — match `BUNNIFY_BASE_URL` from `config.env`  
+   [CHROME_SETUP.md](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md)
+4. **Try it:** `bunnify gh` or address-bar keyword (e.g. `b gh`)
 
 ### Upgrade
 
 ```bash
 pipx upgrade bunnify
 bunnify --version
+bunnify onboard    # refresh next-step reminders
 ```
 
 Bookmarks and `~/.config/bunnify/config.env` are user data — upgrades do not

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.
 # edit ~/.config/bunnify/bookmarks.json with your shortcuts
 ```
 
-See [Configuration](docs/CONFIG.md) for overrides (`BUNNIFY_BOOKMARKS`,
-`XDG_CONFIG_HOME`).
+See [Configuration](https://github.com/the-hcma/bunnify/blob/main/docs/CONFIG.md)
+for overrides (`BUNNIFY_BOOKMARKS`, `XDG_CONFIG_HOME`).
 
 ### 2. Configure local or remote mode
 
@@ -139,10 +139,13 @@ curl --max-time 2 http://127.0.0.1:8000/health
 `bunnify setup` starts a managed local server for daily CLI use. Details:
 [Local and remote setup](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md).
 
-**Linux production:** [systemd user service](docs/SYSTEMD.md) via
-`setup-service` from [repository-helpers](https://github.com/the-hcma/repository-helpers).
+**Linux production:**
+[systemd user service](https://github.com/the-hcma/bunnify/blob/main/docs/SYSTEMD.md)
+via `setup-service` from
+[repository-helpers](https://github.com/the-hcma/repository-helpers).
 
-**macOS:** [LaunchAgent example](etc/launchd/com.thehcma.bunnify.plist.example).
+**macOS:**
+[LaunchAgent example](https://github.com/the-hcma/bunnify/blob/main/etc/launchd/com.thehcma.bunnify.plist.example).
 
 ## Web usage
 
@@ -194,8 +197,9 @@ cp bunnify.json.example ~/.config/bunnify/bookmarks.json
 ./test_bunnify
 ```
 
-Full guidelines: [CONTRIBUTING.md](CONTRIBUTING.md). Quality gates:
-`./scripts/checks`.
+Full guidelines:
+[CONTRIBUTING.md](https://github.com/the-hcma/bunnify/blob/main/CONTRIBUTING.md).
+Quality gates: `./scripts/checks`.
 
 Wrappers under `./scripts/` prefer `uv run` when `uv` is on `PATH`, otherwise
 the checkout `.venv` (same entry points systemd uses on service hosts).
@@ -204,12 +208,12 @@ the checkout `.venv` (same entry points systemd uses on service hosts).
 
 | Doc | Audience |
 |-----|----------|
-| [CONFIG.md](docs/CONFIG.md) | XDG paths and environment variables |
-| [LOCAL.md](docs/LOCAL.md) | Local vs remote setup, ports, LaunchAgent |
-| [SYSTEMD.md](docs/SYSTEMD.md) | Linux user service |
-| [CHROME_SETUP.md](CHROME_SETUP.md) | Browser search engine |
-| [QUICK_REFERENCE.md](QUICK_REFERENCE.md) | Cheat sheet |
-| [RELEASING.md](docs/RELEASING.md) | Maintainers: PyPI releases |
+| [CONFIG.md](https://github.com/the-hcma/bunnify/blob/main/docs/CONFIG.md) | XDG paths and environment variables |
+| [LOCAL.md](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md) | Local vs remote setup, ports, LaunchAgent |
+| [SYSTEMD.md](https://github.com/the-hcma/bunnify/blob/main/docs/SYSTEMD.md) | Linux user service |
+| [CHROME_SETUP.md](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md) | Browser search engine |
+| [QUICK_REFERENCE.md](https://github.com/the-hcma/bunnify/blob/main/QUICK_REFERENCE.md) | Cheat sheet |
+| [RELEASING.md](https://github.com/the-hcma/bunnify/blob/main/docs/RELEASING.md) | Maintainers: PyPI releases |
 
 ## Troubleshooting
 
@@ -242,8 +246,10 @@ bunnify-server --stop --pid-dir ~/.local/share/bunnify/run
 
 ## Releasing
 
-Maintainers: [docs/RELEASING.md](docs/RELEASING.md) (Release Please + PyPI).
+Maintainers:
+[docs/RELEASING.md](https://github.com/the-hcma/bunnify/blob/main/docs/RELEASING.md)
+(Release Please + PyPI).
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](https://github.com/the-hcma/bunnify/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -23,11 +23,47 @@ server). No repository checkout or `uv` is required at runtime.
 
 ### After install
 
-1. **Seed bookmarks and run setup** (starts or points at a server) — follow
-   [Quick start](#quick-start) below, or the full guide:
+Do these once so the CLI, server, and browser all work together:
+
+1. **Create your bookmarks file** at
+   `~/.config/bunnify/bookmarks.json` (required before the server starts):
+
+   ```bash
+   mkdir -p ~/.config/bunnify
+   curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.example \
+     -o ~/.config/bunnify/bookmarks.json
+   # edit ~/.config/bunnify/bookmarks.json with your shortcuts
+   ```
+
+   Override path with `BUNNIFY_BOOKMARKS` or `XDG_CONFIG_HOME` — see
+   [Configuration](https://github.com/the-hcma/bunnify/blob/main/docs/CONFIG.md).
+
+2. **Configure and start the server** (local on a laptop; remote only for a
+   home/always-on host):
+
+   ```bash
+   bunnify setup
+   ```
+
+   Full guide:
    [Local and remote server setup](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md)
-2. **Configure Chrome or Edge** as a site search / OpenSearch engine:
+
+3. **Configure Chrome or Edge** as a site search engine using the same
+   `BUNNIFY_BASE_URL` from `~/.config/bunnify/config.env`:
    [Chrome / Edge setup](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md)
+
+4. **Try it:** `bunnify gh` or type `b gh` in the address bar (if keyword is `b`).
+
+### Upgrade
+
+```bash
+pipx upgrade bunnify
+bunnify --version
+```
+
+Bookmarks and `~/.config/bunnify/config.env` are user data — upgrades do not
+overwrite them. After a major server change, re-run `bunnify setup` only if
+docs or release notes say so.
 
 Source and docs: [github.com/the-hcma/bunnify](https://github.com/the-hcma/bunnify).
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -27,6 +27,7 @@ from app.config import (
     ENV_VAR,
     MIN_LOCAL_PORT,
     ServerPreferences,
+    default_bookmarks_path,
     ensure_user_bookmarks,
     env_file_path,
     legacy_env_file_path,
@@ -153,6 +154,44 @@ def ensure_ready_base_url(
                 environ=environ,
             )
         return base_url
+
+
+def format_onboarding_text() -> str:
+    """Return post-install / post-upgrade next steps for the terminal."""
+    bookmarks = default_bookmarks_path()
+    config = env_file_path()
+    return "\n".join(
+        [
+            "Bunnify — next steps after install or upgrade",
+            "",
+            "1. Create your bookmarks file (required before the server starts):",
+            f"     mkdir -p {bookmarks.parent}",
+            "     curl -fsSL \\",
+            "       https://raw.githubusercontent.com/the-hcma/bunnify/"
+            "main/bunnify.json.example \\",
+            f"       -o {bookmarks}",
+            f"     # edit {bookmarks}",
+            "",
+            "2. Configure and start the server (local on a laptop; remote for a",
+            "   home/always-on host):",
+            "     bunnify setup",
+            "   Guide: https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md",
+            "",
+            "3. Configure Chrome or Edge using BUNNIFY_BASE_URL from:",
+            f"     {config}",
+            "   Guide: https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md",
+            "",
+            "4. Try it:  bunnify gh   (or address-bar keyword, e.g. b gh)",
+            "",
+            "Upgrade later:",
+            "     pipx upgrade bunnify",
+            "     bunnify --version",
+            "   Bookmarks and config.env are kept across upgrades.",
+            "",
+            "Docs: https://github.com/the-hcma/bunnify",
+            "Re-print this message anytime:  bunnify onboard",
+        ]
+    )
 
 
 def open_url(url: str, *, opener: Callable[[str], bool] | None = None) -> None:
@@ -822,6 +861,12 @@ def _run(
     ),
 )
 @click.option(
+    "--onboard",
+    "onboard_requested",
+    is_flag=True,
+    help="Print post-install / upgrade next steps (also: `bunnify onboard`).",
+)
+@click.option(
     "--setup",
     "setup_requested",
     is_flag=True,
@@ -839,6 +884,7 @@ def main(
     color_mode: str,
     edit_mode: str | None,
     env_file: Path | None,
+    onboard_requested: bool,
     setup_requested: bool,
 ) -> None:
     """
@@ -852,6 +898,11 @@ def main(
     Direct:
       ./scripts/bunnify vault
       ./scripts/bunnify pr 12345
+
+    \b
+    After pipx install or upgrade:
+      bunnify onboard
+      bunnify --onboard
 
     \b
     Server setup (`setup` is a reserved shortcut name):
@@ -871,6 +922,10 @@ def main(
     """
     if shortcut_args == ("version",):
         click.echo(BUILD_INFO)
+        return
+
+    if onboard_requested or shortcut_args == ("onboard",):
+        click.echo(format_onboarding_text())
         return
 
     theme = Theme(enabled=stdout_color_enabled(color_mode.lower()))

--- a/app/cli.py
+++ b/app/cli.py
@@ -156,6 +156,30 @@ def ensure_ready_base_url(
         return base_url
 
 
+def format_browser_setup_text(base_url: str) -> str:
+    """Return Chrome/Edge OpenSearch instructions for ``base_url``."""
+    normalized = base_url.rstrip("/")
+    search_url = f"{normalized}/search/?q=%s"
+    return "\n".join(
+        [
+            "Configure Chrome or Edge for address-bar shortcuts",
+            "(use this exact URL — it must match the server you just set up):",
+            "",
+            "1. Open search-engine settings:",
+            "     Chrome → chrome://settings/searchEngines",
+            "     Edge   → edge://settings/searchEngines",
+            "2. Add (or edit) a site search entry:",
+            "     Search engine name: Bunnify",
+            "     Shortcut / keyword: b",
+            f"     URL: {search_url}",
+            "3. Save, then in the address bar type: b gh",
+            "",
+            f"Saved server base URL: {normalized}",
+            "Guide: https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md",
+        ]
+    )
+
+
 def format_onboarding_text() -> str:
     """Return post-install / post-upgrade next steps for the terminal."""
     bookmarks = default_bookmarks_path()
@@ -246,16 +270,26 @@ def run_setup(
     environ: dict[str, str] | None = None,
     env_path: Path | None = None,
     print_fn: Callable[[str], None] | None = None,
+    theme: Theme | None = None,
 ) -> str:
     """Interactively configure a verified local or remote Bunnify server."""
     ask = prompt_fn or input
     log = print_fn or click.echo
+    colors = theme if theme is not None else Theme(enabled=False)
     path = env_path if env_path is not None else env_file_path(environ=environ)
     existing = load_preferences(environ=environ, env_path=path)
 
+    log(colors.header("Bunnify setup"))
+    log(colors.dim("Press Enter to accept the value in [brackets]."))
+
     while True:
         try:
-            answer = ask("Server mode, local or remote? [local]: ")
+            answer = ask(
+                colors.brand("Server mode")
+                + colors.dim(" [local]")
+                + colors.dim(" (Enter accepts)")
+                + ": "
+            )
         except EOFError as exc:
             raise ClientError("Setup aborted") from exc
         mode = answer.strip().lower() or "local"
@@ -265,7 +299,7 @@ def run_setup(
         if mode in {"r", "remote"}:
             mode = "remote"
             break
-        log("Please enter 'local' or 'remote'.")
+        log(colors.warn("Please enter 'local' or 'remote'."))
 
     if mode == "local":
         bookmarks = ensure_user_bookmarks(
@@ -282,6 +316,7 @@ def run_setup(
                 else None
             ),
             print_fn=log,
+            theme=colors,
         )
         while True:
             try:
@@ -291,7 +326,10 @@ def run_setup(
                     bookmarks=bookmarks,
                 )
             except (OSError, RuntimeError, ValueError) as exc:
-                if _retry_requested(ask, f"Local server failed: {exc}\nRetry? [Y/n]: "):
+                if _retry_requested(
+                    ask,
+                    colors.warn(f"Local server failed: {exc}\n") + "Retry? [Y/n]: ",
+                ):
                     preferred_port = None
                     continue
                 raise ClientError("Setup aborted; settings were not changed") from exc
@@ -302,11 +340,22 @@ def run_setup(
                     local_port=actual_port,
                 )
                 save_preferences(preferences, env_path=path, environ=environ)
-                log(f"Configured local Bunnify server at {base_url}")
+                log(
+                    colors.ok(
+                        f"✓ Port {actual_port} is free (or already running "
+                        "Bunnify) and /health returned ok"
+                    )
+                )
+                log(colors.ok(f"✓ Configured local Bunnify server at {base_url}"))
+                log("")
+                log(colors.header("Browser"))
+                for line in format_browser_setup_text(base_url).splitlines():
+                    log(line)
                 return base_url
             if not _retry_requested(
                 ask,
-                f"Health check failed for {base_url}.\nRetry? [Y/n]: ",
+                colors.warn(f"Health check failed for {base_url}.\n")
+                + "Retry? [Y/n]: ",
             ):
                 raise ClientError("Setup aborted; settings were not changed")
 
@@ -317,7 +366,12 @@ def run_setup(
     )
     while True:
         try:
-            answer = ask(f"Remote Bunnify URL [{suggestion}]: ")
+            answer = ask(
+                colors.brand("Remote Bunnify URL")
+                + colors.dim(f" [{suggestion}]")
+                + colors.dim(" (Enter accepts)")
+                + ": "
+            )
         except EOFError as exc:
             raise ClientError("Setup aborted; settings were not changed") from exc
         base_url = resolve_base_url(
@@ -331,11 +385,17 @@ def run_setup(
                 local_port=None,
             )
             save_preferences(preferences, env_path=path, environ=environ)
-            log(f"Configured remote Bunnify server at {base_url}")
+            log(colors.ok(f"✓ Health check passed for {base_url}"))
+            log(colors.ok(f"✓ Configured remote Bunnify server at {base_url}"))
+            log("")
+            log(colors.header("Browser"))
+            for line in format_browser_setup_text(base_url).splitlines():
+                log(line)
             return base_url
         if not _retry_requested(
             ask,
-            f"Health check failed for {base_url}.\nTry another URL? [Y/n]: ",
+            colors.warn(f"Health check failed for {base_url}.\n")
+            + "Try another URL? [Y/n]: ",
         ):
             raise ClientError("Setup aborted; settings were not changed")
 
@@ -350,12 +410,16 @@ def build_query_from_args(args: tuple[str, ...]) -> str:
     return " ".join(args).strip()
 
 
-def _retry_requested(prompt_fn: Callable[[str], str], message: str) -> bool:
-    try:
-        answer = prompt_fn(message)
-    except EOFError:
-        return False
-    return answer.strip().lower() not in {"abort", "n", "no", "q", "quit"}
+def _find_usable_local_port(start: int) -> int:
+    """Return the next free port or healthy Bunnify at or above ``start``."""
+    candidate = max(start, MIN_LOCAL_PORT)
+    while candidate <= 65535:
+        if port_is_free(candidate):
+            return candidate
+        if check_health(f"http://127.0.0.1:{candidate}"):
+            return candidate
+        candidate += 1
+    raise ClientError(f"No free local port found between {MIN_LOCAL_PORT} and 65535")
 
 
 def _prompt_local_port(
@@ -363,16 +427,23 @@ def _prompt_local_port(
     *,
     existing_port: int | None,
     print_fn: Callable[[str], None] | None = None,
+    theme: Theme | None = None,
 ) -> int:
     """Ask for a free non-privileged local server port."""
     log = print_fn or (lambda _message: None)
+    colors = theme if theme is not None else Theme(enabled=False)
     default_port = existing_port if existing_port is not None else 8000
     if default_port != 0 and not MIN_LOCAL_PORT <= default_port <= 65535:
         default_port = 8000
 
     while True:
         try:
-            answer = prompt_fn(f"Local server port [{default_port}]: ")
+            answer = prompt_fn(
+                colors.brand("Local server port")
+                + colors.dim(f" [{default_port}]")
+                + colors.dim(" (Enter accepts)")
+                + ": "
+            )
         except EOFError as exc:
             raise ClientError("Setup aborted") from exc
         stripped = answer.strip()
@@ -383,24 +454,41 @@ def _prompt_local_port(
             try:
                 port = int(stripped)
             except ValueError:
-                log(f"Invalid port: {stripped!r}. Try again.")
+                log(colors.warn(f"Invalid port: {stripped!r}. Try again."))
                 continue
         assert port is not None
         if port == 0:
+            log(colors.dim("Using an OS-assigned ephemeral port (0)."))
             return 0
         if not MIN_LOCAL_PORT <= port <= 65535:
             log(
-                f"Port must be {MIN_LOCAL_PORT}-65535 "
-                "(or 0 for an OS-assigned port). Try again."
+                colors.warn(
+                    f"Port must be {MIN_LOCAL_PORT}-65535 "
+                    "(or 0 for an OS-assigned port). Try again."
+                )
             )
             continue
-        if not port_is_free(port):
-            if check_health(f"http://127.0.0.1:{port}"):
-                return port
-            log(f"Port {port} is already in use. Choose another port.")
-            default_port = port
-            continue
-        return port
+        if port_is_free(port):
+            log(colors.ok(f"✓ Port {port} is free"))
+            return port
+        if check_health(f"http://127.0.0.1:{port}"):
+            log(colors.ok(f"✓ Port {port} is already serving a healthy Bunnify"))
+            return port
+        log(colors.warn(f"Port {port} is already in use. Searching for a free port…"))
+        found = _find_usable_local_port(port + 1)
+        if port_is_free(found):
+            log(colors.ok(f"✓ Found free port {found}"))
+        else:
+            log(colors.ok(f"✓ Found healthy Bunnify on port {found}"))
+        return found
+
+
+def _retry_requested(prompt_fn: Callable[[str], str], message: str) -> bool:
+    try:
+        answer = prompt_fn(message)
+    except EOFError:
+        return False
+    return answer.strip().lower() not in {"abort", "n", "no", "q", "quit"}
 
 
 def _wait_for_healthy_remote(
@@ -900,7 +988,7 @@ def main(
       ./scripts/bunnify pr 12345
 
     \b
-    After pipx install or upgrade:
+    After pipx install or upgrade (`onboard` is a reserved shortcut name):
       bunnify onboard
       bunnify --onboard
 
@@ -948,6 +1036,7 @@ def main(
                 prompt_fn=prompt_fn,
                 env_path=env_file,
                 print_fn=click.echo,
+                theme=theme,
             )
             return
         resolved_url = ensure_ready_base_url(

--- a/app/config.py
+++ b/app/config.py
@@ -319,8 +319,11 @@ def ensure_user_bookmarks(
         f"{target}\n"
         "Create it manually before starting the server, for example:\n"
         f"  mkdir -p {target.parent}\n"
-        f"  cp /path/to/your/bookmarks.json {target}\n"
-        "Or set BUNNIFY_BOOKMARKS to an existing file path."
+        "  curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/"
+        "bunnify.json.example \\\n"
+        f"    -o {target}\n"
+        "Or set BUNNIFY_BOOKMARKS to an existing file path.\n"
+        "Full checklist: bunnify onboard"
     )
 
 

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1339,6 +1339,20 @@ class ConfigUnitTests(TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         setup.assert_called_once()
 
+    def test_onboard_prints_next_steps(self) -> None:
+        from app.cli import main
+
+        result = CliRunner().invoke(main, ["onboard"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("bookmarks.json", result.output)
+        self.assertIn("bunnify setup", result.output)
+        self.assertIn("CHROME_SETUP.md", result.output)
+        self.assertIn("pipx upgrade bunnify", result.output)
+
+        flagged = CliRunner().invoke(main, ["--onboard"])
+        self.assertEqual(flagged.exit_code, 0)
+        self.assertIn("bunnify setup", flagged.output)
+
     def test_base_url_prepends_http_scheme(self) -> None:
         from app.config import resolve_base_url
 

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -992,6 +992,7 @@ class ConfigUnitTests(TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "config.env"
             bookmarks = Path(tmp) / "bookmarks.json"
+            messages: list[str] = []
             with (
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
                 patch(
@@ -1005,11 +1006,18 @@ class ConfigUnitTests(TestCase):
                     prompt_fn=lambda _message: "",
                     environ={"XDG_CONFIG_HOME": tmp},
                     env_path=path,
-                    print_fn=lambda _message: None,
+                    print_fn=messages.append,
                 )
 
             self.assertEqual(result, "http://127.0.0.1:8123")
             self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
+            joined = "\n".join(messages)
+            self.assertIn("Port 8000 is free", joined)
+            self.assertIn("Configured local Bunnify server", joined)
+            self.assertIn("http://127.0.0.1:8123/search/?q=%s", joined)
+            self.assertIn("chrome://settings/searchEngines", joined)
+            self.assertIn("edge://settings/searchEngines", joined)
+            self.assertIn("Shortcut / keyword: b", joined)
             preferences = load_preferences(environ={}, env_path=path)
             self.assertIsNotNone(preferences)
             assert preferences is not None
@@ -1103,7 +1111,7 @@ class ConfigUnitTests(TestCase):
             assert preferences is not None
             self.assertEqual(preferences.local_port, 8765)
 
-    def test_setup_local_reprompts_when_default_port_busy(self) -> None:
+    def test_setup_local_finds_next_free_port_when_busy(self) -> None:
         import tempfile
         from pathlib import Path
 
@@ -1112,23 +1120,20 @@ class ConfigUnitTests(TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "config.env"
             bookmarks = Path(tmp) / "bookmarks.json"
-            responses = iter(["local", "", "8765"])
+            responses = iter(["local", ""])
             messages: list[str] = []
+
+            def port_free(port: int) -> bool:
+                return port != 8000
+
             with (
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
                 patch(
                     "app.cli.ensure_local_server",
-                    return_value=("http://127.0.0.1:8765", 8765),
+                    return_value=("http://127.0.0.1:8001", 8001),
                 ) as ensure_server,
-                patch("app.cli.check_health", return_value=True),
-                patch(
-                    "app.cli.check_health",
-                    side_effect=lambda url: ":8765" in url,
-                ),
-                patch(
-                    "app.cli.port_is_free",
-                    side_effect=[False, True],
-                ),
+                patch("app.cli.check_health", side_effect=lambda url: ":8001" in url),
+                patch("app.cli.port_is_free", side_effect=port_free),
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
@@ -1137,9 +1142,51 @@ class ConfigUnitTests(TestCase):
                     print_fn=messages.append,
                 )
 
-            self.assertEqual(result, "http://127.0.0.1:8765")
-            self.assertEqual(ensure_server.call_args.kwargs["port"], 8765)
-            self.assertTrue(any("already in use" in message for message in messages))
+            self.assertEqual(result, "http://127.0.0.1:8001")
+            self.assertEqual(ensure_server.call_args.kwargs["port"], 8001)
+            joined = "\n".join(messages)
+            self.assertIn("already in use", joined)
+            self.assertIn("Found free port 8001", joined)
+            self.assertIn("http://127.0.0.1:8001/search/?q=%s", joined)
+            self.assertIn("chrome://settings/searchEngines", joined)
+            self.assertIn("edge://settings/searchEngines", joined)
+            self.assertIn("Shortcut / keyword: b", joined)
+
+    def test_setup_local_scan_reuses_healthy_bunnify(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import run_setup
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            responses = iter(["local", ""])
+            messages: list[str] = []
+
+            def port_free(port: int) -> bool:
+                return port not in {8000, 8001}
+
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8001", 8001),
+                ) as ensure_server,
+                patch("app.cli.check_health", side_effect=lambda url: ":8001" in url),
+                patch("app.cli.port_is_free", side_effect=port_free),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    print_fn=messages.append,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8001")
+            self.assertEqual(ensure_server.call_args.kwargs["port"], 8001)
+            joined = "\n".join(messages)
+            self.assertIn("Found healthy Bunnify on port 8001", joined)
 
     def test_setup_local_accepts_port_with_healthy_server(self) -> None:
         import tempfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,14 @@ dependencies = [
 bunnify = "app.cli:main"
 bunnify-server = "app.server_cli:main"
 
+[project.urls]
+Changelog = "https://github.com/the-hcma/bunnify/blob/main/CHANGELOG.md"
+"Chrome / Edge setup" = "https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md"
+Homepage = "https://github.com/the-hcma/bunnify"
+Issues = "https://github.com/the-hcma/bunnify/issues"
+Repository = "https://github.com/the-hcma/bunnify"
+"Server setup" = "https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- **`bunnify onboard` / `--onboard`** prints bookmarks path, setup, Chrome/Edge, and upgrade steps (pipx cannot run post-install hooks)
- README documents `bunnify onboard` after install/upgrade; PyPI `project.urls` + absolute GitHub links
- Missing-bookmarks error points at `bunnify onboard`
- Chrome/Edge covered in CHROME_SETUP

## Test plan
- [x] `bunnify onboard` / `--onboard` tests
- [ ] After `pipx install` / `upgrade`, run `bunnify onboard` and follow the checklist
- [ ] PyPI page links look right after the next release