### PR TITLE
feat: web UI version under logo + Edge/bunnylol welcome

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -18,10 +18,20 @@ from app.config import data_dir
 from app.local_server import ensure_local_server, stop_local_server
 from app.server_cli import _is_bunnify_command
 from app.server_cli import main as server_main
-from app.version import build_info, build_version, git_commit, package_version
+from app.version import (
+    build_info,
+    build_version,
+    format_cli_version_line,
+    get_build_info,
+    git_commit,
+    package_version,
+)
 
 
 class BuildInfoTests(SimpleTestCase):
+    def tearDown(self) -> None:
+        get_build_info.cache_clear()
+
     @mock.patch("app.version.git_commit", return_value="abcdef1")
     @mock.patch("app.version.package_version", return_value="0.2.3")
     def test_build_info_formats_version_and_commit(
@@ -29,13 +39,18 @@ class BuildInfoTests(SimpleTestCase):
         _package_version: mock.Mock,
         _git_commit: mock.Mock,
     ) -> None:
-        self.assertEqual(build_info(), "bunnify 0.2.3 (commit abcdef1)")
-        self.assertEqual(build_version(), "0.2.3 (commit abcdef1)")
+        get_build_info.cache_clear()
+        self.assertEqual(build_info(), "bunnify 0.2.3 (abcdef1)")
+        self.assertEqual(build_version(), "0.2.3 (abcdef1)")
+        self.assertEqual(
+            format_cli_version_line(prog="bunnify-server"),
+            "bunnify-server 0.2.3 (abcdef1)",
+        )
 
     def test_git_commit_prefers_environment(self) -> None:
         self.assertEqual(
             git_commit(environ={"BUNNIFY_GIT_SHA": "abcdef1234567890"}),
-            "abcdef1",
+            "abcdef123456",
         )
 
     def test_package_version_falls_back_to_pyproject(self) -> None:

--- a/app/version.py
+++ b/app/version.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import tomllib
 from collections.abc import Mapping
+from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
@@ -14,12 +15,25 @@ PACKAGE_NAME = "bunnify"
 
 def build_info() -> str:
     """Return a human-readable package version and source revision."""
-    return f"{PACKAGE_NAME} {build_version()}"
+    return format_cli_version_line(prog=PACKAGE_NAME)
 
 
 def build_version() -> str:
     """Return the package version and source revision without a program name."""
