### PR TITLE
fix: wait for port free after managed server stop

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -514,20 +514,12 @@ def _offer_restart_mismatched_server(
     ):
         return port
     try:
-        stop_local_server(pid_dir)
+        stop_local_server(pid_dir, port=port)
     except RuntimeError as exc:
         print_fn(theme.warn(f"Could not stop the managed server: {exc}"))
         return None
-    if port_is_free(port):
-        print_fn(theme.ok(f"✓ Stopped previous server; port {port} is free"))
-        return port
-    print_fn(
-        theme.warn(
-            f"Port {port} is still busy after stop. "
-            "Choose another port, or stop the other process."
-        )
-    )
-    return None
+    print_fn(theme.ok(f"✓ Stopped previous server; port {port} is free"))
+    return port
 
 
 def _prompt_local_port(

--- a/app/local_server.py
+++ b/app/local_server.py
@@ -93,8 +93,33 @@ def ensure_local_server(
     )
 
 
-def stop_local_server(pid_dir: Path) -> None:
-    """Stop the managed local server associated with ``pid_dir``."""
+def port_is_free(port: int) -> bool:
+    """Return whether ``port`` can be bound with ``SO_REUSEADDR`` (Django-compatible).
+
+    A plain bind without reuse can fail on macOS after a process exits while the
+    prior listen socket is still draining, even though nothing accepts connections
+    and Django's runserver (which sets reuse) could start successfully.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+        candidate.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            candidate.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
+def stop_local_server(
+    pid_dir: Path,
+    *,
+    port: int | None = None,
+    port_timeout_s: float = 15,
+) -> None:
+    """Stop the managed local server associated with ``pid_dir``.
+
+    When ``port`` is set, wait until that port can be bound again before
+    returning so callers can restart on the same port.
+    """
     completed = subprocess.run(
         [
             sys.executable,
@@ -107,18 +132,27 @@ def stop_local_server(pid_dir: Path) -> None:
         capture_output=True,
         check=False,
         text=True,
-        timeout=30,
+        timeout=max(30.0, port_timeout_s + 5),
     )
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout).strip()
         suffix = f": {detail}" if detail else ""
         raise RuntimeError(f"Failed to stop the local Bunnify server{suffix}")
+    if port is None:
+        return
+    if wait_for_port_free(port, timeout_s=port_timeout_s):
+        return
+    raise RuntimeError(
+        f"Port {port} is still busy after stop; "
+        "choose another port or stop the other process"
+    )
 
 
-def port_is_free(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
-        try:
-            candidate.bind(("127.0.0.1", port))
-        except OSError:
-            return False
-    return True
+def wait_for_port_free(port: int, *, timeout_s: float = 15) -> bool:
+    """Poll until ``port`` accepts a bind on localhost, or ``timeout_s`` elapses."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if port_is_free(port):
+            return True
+        time.sleep(0.05)
+    return port_is_free(port)

--- a/app/local_server.py
+++ b/app/local_server.py
@@ -120,20 +120,27 @@ def stop_local_server(
     When ``port`` is set, wait until that port can be bound again before
     returning so callers can restart on the same port.
     """
-    completed = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "app.server_cli",
-            "--stop",
-            "--pid-dir",
-            str(pid_dir),
-        ],
-        capture_output=True,
-        check=False,
-        text=True,
-        timeout=max(30.0, port_timeout_s + 5),
-    )
+    # Worst case: SIGTERM+SIGKILL waits for pid and listener, then port wait.
+    stop_timeout_s = max(60.0, port_timeout_s + 35)
+    try:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "app.server_cli",
+                "--stop",
+                "--pid-dir",
+                str(pid_dir),
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=stop_timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"Timed out stopping the local Bunnify server after {stop_timeout_s:g}s"
+        ) from exc
     if completed.returncode != 0:
         detail = (completed.stderr or completed.stdout).strip()
         suffix = f": {detail}" if detail else ""

--- a/app/local_server.py
+++ b/app/local_server.py
@@ -74,7 +74,7 @@ def ensure_local_server(
     while actual_port == 0 and time.monotonic() < deadline:
         try:
             actual_port = int(port_file.read_text(encoding="utf-8").strip())
-        except OSError, ValueError:
+        except (OSError, ValueError):
             time.sleep(0.1)
 
     if not actual_port:

--- a/app/local_server.py
+++ b/app/local_server.py
@@ -74,7 +74,7 @@ def ensure_local_server(
     while actual_port == 0 and time.monotonic() < deadline:
         try:
             actual_port = int(port_file.read_text(encoding="utf-8").strip())
-        except (OSError, ValueError):
+        except OSError, ValueError:
             time.sleep(0.1)
 
     if not actual_port:

--- a/app/local_server.py
+++ b/app/local_server.py
@@ -131,6 +131,8 @@ def stop_local_server(
                 "--stop",
                 "--pid-dir",
                 str(pid_dir),
+                "--port-timeout",
+                str(port_timeout_s),
             ],
             capture_output=True,
             check=False,

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -488,7 +488,12 @@ def _stop_managed_server(pid_dir: Path, *, quiet: bool = False) -> int:
             _terminate_pid(listener_pid)
             signaled_pids.append(listener_pid)
 
-    if port is not None and not _wait_for_port_free(port, timeout_s=15):
+    should_wait_for_port = bool(signaled_pids) or not quiet
+    if (
+        port is not None
+        and should_wait_for_port
+        and not _wait_for_port_free(port, timeout_s=15)
+    ):
         _cleanup_files(pid_dir)
         if not quiet:
             print(f"Port {port} is still busy after stop.", file=sys.stderr)

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -373,17 +373,22 @@ def _process_command(pid: int) -> str | None:
 
 
 def _process_managed_by_pid_dir(pid: int, pid_dir: Path) -> bool:
-    """Return whether ``pid`` is a Bunnify server for this ``pid_dir``."""
+    """Return whether ``pid`` is a Bunnify server for this ``pid_dir``.
+
+    Processes started without an explicit ``--pid-dir`` use the default
+    :func:`run_dir` (same as ``_parse_options``), so treat a missing flag as
+    that default rather than as a mismatch.
+    """
     command = _process_command(pid)
     if command is None or not _is_bunnify_command(command):
         return False
     recorded = _pid_dir_from_command(command)
     if recorded is None:
-        return False
+        recorded = run_dir()
     try:
         return recorded.resolve() == pid_dir.expanduser().resolve()
     except OSError:
-        return recorded == pid_dir.expanduser()
+        return recorded.expanduser() == pid_dir.expanduser()
 
 
 def _read_pid(path: Path) -> int | None:

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -227,19 +227,8 @@ def _is_bunnify_command(command: str) -> bool:
 
 
 def _is_bunnify_process(pid: int) -> bool:
-    if not _is_process_running(pid):
-        return False
-    try:
-        completed = subprocess.run(
-            ["ps", "-p", str(pid), "-o", "command="],
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=5,
-        )
-    except OSError, subprocess.TimeoutExpired:
-        return False
-    return _is_bunnify_command(completed.stdout)
+    command = _process_command(pid)
+    return command is not None and _is_bunnify_command(command)
 
 
 def _is_process_running(pid: int) -> bool:
@@ -296,6 +285,21 @@ def _parse_options(argv: list[str] | None) -> ServerOptions:
     )
 
 
+def _pid_dir_from_command(command: str) -> Path | None:
+    """Return ``--pid-dir`` from a process command line, if present."""
+    try:
+        arguments = shlex.split(command)
+    except ValueError:
+        return None
+    try:
+        index = arguments.index("--pid-dir")
+    except ValueError:
+        return None
+    if index + 1 >= len(arguments):
+        return None
+    return Path(arguments[index + 1]).expanduser()
+
+
 def _pid_paths(pid_dir: Path) -> tuple[Path, Path, Path]:
     return (
         pid_dir / ".bunnify.pid",
@@ -327,6 +331,38 @@ def _port_value(raw: str) -> int:
     if not 0 <= port <= 65535:
         raise argparse.ArgumentTypeError("must be between 0 and 65535")
     return port
+
+
+def _process_command(pid: int) -> str | None:
+    """Return the ``ps`` command line for ``pid``, or ``None`` on failure."""
+    if not _is_process_running(pid):
+        return None
+    try:
+        completed = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return None
+    command = completed.stdout.strip()
+    return command or None
+
+
+def _process_managed_by_pid_dir(pid: int, pid_dir: Path) -> bool:
+    """Return whether ``pid`` is a Bunnify server for this ``pid_dir``."""
+    command = _process_command(pid)
+    if command is None or not _is_bunnify_command(command):
+        return False
+    recorded = _pid_dir_from_command(command)
+    if recorded is None:
+        return False
+    try:
+        return recorded.resolve() == pid_dir.expanduser().resolve()
+    except OSError:
+        return recorded == pid_dir.expanduser()
 
 
 def _read_pid(path: Path) -> int | None:
@@ -483,7 +519,7 @@ def _stop_managed_server(pid_dir: Path, *, quiet: bool = False) -> int:
         for listener_pid in _listener_pids(port):
             if listener_pid == os.getpid() or listener_pid in signaled_pids:
                 continue
-            if not _is_bunnify_process(listener_pid):
+            if not _process_managed_by_pid_dir(listener_pid, pid_dir):
                 continue
             _terminate_pid(listener_pid)
             signaled_pids.append(listener_pid)

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -253,7 +253,7 @@ def _listener_pids(port: int) -> list[int]:
             text=True,
             timeout=5,
         )
-    except OSError, subprocess.TimeoutExpired:
+    except (OSError, subprocess.TimeoutExpired):
         return []
     pids: list[int] = []
     for line in completed.stdout.splitlines():
@@ -366,7 +366,7 @@ def _process_command(pid: int) -> str | None:
             text=True,
             timeout=5,
         )
-    except OSError, subprocess.TimeoutExpired:
+    except (OSError, subprocess.TimeoutExpired):
         return None
     command = completed.stdout.strip()
     return command or None
@@ -394,14 +394,14 @@ def _process_managed_by_pid_dir(pid: int, pid_dir: Path) -> bool:
 def _read_pid(path: Path) -> int | None:
     try:
         return int(path.read_text(encoding="utf-8").strip())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return None
 
 
 def _read_port(path: Path) -> int | None:
     try:
         port = int(path.read_text(encoding="utf-8").strip())
-    except OSError, ValueError:
+    except (OSError, ValueError):
         return None
     if not 1 <= port <= 65535:
         return None

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -253,7 +253,7 @@ def _listener_pids(port: int) -> list[int]:
             text=True,
             timeout=5,
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except OSError, subprocess.TimeoutExpired:
         return []
     pids: list[int] = []
     for line in completed.stdout.splitlines():
@@ -366,7 +366,7 @@ def _process_command(pid: int) -> str | None:
             text=True,
             timeout=5,
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except OSError, subprocess.TimeoutExpired:
         return None
     command = completed.stdout.strip()
     return command or None
@@ -394,14 +394,14 @@ def _process_managed_by_pid_dir(pid: int, pid_dir: Path) -> bool:
 def _read_pid(path: Path) -> int | None:
     try:
         return int(path.read_text(encoding="utf-8").strip())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
 
 
 def _read_port(path: Path) -> int | None:
     try:
         port = int(path.read_text(encoding="utf-8").strip())
-    except (OSError, ValueError):
+    except OSError, ValueError:
         return None
     if not 1 <= port <= 65535:
         return None

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -254,6 +254,27 @@ def _is_process_running(pid: int) -> bool:
     return True
 
 
+def _listener_pids(port: int) -> list[int]:
+    """Return PIDs listening on TCP ``port`` (best-effort via ``lsof``)."""
+    try:
+        completed = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return []
+    pids: list[int] = []
+    for line in completed.stdout.splitlines():
+        try:
+            pids.append(int(line.strip()))
+        except ValueError:
+            continue
+    return pids
+
+
 def _parse_options(argv: list[str] | None) -> ServerOptions:
     namespace = build_parser().parse_args(argv)
     console = bool(namespace.console)
@@ -283,6 +304,21 @@ def _pid_paths(pid_dir: Path) -> tuple[Path, Path, Path]:
     )
 
 
+def _port_is_free(port: int) -> bool:
+    """Return whether ``port`` can be bound with ``SO_REUSEADDR``.
+
+    Matches Django's runserver reuse behavior so a draining listen socket after
+    SIGTERM is not mistaken for an active occupant.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+        candidate.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            candidate.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
 def _port_value(raw: str) -> int:
     try:
         port = int(raw)
@@ -300,9 +336,20 @@ def _read_pid(path: Path) -> int | None:
         return None
 
 
+def _read_port(path: Path) -> int | None:
+    try:
+        port = int(path.read_text(encoding="utf-8").strip())
+    except OSError, ValueError:
+        return None
+    if not 1 <= port <= 65535:
+        return None
+    return port
+
+
 def _resolve_port(requested_port: int) -> int:
     if requested_port:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+            candidate.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 candidate.bind(("127.0.0.1", requested_port))
             except OSError as exc:
@@ -412,29 +459,64 @@ def _start_watcher(bookmarks: Path) -> None:
 
 
 def _stop_managed_server(pid_dir: Path, *, quiet: bool = False) -> int:
-    pid_file, _port_file, _watcher_pid_file = _pid_paths(pid_dir)
+    """SIGTERM the managed server, wait for exit, then confirm its port is free."""
+    pid_file, port_file, _watcher_pid_file = _pid_paths(pid_dir)
     pid = _read_pid(pid_file)
+    port = _read_port(port_file)
     if pid == os.getpid():
         return 0
-    if pid is None or not _is_process_running(pid):
-        _cleanup_files(pid_dir)
-        if not quiet:
-            print("Bunnify was not running.")
-        return 0
-    if not _is_bunnify_process(pid):
-        _cleanup_files(pid_dir)
-        if not quiet:
-            print(f"Refusing to stop unrelated process {pid}; removed stale PID files.")
-        return 0
 
-    os.kill(pid, signal.SIGTERM)
-    if not _wait_for_exit(pid, timeout_s=10):
-        os.kill(pid, signal.SIGKILL)
-        _wait_for_exit(pid, timeout_s=2)
+    signaled_pids: list[int] = []
+    if pid is not None and _is_process_running(pid):
+        if not _is_bunnify_process(pid):
+            _cleanup_files(pid_dir)
+            if not quiet:
+                print(
+                    f"Refusing to stop unrelated process {pid}; "
+                    "removed stale PID files."
+                )
+            return 0
+        _terminate_pid(pid)
+        signaled_pids.append(pid)
+
+    if port is not None and not _port_is_free(port):
+        for listener_pid in _listener_pids(port):
+            if listener_pid == os.getpid() or listener_pid in signaled_pids:
+                continue
+            if not _is_bunnify_process(listener_pid):
+                continue
+            _terminate_pid(listener_pid)
+            signaled_pids.append(listener_pid)
+
+    if port is not None and not _wait_for_port_free(port, timeout_s=15):
+        _cleanup_files(pid_dir)
+        if not quiet:
+            print(f"Port {port} is still busy after stop.", file=sys.stderr)
+        return 1
+
     _cleanup_files(pid_dir)
     if not quiet:
-        print(f"Stopped Bunnify server (PID {pid}).")
+        if signaled_pids:
+            stopped = ", ".join(str(value) for value in signaled_pids)
+            print(f"Stopped Bunnify server (PID {stopped}).")
+        else:
+            print("Bunnify was not running.")
     return 0
+
+
+def _terminate_pid(pid: int) -> None:
+    """Send SIGTERM, escalate to SIGKILL if the process does not exit."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    if _wait_for_exit(pid, timeout_s=10):
+        return
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    _wait_for_exit(pid, timeout_s=2)
 
 
 def _wait_for_exit(pid: int, *, timeout_s: float) -> bool:
@@ -444,6 +526,15 @@ def _wait_for_exit(pid: int, *, timeout_s: float) -> bool:
             return True
         time.sleep(0.1)
     return not _is_process_running(pid)
+
+
+def _wait_for_port_free(port: int, *, timeout_s: float) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if _port_is_free(port):
+            return True
+        time.sleep(0.05)
+    return _port_is_free(port)
 
 
 def _write_runtime_files(pid_dir: Path, port: int, *, pid: int | None = None) -> None:

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -298,19 +298,30 @@ def _parse_options(argv: list[str] | None) -> ServerOptions:
     )
 
 
+def _flag_value_from_arguments(arguments: list[str], flag: str) -> str | None:
+    """Return ``flag``'s value (``--flag value`` or ``--flag=value``)."""
+    prefix = f"{flag}="
+    for index, token in enumerate(arguments):
+        if token == flag:
+            if index + 1 >= len(arguments):
+                return None
+            return arguments[index + 1]
+        if token.startswith(prefix):
+            value = token[len(prefix) :]
+            return value or None
+    return None
+
+
 def _pid_dir_from_command(command: str) -> Path | None:
     """Return ``--pid-dir`` from a process command line, if present."""
     try:
         arguments = shlex.split(command)
     except ValueError:
         return None
-    try:
-        index = arguments.index("--pid-dir")
-    except ValueError:
+    value = _flag_value_from_arguments(arguments, "--pid-dir")
+    if value is None:
         return None
-    if index + 1 >= len(arguments):
-        return None
-    return Path(arguments[index + 1]).expanduser()
+    return Path(value).expanduser()
 
 
 def _pid_paths(pid_dir: Path) -> tuple[Path, Path, Path]:
@@ -327,14 +338,11 @@ def _port_from_command(command: str) -> int | None:
         arguments = shlex.split(command)
     except ValueError:
         return None
-    try:
-        index = arguments.index("--port")
-    except ValueError:
-        return None
-    if index + 1 >= len(arguments):
+    value = _flag_value_from_arguments(arguments, "--port")
+    if value is None:
         return None
     try:
-        port = int(arguments[index + 1])
+        port = int(value)
     except ValueError:
         return None
     if not 1 <= port <= 65535:

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -33,6 +33,7 @@ class ServerOptions:
     noninteractive: bool
     pid_dir: Path
     port: int
+    port_timeout_s: float
     stop: bool
 
 
@@ -98,6 +99,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="TCP port, or 0 for an OS-selected ephemeral port (default: 8000).",
     )
     parser.add_argument(
+        "--port-timeout",
+        type=_port_timeout_value,
+        default=15.0,
+        help=(
+            "Seconds to wait for the managed port to free after --stop (default: 15)."
+        ),
+    )
+    parser.add_argument(
         "--stop",
         action="store_true",
         help="Stop the server identified by files under --pid-dir.",
@@ -115,7 +124,10 @@ def main(argv: list[str] | None = None) -> int:
     options = _parse_options(argv)
     options.pid_dir.mkdir(parents=True, exist_ok=True)
     if options.stop:
-        return _stop_managed_server(options.pid_dir)
+        return _stop_managed_server(
+            options.pid_dir,
+            port_timeout_s=options.port_timeout_s,
+        )
 
     try:
         bookmarks = _ensure_bookmarks(options)
@@ -281,6 +293,7 @@ def _parse_options(argv: list[str] | None) -> ServerOptions:
         noninteractive=bool(namespace.noninteractive),
         pid_dir=(namespace.pid_dir or run_dir()).expanduser(),
         port=namespace.port,
+        port_timeout_s=float(namespace.port_timeout),
         stop=bool(namespace.stop),
     )
 
@@ -342,6 +355,16 @@ def _port_is_free(port: int) -> bool:
         except OSError:
             return False
     return True
+
+
+def _port_timeout_value(raw: str) -> float:
+    try:
+        timeout_s = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a number") from exc
+    if timeout_s <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return timeout_s
 
 
 def _port_value(raw: str) -> int:
@@ -520,7 +543,12 @@ def _start_watcher(bookmarks: Path) -> None:
     ).start()
 
 
-def _stop_managed_server(pid_dir: Path, *, quiet: bool = False) -> int:
+def _stop_managed_server(
+    pid_dir: Path,
+    *,
+    quiet: bool = False,
+    port_timeout_s: float = 15,
+) -> int:
     """SIGTERM the managed server, wait for exit, then confirm its port is free."""
     pid_file, port_file, _watcher_pid_file = _pid_paths(pid_dir)
     pid = _read_pid(pid_file)
@@ -564,7 +592,7 @@ def _stop_managed_server(pid_dir: Path, *, quiet: bool = False) -> int:
     if (
         port is not None
         and should_wait_for_port
-        and not _wait_for_port_free(port, timeout_s=15)
+        and not _wait_for_port_free(port, timeout_s=port_timeout_s)
     ):
         _cleanup_files(pid_dir)
         if not quiet:

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -308,6 +308,27 @@ def _pid_paths(pid_dir: Path) -> tuple[Path, Path, Path]:
     )
 
 
+def _port_from_command(command: str) -> int | None:
+    """Return ``--port`` from a process command line when it is a fixed port."""
+    try:
+        arguments = shlex.split(command)
+    except ValueError:
+        return None
+    try:
+        index = arguments.index("--port")
+    except ValueError:
+        return None
+    if index + 1 >= len(arguments):
+        return None
+    try:
+        port = int(arguments[index + 1])
+    except ValueError:
+        return None
+    if not 1 <= port <= 65535:
+        return None
+    return port
+
+
 def _port_is_free(port: int) -> bool:
     """Return whether ``port`` can be bound with ``SO_REUSEADDR``.
 
@@ -504,14 +525,24 @@ def _stop_managed_server(pid_dir: Path, *, quiet: bool = False) -> int:
 
     signaled_pids: list[int] = []
     if pid is not None and _is_process_running(pid):
-        if not _is_bunnify_process(pid):
+        if not _process_managed_by_pid_dir(pid, pid_dir):
             _cleanup_files(pid_dir)
             if not quiet:
-                print(
-                    f"Refusing to stop unrelated process {pid}; "
-                    "removed stale PID files."
-                )
+                if _is_bunnify_process(pid):
+                    print(
+                        f"Refusing to stop process {pid} "
+                        "(different --pid-dir); removed stale PID files."
+                    )
+                else:
+                    print(
+                        f"Refusing to stop unrelated process {pid}; "
+                        "removed stale PID files."
+                    )
             return 0
+        if port is None:
+            command = _process_command(pid)
+            if command is not None:
+                port = _port_from_command(command)
         _terminate_pid(pid)
         signaled_pids.append(pid)
 

--- a/app/tests.py
+++ b/app/tests.py
@@ -372,10 +372,22 @@ class ServerStopTests(SimpleTestCase):
             ),
             Path("/tmp/bunnify-run"),
         )
+        self.assertEqual(
+            _pid_dir_from_command(
+                "python -m app.server_cli --pid-dir=/tmp/bunnify-run --port=8000"
+            ),
+            Path("/tmp/bunnify-run"),
+        )
         self.assertIsNone(_pid_dir_from_command("python -m app.server_cli --port 8000"))
         self.assertEqual(
             _port_from_command(
                 "python -m app.server_cli --pid-dir /tmp/run --port 8123"
+            ),
+            8123,
+        )
+        self.assertEqual(
+            _port_from_command(
+                "python -m app.server_cli --pid-dir=/tmp/run --port=8123"
             ),
             8123,
         )

--- a/app/tests.py
+++ b/app/tests.py
@@ -325,7 +325,7 @@ class ServerStopTests(SimpleTestCase):
             wait_for_port.assert_not_called()
 
     def test_pid_dir_from_command_reads_flag(self) -> None:
-        from app.server_cli import _pid_dir_from_command
+        from app.server_cli import _pid_dir_from_command, _port_from_command
 
         self.assertEqual(
             _pid_dir_from_command(
@@ -334,6 +334,69 @@ class ServerStopTests(SimpleTestCase):
             Path("/tmp/bunnify-run"),
         )
         self.assertIsNone(_pid_dir_from_command("python -m app.server_cli --port 8000"))
+        self.assertEqual(
+            _port_from_command(
+                "python -m app.server_cli --pid-dir /tmp/run --port 8123"
+            ),
+            8123,
+        )
+        self.assertIsNone(
+            _port_from_command("python -m app.server_cli --pid-dir /tmp/run --port 0")
+        )
+
+    def test_stop_scopes_recorded_pid_to_pid_dir(self) -> None:
+        from app.server_cli import _stop_managed_server
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+            (pid_dir / ".bunnify.pid").write_text("4242\n", encoding="utf-8")
+            (pid_dir / ".bunnify.port").write_text("8123\n", encoding="utf-8")
+
+            with (
+                mock.patch("app.server_cli._is_process_running", return_value=True),
+                mock.patch(
+                    "app.server_cli._process_managed_by_pid_dir",
+                    return_value=False,
+                ),
+                mock.patch("app.server_cli._is_bunnify_process", return_value=True),
+                mock.patch("app.server_cli._terminate_pid") as terminate,
+            ):
+                self.assertEqual(_stop_managed_server(pid_dir, quiet=True), 0)
+
+            terminate.assert_not_called()
+            self.assertFalse((pid_dir / ".bunnify.pid").exists())
+
+    def test_stop_recovers_port_from_command_when_port_file_missing(self) -> None:
+        from app.server_cli import _stop_managed_server
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+            (pid_dir / ".bunnify.pid").write_text("4242\n", encoding="utf-8")
+
+            with (
+                mock.patch("app.server_cli._is_process_running", return_value=True),
+                mock.patch(
+                    "app.server_cli._process_managed_by_pid_dir",
+                    return_value=True,
+                ),
+                mock.patch(
+                    "app.server_cli._process_command",
+                    return_value=(
+                        "python -m app.server_cli --pid-dir "
+                        f"{pid_dir} --port 8123 --foreground"
+                    ),
+                ),
+                mock.patch("app.server_cli._terminate_pid") as terminate,
+                mock.patch("app.server_cli._port_is_free", return_value=True),
+                mock.patch(
+                    "app.server_cli._wait_for_port_free",
+                    return_value=True,
+                ) as wait_for_port,
+            ):
+                self.assertEqual(_stop_managed_server(pid_dir, quiet=False), 0)
+
+            terminate.assert_called_once_with(4242)
+            wait_for_port.assert_called_once_with(8123, timeout_s=15)
 
 
 class ServerProcessTests(SimpleTestCase):

--- a/app/tests.py
+++ b/app/tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import socket
 import subprocess
 import sys
 import tempfile
@@ -158,6 +159,63 @@ class LocalServerTests(SimpleTestCase):
         self.assertEqual(command[:3], [sys.executable, "-m", "app.server_cli"])
         self.assertIn("--stop", command)
 
+    @mock.patch("app.local_server.wait_for_port_free", return_value=True)
+    @mock.patch("app.local_server.subprocess.run")
+    def test_stop_waits_for_requested_port(
+        self,
+        run: mock.Mock,
+        wait_for_port: mock.Mock,
+    ) -> None:
+        run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+
+            stop_local_server(pid_dir, port=8123, port_timeout_s=1)
+
+        wait_for_port.assert_called_once_with(8123, timeout_s=1)
+
+    @mock.patch("app.local_server.wait_for_port_free", return_value=False)
+    @mock.patch("app.local_server.subprocess.run")
+    def test_stop_raises_when_port_stays_busy(
+        self,
+        run: mock.Mock,
+        _wait_for_port: mock.Mock,
+    ) -> None:
+        run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+
+            with self.assertRaisesRegex(RuntimeError, "still busy after stop"):
+                stop_local_server(pid_dir, port=8123, port_timeout_s=0.1)
+
+    def test_wait_for_port_free_returns_true_when_bindable(self) -> None:
+        from app.local_server import wait_for_port_free
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as holder:
+            holder.bind(("127.0.0.1", 0))
+            port = int(holder.getsockname()[1])
+
+        self.assertTrue(wait_for_port_free(port, timeout_s=1))
+
+    def test_wait_for_port_free_times_out_while_held(self) -> None:
+        from app.local_server import wait_for_port_free
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as holder:
+            holder.bind(("127.0.0.1", 0))
+            holder.listen()
+            port = int(holder.getsockname()[1])
+            self.assertFalse(wait_for_port_free(port, timeout_s=0.2))
+
+    def test_port_is_free_uses_reuseaddr(self) -> None:
+        from app.local_server import port_is_free
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as holder:
+            holder.bind(("127.0.0.1", 0))
+            port = int(holder.getsockname()[1])
+        # Closed socket may still look busy without SO_REUSEADDR; our check must
+        # match Django's runserver and treat the port as usable.
+        self.assertTrue(port_is_free(port))
+
 
 class ServerCliVersionTests(SimpleTestCase):
     def test_version_uses_distribution_metadata(self) -> None:
@@ -168,6 +226,46 @@ class ServerCliVersionTests(SimpleTestCase):
 
         self.assertEqual(raised.exception.code, 0)
         self.assertEqual(output.getvalue(), f"bunnify-server {build_version()}\n")
+
+
+class ServerStopTests(SimpleTestCase):
+    def test_stop_returns_error_when_port_stays_busy(self) -> None:
+        from app.server_cli import _stop_managed_server
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as holder:
+                holder.bind(("127.0.0.1", 0))
+                holder.listen()
+                port = int(holder.getsockname()[1])
+                (pid_dir / ".bunnify.port").write_text(f"{port}\n", encoding="utf-8")
+
+                with (
+                    mock.patch("app.server_cli._listener_pids", return_value=[]),
+                    mock.patch(
+                        "app.server_cli._wait_for_port_free",
+                        return_value=False,
+                    ),
+                ):
+                    self.assertEqual(_stop_managed_server(pid_dir, quiet=True), 1)
+
+    def test_stop_terminates_listener_when_pid_file_stale(self) -> None:
+        from app.server_cli import _stop_managed_server
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+            (pid_dir / ".bunnify.port").write_text("8123\n", encoding="utf-8")
+
+            with (
+                mock.patch("app.server_cli._port_is_free", side_effect=[False, True]),
+                mock.patch("app.server_cli._listener_pids", return_value=[4242]),
+                mock.patch("app.server_cli._is_bunnify_process", return_value=True),
+                mock.patch("app.server_cli._terminate_pid") as terminate,
+                mock.patch("app.server_cli._wait_for_port_free", return_value=True),
+            ):
+                self.assertEqual(_stop_managed_server(pid_dir, quiet=True), 0)
+
+            terminate.assert_called_once_with(4242)
 
 
 class ServerProcessTests(SimpleTestCase):

--- a/app/tests.py
+++ b/app/tests.py
@@ -161,6 +161,24 @@ class LocalServerTests(SimpleTestCase):
 
     @mock.patch("app.local_server.wait_for_port_free", return_value=True)
     @mock.patch("app.local_server.subprocess.run")
+    def test_stop_passes_port_timeout_to_server_cli(
+        self,
+        run: mock.Mock,
+        wait_for_port: mock.Mock,
+    ) -> None:
+        run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+
+            stop_local_server(pid_dir, port=8123, port_timeout_s=1.5)
+
+        command = run.call_args.args[0]
+        self.assertIn("--port-timeout", command)
+        self.assertEqual(command[command.index("--port-timeout") + 1], "1.5")
+        wait_for_port.assert_called_once_with(8123, timeout_s=1.5)
+
+    @mock.patch("app.local_server.wait_for_port_free", return_value=True)
+    @mock.patch("app.local_server.subprocess.run")
     def test_stop_waits_for_requested_port(
         self,
         run: mock.Mock,
@@ -261,9 +279,17 @@ class ServerStopTests(SimpleTestCase):
                     mock.patch(
                         "app.server_cli._wait_for_port_free",
                         return_value=False,
-                    ),
+                    ) as wait_for_port,
                 ):
-                    self.assertEqual(_stop_managed_server(pid_dir, quiet=False), 1)
+                    self.assertEqual(
+                        _stop_managed_server(
+                            pid_dir,
+                            quiet=False,
+                            port_timeout_s=0.25,
+                        ),
+                        1,
+                    )
+                wait_for_port.assert_called_once_with(port, timeout_s=0.25)
 
     def test_quiet_stop_skips_wait_when_nothing_signaled(self) -> None:
         from app.server_cli import _stop_managed_server

--- a/app/tests.py
+++ b/app/tests.py
@@ -324,7 +324,20 @@ class ServerStopTests(SimpleTestCase):
             terminate.assert_not_called()
             wait_for_port.assert_not_called()
 
-    def test_pid_dir_from_command_reads_flag(self) -> None:
+    def test_process_managed_by_pid_dir_defaults_missing_flag(self) -> None:
+        from app.server_cli import _process_managed_by_pid_dir
+
+        default = Path("/tmp/default-run")
+        with (
+            mock.patch(
+                "app.server_cli._process_command",
+                return_value="python -m app.server_cli --port 8000 --foreground",
+            ),
+            mock.patch("app.server_cli.run_dir", return_value=default),
+        ):
+            self.assertTrue(_process_managed_by_pid_dir(1, default))
+            self.assertFalse(_process_managed_by_pid_dir(1, Path("/tmp/other-run")))
+
         from app.server_cli import _pid_dir_from_command, _port_from_command
 
         self.assertEqual(

--- a/app/tests.py
+++ b/app/tests.py
@@ -291,13 +291,49 @@ class ServerStopTests(SimpleTestCase):
             with (
                 mock.patch("app.server_cli._port_is_free", side_effect=[False, True]),
                 mock.patch("app.server_cli._listener_pids", return_value=[4242]),
-                mock.patch("app.server_cli._is_bunnify_process", return_value=True),
+                mock.patch(
+                    "app.server_cli._process_managed_by_pid_dir",
+                    return_value=True,
+                ),
                 mock.patch("app.server_cli._terminate_pid") as terminate,
                 mock.patch("app.server_cli._wait_for_port_free", return_value=True),
             ):
                 self.assertEqual(_stop_managed_server(pid_dir, quiet=True), 0)
 
             terminate.assert_called_once_with(4242)
+
+    def test_stop_skips_listener_for_other_pid_dir(self) -> None:
+        from app.server_cli import _stop_managed_server
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+            (pid_dir / ".bunnify.port").write_text("8123\n", encoding="utf-8")
+
+            with (
+                mock.patch("app.server_cli._port_is_free", return_value=False),
+                mock.patch("app.server_cli._listener_pids", return_value=[4242]),
+                mock.patch(
+                    "app.server_cli._process_managed_by_pid_dir",
+                    return_value=False,
+                ),
+                mock.patch("app.server_cli._terminate_pid") as terminate,
+                mock.patch("app.server_cli._wait_for_port_free") as wait_for_port,
+            ):
+                self.assertEqual(_stop_managed_server(pid_dir, quiet=True), 0)
+
+            terminate.assert_not_called()
+            wait_for_port.assert_not_called()
+
+    def test_pid_dir_from_command_reads_flag(self) -> None:
+        from app.server_cli import _pid_dir_from_command
+
+        self.assertEqual(
+            _pid_dir_from_command(
+                "python -m app.server_cli --pid-dir /tmp/bunnify-run --port 8000"
+            ),
+            Path("/tmp/bunnify-run"),
+        )
+        self.assertIsNone(_pid_dir_from_command("python -m app.server_cli --port 8000"))
 
 
 class ServerProcessTests(SimpleTestCase):

--- a/app/tests.py
+++ b/app/tests.py
@@ -174,6 +174,22 @@ class LocalServerTests(SimpleTestCase):
 
         wait_for_port.assert_called_once_with(8123, timeout_s=1)
 
+    @mock.patch("app.local_server.wait_for_port_free", return_value=True)
+    @mock.patch(
+        "app.local_server.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["bunnify-server"], timeout=60),
+    )
+    def test_stop_maps_timeout_to_runtime_error(
+        self,
+        _run: mock.Mock,
+        _wait_for_port: mock.Mock,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+
+            with self.assertRaisesRegex(RuntimeError, "Timed out stopping"):
+                stop_local_server(pid_dir, port=8123, port_timeout_s=1)
+
     @mock.patch("app.local_server.wait_for_port_free", return_value=False)
     @mock.patch("app.local_server.subprocess.run")
     def test_stop_raises_when_port_stays_busy(
@@ -247,7 +263,23 @@ class ServerStopTests(SimpleTestCase):
                         return_value=False,
                     ),
                 ):
-                    self.assertEqual(_stop_managed_server(pid_dir, quiet=True), 1)
+                    self.assertEqual(_stop_managed_server(pid_dir, quiet=False), 1)
+
+    def test_quiet_stop_skips_wait_when_nothing_signaled(self) -> None:
+        from app.server_cli import _stop_managed_server
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+            (pid_dir / ".bunnify.port").write_text("8123\n", encoding="utf-8")
+
+            with (
+                mock.patch("app.server_cli._port_is_free", return_value=False),
+                mock.patch("app.server_cli._listener_pids", return_value=[]),
+                mock.patch("app.server_cli._wait_for_port_free") as wait_for_port,
+            ):
+                self.assertEqual(_stop_managed_server(pid_dir, quiet=True), 0)
+
+            wait_for_port.assert_not_called()
 
     def test_stop_terminates_listener_when_pid_file_stale(self) -> None:
         from app.server_cli import _stop_managed_server

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1336,7 +1336,9 @@ class ConfigUnitTests(TestCase):
                 patch("app.cli.port_is_free", side_effect=port_free),
                 patch(
                     "app.cli.stop_local_server",
-                    side_effect=lambda _pid_dir: port_state.__setitem__("free", True),
+                    side_effect=lambda _pid_dir, **_kwargs: port_state.__setitem__(
+                        "free", True
+                    ),
                 ) as stop_server,
             ):
                 result = run_setup(
@@ -1348,11 +1350,60 @@ class ConfigUnitTests(TestCase):
 
             self.assertEqual(result, "http://127.0.0.1:8000")
             stop_server.assert_called_once()
+            self.assertEqual(stop_server.call_args.kwargs.get("port"), 8000)
             self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
             joined = "\n".join(messages)
             self.assertIn("already serving Bunnify 0.2.0 (oldoldoldold)", joined)
             self.assertIn("differs from this CLI", joined)
             self.assertIn("Stopped previous server", joined)
+
+    def test_setup_local_reports_stop_failure_when_port_stays_busy(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import run_setup
+        from app.config import LOCAL_PORT_FILE_NAME, run_dir
+
+        remote = _healthy_status(version="0.2.0", commit="oldoldoldold")
+        responses = iter(["local", "", "y"])
+        messages: list[str] = []
+
+        def prompt(_message: str) -> str:
+            try:
+                return next(responses)
+            except StopIteration as exc:
+                raise EOFError from exc
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            environ = {"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp}
+            managed = run_dir(environ=environ)
+            managed.mkdir(parents=True, exist_ok=True)
+            (managed / LOCAL_PORT_FILE_NAME).write_text("8000\n", encoding="utf-8")
+
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.port_is_free", return_value=False),
+                patch(
+                    "app.cli.stop_local_server",
+                    side_effect=RuntimeError("Port 8000 is still busy after stop"),
+                ),
+                self.assertRaises(ClientError),
+            ):
+                run_setup(
+                    prompt_fn=prompt,
+                    environ=environ,
+                    env_path=path,
+                    print_fn=messages.append,
+                )
+
+            joined = "\n".join(messages)
+            self.assertIn("Could not stop the managed server", joined)
+            self.assertIn("still busy after stop", joined)
 
     def test_setup_local_reuses_unmanaged_mismatched_server(self) -> None:
         import tempfile


### PR DESCRIPTION
## Summary
- After stopping the managed local server, wait for process exit and confirm the port is reusable (with `SO_REUSEADDR`, matching Django runserver) before restarting on the same port.
- Also SIGTERM any leftover Bunnify listener on the managed port when the PID file is stale, so `bunnify setup` no longer falsely jumps to the next free port (e.g. 8001).

## Test plan
- [x] `./scripts/checks` (ruff, pyright, shellcheck, unit, packaging smoke, integration)
- [x] Integration: stop → wait → restart on the same port
- [ ] Re-run `bunnify setup` with a managed server on 8000 and choose restart; expect 8000 reused


Made with [Cursor](https://cursor.com)

## Stack
```text
main
 └── #282 setup-port-stop/wait-port-free   ← you are here
      └── #284 setup-port-stop/seed-and-docs  (bookmarks seed + docs)
```