-    return f"{package_version()} (commit {git_commit()})"
+    package, commit = get_build_info()
+    return f"{package} ({commit})"
+
+
+def format_cli_version_line(*, prog: str) -> str:
+    """One-line version string for ``--version`` on console entry points."""
+    package, commit = get_build_info()
+    return f"{prog} {package} ({commit})"
+
+
+@lru_cache(maxsize=1)
+def get_build_info() -> tuple[str, str]:
+    """Return ``(package_version, commit_short_or_unknown)`` once per process."""
+    return (package_version(), git_commit())
 
 
 def git_commit(
@@ -29,14 +43,15 @@ def git_commit(
 ) -> str:
     """Return the configured or checkout Git commit, shortened for display."""
     environment = os.environ if environ is None else environ
-    configured_sha = environment.get("BUNNIFY_GIT_SHA", "").strip()
-    if configured_sha:
-        return configured_sha[:7]
+    for key in ("BUNNIFY_GIT_SHA", "GITHUB_SHA"):
+        configured_sha = environment.get(key, "").strip()
+        if configured_sha:
+            return configured_sha[:12] if len(configured_sha) > 12 else configured_sha
 
     checkout = repository or Path(__file__).resolve().parents[1]
     try:
         result = subprocess.run(
-            ["git", "-C", str(checkout), "rev-parse", "--short=7", "HEAD"],
+            ["git", "-C", str(checkout), "rev-parse", "--short=12", "HEAD"],
             capture_output=True,
             check=True,
             text=True,

--- a/bookmarks/templates/bookmarks/base.html
+++ b/bookmarks/templates/bookmarks/base.html
@@ -36,6 +36,12 @@
             margin: 0;
             font-size: 1.5rem;
         }
+        .build-version {
+            color: #aeb6bf;
+            font-size: 0.8rem;
+            margin: 0.35rem 0 0;
+            cursor: default;
+        }
         nav {
             display: flex;
             flex-direction: column;
@@ -51,11 +57,6 @@
         }
         nav a:hover {
             background-color: #ecf0f1;
-        }
-        .build-info {
-            color: #aeb6bf;
-            font-size: 0.75rem;
-            margin-top: auto;
         }
         .content {
             margin-left: 200px;
@@ -80,14 +81,16 @@
 </head>
 <body>
     <header>
-        <h1>🐰 Bunnify</h1>
+        <div class="brand">
+            <h1>🐰 Bunnify</h1>
+            {% if package_version %}
+                <p class="build-version" title="commit {{ git_commit }}">{{ package_version }}</p>
+            {% endif %}
+        </div>
         <nav>
             <a href="/">Home</a>
             <a href="/list/">All Bookmarks</a>
         </nav>
-        {% if build_info %}
-            <footer class="build-info">{{ build_info }}</footer>
-        {% endif %}
     </header>
     <div class="content">
         {% block content %}{% endblock %}

--- a/bookmarks/templates/bookmarks/index.html
+++ b/bookmarks/templates/bookmarks/index.html
@@ -5,17 +5,22 @@
 {% block content %}
 <h2>🐰 Welcome to Bunnify</h2>
 
-<p>Smart bookmark manager with instant Chrome integration.</p>
+<p>
+    Smart bookmark manager with instant Chrome and Edge integration.
+    Inspired by Meta’s internal <em>bunnylol</em> address-bar shortcuts —
+    same idea, for your own bookmarks.
+</p>
 
 <div style="background-color: #f0f8ff; border-left: 4px solid #3498db; padding: 1.5rem; margin: 2rem 0; border-radius: 4px;">
-    <h3 style="margin-top: 0;">⚡ Quick Setup for Chrome</h3>
-    
+    <h3 style="margin-top: 0;">⚡ Quick Setup for Chrome or Edge</h3>
+
     <p><strong>Make Bunnify your default search engine in 3 steps:</strong></p>
-    
+
     <ol>
         <li>
-            <strong>Go to Chrome settings:</strong><br>
-            Visit <code>chrome://settings/searchEngines</code>
+            <strong>Open search-engine settings:</strong><br>
+            Chrome → <code>chrome://settings/searchEngines</code><br>
+            Edge → <code>edge://settings/searchEngines</code>
         </li>
         <li>
             <strong>Add Bunnify:</strong><br>
@@ -31,15 +36,15 @@
             Click the three dots (⋮) next to Bunnify and select "Make default"
         </li>
     </ol>
-    
-    <p><strong>Now you can use it from Chrome's address bar:</strong></p>
+
+    <p><strong>Now you can use it from the address bar:</strong></p>
     <ul>
         <li>Type <code>c</code> → Opens Calendar</li>
         <li>Type <code>gh</code> → Opens GitHub</li>
         <li>Type <code>g django</code> → Google search for "django"</li>
         <li>Type <code>pr 12345</code> → Opens PR #12345</li>
     </ul>
-    
+
     <p style="margin-bottom: 0;"><em>This single URL handles all your bookmarks automatically!</em></p>
 </div>
 
@@ -65,7 +70,7 @@
 <h4>3. View All Bookmarks</h4>
 <p>Visit <a href="/list/">/list/</a> to see all available bookmarks and their keys.</p>
 
-<h3>Manual Redirect (Without Chrome Setup)</h3>
+<h3>Manual Redirect (Without Browser Setup)</h3>
 <p>You can also access bookmarks directly via query parameters:</p>
 <ul>
     <li><code>/pr/?pr_number=12345</code> → Opens PR #12345</li>

--- a/bookmarks/tests.py
+++ b/bookmarks/tests.py
@@ -1,6 +1,6 @@
 from django.test import Client, TestCase
 
-from app.version import build_info
+from app.version import get_build_info
 
 from .models import Bookmark
 
@@ -11,6 +11,7 @@ class SmokeTests(TestCase):
     def setUp(self):
         """Set up test fixtures"""
         self.client = Client()
+        get_build_info.cache_clear()
 
         # Create test bookmarks
         Bookmark.objects.create(
@@ -32,7 +33,11 @@ class SmokeTests(TestCase):
         """Test that the index page loads successfully"""
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, build_info())
+        package, commit = get_build_info()
+        self.assertContains(response, package)
+        self.assertContains(response, f'title="commit {commit}"')
+        self.assertContains(response, "Chrome or Edge")
+        self.assertContains(response, "bunnylol")
 
     def test_list_page_loads(self):
         """Test that the list page loads and shows bookmarks"""

--- a/bookmarks/views.py
+++ b/bookmarks/views.py
@@ -15,7 +15,7 @@ from django.shortcuts import redirect, render
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_http_methods
 
-from app.version import build_info
+from app.version import get_build_info
 
 from .keys_catalog import catalog_payload
 from .models import Bookmark
@@ -23,8 +23,6 @@ from .resolve import PLACEHOLDER_PATTERN, resolve_query, substitute_placeholder_
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
-
-BUILD_INFO = build_info()
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
@@ -51,7 +49,11 @@ def _absolute_resolve_url(request: HttpRequest, url: str) -> str:
 
 def _build_info_context() -> dict[str, str]:
     """Return template context describing this Bunnify build."""
-    return {"build_info": BUILD_INFO}
+    package, commit = get_build_info()
+    return {
+        "git_commit": commit,
+        "package_version": package,
+    }
 
 
 @require_http_methods(["GET"])
@@ -190,7 +192,12 @@ def cmd_palette(request: HttpRequest) -> HttpResponse:
         )
 
     return render(
-        request, "bookmarks/cmd.html", {"bookmarks_json": json.dumps(bookmarks_data)}
+        request,
+        "bookmarks/cmd.html",
+        {
+            **_build_info_context(),
+            "bookmarks_json": json.dumps(bookmarks_data),
+        },
     )
 
 


### PR DESCRIPTION
## Summary
- Show package version under the Bunnify logo with a `commit <sha>` hover tooltip (domesti-bot-style version/commit split)
- Align `bunnify` / `bunnify-server --version` to print version and commit (e.g. `bunnify 0.2.0 (abc…)`)
- Welcome copy: Chrome and Edge setup URLs; nod to Meta’s internal bunnylol

## Test plan
- [x] `./test_bunnify` BuildInfo / CliVersion / Smoke index tests
- [x] `scripts/dev/pre-pr-checks` + `./scripts/checks`
- [ ] Hover logo version in `/` and confirm commit tooltip
- [ ] `bunnify --version` shows version and commit


Made with [Cursor](https://cursor.com)