### PR TITLE
feat: seed example bookmarks during setup and refresh docs

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,14 +1,17 @@
 # ⚡ Quick reference
 
 Assumes `pipx install bunnify`, `pipx ensurepath` (so `~/.local/bin` is on
-`PATH`), a seeded `~/.config/bunnify/bookmarks.json`, and a completed
-`bunnify --setup`. Prefer **local** mode on a laptop; use **remote** for a
+`PATH`), bookmarks at `~/.config/bunnify/bookmarks.json` (install via
+`bunnify setup` or from `bunnify.json.example`), and a completed
+`bunnify setup`. Prefer **local** mode on a laptop; use **remote** for a
 home-server install. Your base URL is in `~/.config/bunnify/config.env` as
 `BUNNIFY_BASE_URL` — Chrome must use the same URL.
 
 ## Bookmarks file
 
 ```bash
+bunnify setup   # offers to install example bookmarks when missing
+# or:
 mkdir -p ~/.config/bunnify
 curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.example \
   -o ~/.config/bunnify/bookmarks.json
@@ -19,8 +22,9 @@ curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.
 ```bash
 bunnify                         # interactive REPL
 bunnify onboard                 # post-install / upgrade checklist
-bunnify --setup                 # configure local or remote server
+bunnify setup                   # configure local or remote server
 bunnify gh                      # open a shortcut (example key from bunnify.json.example)
+bunnify bun                     # Bunnify source on GitHub
 bunnify pr the-hcma/bunnify 272 # parameterized shortcut (repo + PR number)
 bunnify --fzf                   # fuzzy-pick a shortcut (requires fzf on PATH)
 bunnify --print-url gh          # print resolved URL instead of opening browser

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Bunnify 🐰
+# Bunnify
+
+[![PyPI version](https://img.shields.io/pypi/v/bunnify.svg)](https://pypi.org/project/bunnify/)
+[![Python versions](https://img.shields.io/pypi/pyversions/bunnify.svg)](https://pypi.org/project/bunnify/)
+[![License](https://img.shields.io/pypi/l/bunnify.svg)](https://github.com/the-hcma/bunnify/blob/main/LICENSE)
+[![CI](https://github.com/the-hcma/bunnify/actions/workflows/ci.yml/badge.svg)](https://github.com/the-hcma/bunnify/actions/workflows/ci.yml)
 
 A Python bookmark manager and URL shortcut system: terminal CLI, web command
 palette, Chrome OpenSearch integration, and parameterized redirects.
@@ -22,6 +27,8 @@ running either command. Prefer the pipx apps over any checkout
 The wheel installs **`bunnify`** (CLI) and **`bunnify-server`** (Django
 server). No repository checkout or `uv` is required at runtime.
 
+Package on PyPI: [pypi.org/project/bunnify](https://pypi.org/project/bunnify/).
+
 ### After install or upgrade
 
 pipx does not print package docs after install. Run:
@@ -40,7 +47,8 @@ bunnify --onboard
 Summary of what it covers:
 
 1. **Bookmarks** at `~/.config/bunnify/bookmarks.json` (required before the
-   server starts) — seed from
+   server starts) — `bunnify setup` can install the example shortcuts, or seed
+   from
    [bunnify.json.example](https://github.com/the-hcma/bunnify/blob/main/bunnify.json.example)
 2. **`bunnify setup`** — local on a laptop; remote for a home/always-on host  
    [LOCAL.md](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md)
@@ -64,10 +72,12 @@ Source and docs: [github.com/the-hcma/bunnify](https://github.com/the-hcma/bunni
 
 ## Quick start
 
-### 1. Create your bookmarks file
+### 1. Bookmarks file
 
-Download the [documented example](https://github.com/the-hcma/bunnify/blob/main/bunnify.json.example)
-into XDG config (required before the server starts):
+`bunnify setup` offers to install the example bookmarks when none exist yet.
+You can also create the file yourself from the
+[documented example](https://github.com/the-hcma/bunnify/blob/main/bunnify.json.example)
+into XDG config:
 
 ```bash
 mkdir -p ~/.config/bunnify
@@ -105,6 +115,7 @@ Details:
 ```bash
 bunnify              # interactive REPL (Tab completion, history)
 bunnify gh           # open a shortcut in the browser
+bunnify bun          # Bunnify source on GitHub
 bunnify pr the-hcma/bunnify 272   # parameterized shortcut
 bunnify --fzf        # fuzzy picker
 bunnify --print-url gh
@@ -119,7 +130,6 @@ Unknown keys exit non-zero in direct mode (no search-engine fallback).
 - **Chrome / Edge** — OpenSearch at `/opensearch.xml`
   ([setup guide](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md))
 - **Parameters** — URLs with `#{name}` placeholders and optional defaults
-- **Copilot reviews** — `rpr` shortcut streams in-app PR reviews
 - **Validation** — JSON Schema on load; reserved keys `h` / `help`
 
 ## Server lifecycle
@@ -184,7 +194,7 @@ Reload after edits: the server watches the JSON file, or run
 Contributors clone the repo and use `uv` — separate from the pipx path above.
 
 ```bash
-git clone https://github.com/thehcma/bunnify.git
+git clone https://github.com/the-hcma/bunnify.git
 cd bunnify
 uv sync
 uv run python manage.py migrate
@@ -228,7 +238,7 @@ bunnify-server --console --log-level DEBUG
 
 ```bash
 ls -l ~/.config/bunnify/bookmarks.json
-# create from bunnify.json.example if absent — see Quick start
+# run `bunnify setup` (offers the example), or copy bunnify.json.example
 ```
 
 **CLI can't reach server**

--- a/app/cli.py
+++ b/app/cli.py
@@ -191,13 +191,9 @@ def format_onboarding_text() -> str:
         [
             "Bunnify — next steps after install or upgrade",
             "",
-            "1. Create your bookmarks file (required before the server starts):",
-            f"     mkdir -p {bookmarks.parent}",
-            "     curl -fsSL \\",
-            "       https://raw.githubusercontent.com/the-hcma/bunnify/"
-            "main/bunnify.json.example \\",
-            f"       -o {bookmarks}",
-            f"     # edit {bookmarks}",
+            "1. Bookmarks (required before the server starts):",
+            "     bunnify setup   # offers to install the example shortcuts",
+            f"     # or create {bookmarks} yourself from bunnify.json.example",
             "",
             "2. Configure and start the server (local on a laptop; remote for a",
             "   home/always-on host):",

--- a/app/cli.py
+++ b/app/cli.py
@@ -1132,6 +1132,10 @@ def main(
     theme = Theme(enabled=stdout_color_enabled(color_mode.lower()))
 
     def prompt_fn(message: str) -> str:
+        # click.prompt turns EOF into ``default=""``; decline interactive prompts
+        # when stdin is closed so setup never silently seeds or accepts defaults.
+        if not sys.stdin.isatty():
+            raise EOFError
         return click.prompt(
             message.rstrip(": "),
             default="",

--- a/app/cli.py
+++ b/app/cli.py
@@ -1132,10 +1132,6 @@ def main(
     theme = Theme(enabled=stdout_color_enabled(color_mode.lower()))
 
     def prompt_fn(message: str) -> str:
-        # click.prompt turns EOF into ``default=""``; decline interactive prompts
-        # when stdin is closed so setup never silently seeds or accepts defaults.
-        if not sys.stdin.isatty():
-            raise EOFError
         return click.prompt(
             message.rstrip(": "),
             default="",

--- a/app/config.py
+++ b/app/config.py
@@ -325,7 +325,22 @@ def ensure_user_bookmarks(
         prompt_fn=prompt_fn,
         print_fn=print_fn,
     ):
-        return seed_bookmarks_from_example(target)
+        try:
+            seeded = seed_bookmarks_from_example(target)
+        except FileExistsError:
+            # Another process created the file while we were prompting.
+            return target
+        log = print_fn if print_fn is not None else print
+        log(f"Installed example bookmarks at {seeded}.")
+        log(
+            "Edit that file to personalize shortcuts; the local server watches "
+            "it and reloads automatically (CLI resolves via the server)."
+        )
+        log(
+            "In the interactive REPL, run `refresh` after edits to update "
+            "Tab completion."
+        )
+        return seeded
 
     raise FileNotFoundError(
         "Bookmarks file not found: "

--- a/app/config.py
+++ b/app/config.py
@@ -441,7 +441,12 @@ def _offer_example_bookmarks(
     prompt_fn: Callable[[str], str] | None,
     print_fn: Callable[[str], None] | None,
 ) -> bool:
-    """Prompt whether to install example bookmarks at ``target``. Default yes."""
+    """Prompt whether to install example bookmarks at ``target``.
+
+    On a TTY, Enter accepts (default yes). On non-TTY stdin (pipes / closed
+    stdin), click may turn EOF into ``""`` — require an explicit ``y``/``yes``
+    so closed stdin does not silently seed while piped answers still work.
+    """
     log = print_fn if print_fn is not None else print
     ask = prompt_fn or input
     log(f"No bookmarks found at {target}.")
@@ -449,4 +454,9 @@ def _offer_example_bookmarks(
         answer = ask("Install the example bookmarks there? [Y/n]: ")
     except EOFError:
         return False
-    return answer.strip().lower() in {"", "y", "yes"}
+    normalized = answer.strip().lower()
+    if normalized in {"y", "yes"}:
+        return True
+    if normalized == "" and sys.stdin.isatty():
+        return True
+    return False

--- a/app/config.py
+++ b/app/config.py
@@ -309,11 +309,24 @@ def ensure_user_bookmarks(
     allow_prompt: bool | None = None,
     print_fn: Callable[[str], None] | None = None,
 ) -> Path:
-    """Return the user bookmarks file path, or raise when it is missing."""
-    _ = legacy, prompt_fn, allow_prompt, print_fn
+    """Return the user bookmarks file path, or raise when it is missing.
+
+    When the file is absent and prompting is allowed, offer to install the
+    packaged example bookmarks at the default path (used by ``bunnify setup``).
+    """
+    _ = legacy
     target = dest if dest is not None else default_bookmarks_path(environ=environ)
     if target.is_file():
         return target
+
+    should_prompt = allow_prompt if allow_prompt is not None else sys.stdin.isatty()
+    if should_prompt and _offer_example_bookmarks(
+        target,
+        prompt_fn=prompt_fn,
+        print_fn=print_fn,
+    ):
+        return seed_bookmarks_from_example(target)
+
     raise FileNotFoundError(
         "Bookmarks file not found: "
         f"{target}\n"
@@ -322,6 +335,7 @@ def ensure_user_bookmarks(
         "  curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/"
         "bunnify.json.example \\\n"
         f"    -o {target}\n"
+        "Or run `bunnify setup` and accept installing the example bookmarks.\n"
         "Or set BUNNIFY_BOOKMARKS to an existing file path.\n"
         "Full checklist: bunnify onboard"
     )
@@ -404,3 +418,20 @@ def _env_line_pattern(key: str) -> re.Pattern[str]:
         rf"^[^\S\r\n]*{re.escape(key)}[^\S\r\n]*=[^\S\r\n]*(.*)$",
         re.MULTILINE,
     )
+
+
+def _offer_example_bookmarks(
+    target: Path,
+    *,
+    prompt_fn: Callable[[str], str] | None,
+    print_fn: Callable[[str], None] | None,
+) -> bool:
+    """Prompt whether to install example bookmarks at ``target``. Default yes."""
+    log = print_fn if print_fn is not None else print
+    ask = prompt_fn or input
+    log(f"No bookmarks found at {target}.")
+    try:
+        answer = ask("Install the example bookmarks there? [Y/n]: ")
+    except EOFError:
+        return False
+    return answer.strip().lower() in {"", "y", "yes"}

--- a/app/data/bookmarks.example.json
+++ b/app/data/bookmarks.example.json
@@ -1,42 +1,70 @@
 {
+  "bun": {
+    "description": "Bunnify source code",
+    "url": "https://github.com/the-hcma/bunnify"
+  },
   "c": {
     "description": "Google Calendar",
     "url": "https://calendar.google.com"
+  },
+  "docs": {
+    "description": "Google Docs",
+    "url": "https://docs.google.com/document/u/0/"
+  },
+  "drive": {
+    "description": "Google Drive",
+    "url": "https://drive.google.com"
   },
   "g": {
     "description": "Google Search",
     "url": "https://www.google.com/search?q=#{search_terms}"
   },
-  "gm": {
-    "description": "Gmail",
-    "url": "https://mail.google.com"
-  },
   "gh": {
     "description": "GitHub",
     "url": "https://github.com"
   },
-  "gtcl": {
-    "description": "Graphite CLI changelog",
-    "url": "https://graphite.com/docs/cli-changelog"
-  },
-  "pr": {
-    "description": "GitHub Pull Request (Usage: pr <org/repo> <pr_number>)",
-    "url": "https://github.com/#{repo}/pull/#{pr_number}"
+  "gm": {
+    "description": "Gmail",
+    "url": "https://mail.google.com"
   },
   "i": {
     "description": "GitHub Issue (Usage: i <org/repo> <issue_number>)",
     "url": "https://github.com/#{repo}/issues/#{issue_number}"
   },
-  "ih": {
-    "description": "the-hcma GitHub Issues (Usage: ih <repo>)",
-    "url": "https://github.com/the-hcma/#{repo}/issues"
+  "keep": {
+    "description": "Google Keep",
+    "url": "https://keep.google.com"
   },
-  "ihh": {
-    "description": "thehcma GitHub Issues (Usage: ihh <repo>)",
-    "url": "https://github.com/thehcma/#{repo}/issues"
+  "maps": {
+    "description": "Google Maps",
+    "url": "https://maps.google.com"
   },
-  "rpr": {
-    "description": "Request Copilot review for PR",
-    "url": "http://127.0.0.1:8000/review-pr/?pr=#{pr_id}"
+  "meet": {
+    "description": "Google Meet",
+    "url": "https://meet.google.com"
+  },
+  "photos": {
+    "description": "Google Photos",
+    "url": "https://photos.google.com"
+  },
+  "pr": {
+    "description": "GitHub Pull Request (Usage: pr <org/repo> <pr_number>)",
+    "url": "https://github.com/#{repo}/pull/#{pr_number}"
+  },
+  "sheets": {
+    "description": "Google Sheets",
+    "url": "https://docs.google.com/spreadsheets/u/0/"
+  },
+  "slides": {
+    "description": "Google Slides",
+    "url": "https://docs.google.com/presentation/u/0/"
+  },
+  "translate": {
+    "description": "Google Translate",
+    "url": "https://translate.google.com"
+  },
+  "yt": {
+    "description": "YouTube",
+    "url": "https://www.youtube.com"
   }
 }

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -891,6 +891,54 @@ class ConfigUnitTests(TestCase):
                 ensure_user_bookmarks(dest=target, allow_prompt=False)
 
             self.assertIn("Create it manually", str(context.exception))
+            self.assertIn("bunnify setup", str(context.exception))
+
+    def test_ensure_user_bookmarks_seeds_when_prompt_accepted(self) -> None:
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from app.config import ensure_user_bookmarks
+
+        messages: list[str] = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "config" / "bookmarks.json"
+            result = ensure_user_bookmarks(
+                dest=target,
+                allow_prompt=True,
+                prompt_fn=lambda _prompt: "",
+                print_fn=messages.append,
+            )
+
+            self.assertEqual(result, target)
+            self.assertTrue(target.is_file())
+            payload = json.loads(target.read_text(encoding="utf-8"))
+            self.assertIn("bun", payload)
+            self.assertIn("gh", payload)
+            self.assertIn("yt", payload)
+            self.assertNotIn("ih", payload)
+            self.assertNotIn("ihh", payload)
+            self.assertTrue(
+                any("No bookmarks found" in message for message in messages)
+            )
+
+    def test_ensure_user_bookmarks_declines_seed_when_prompt_rejected(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.config import ensure_user_bookmarks
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "config" / "bookmarks.json"
+            with self.assertRaises(FileNotFoundError):
+                ensure_user_bookmarks(
+                    dest=target,
+                    allow_prompt=True,
+                    prompt_fn=lambda _prompt: "n",
+                    print_fn=lambda _message: None,
+                )
+            self.assertFalse(target.exists())
 
     def test_seed_bookmarks_does_not_overwrite(self) -> None:
         import tempfile

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -907,7 +907,7 @@ class ConfigUnitTests(TestCase):
             result = ensure_user_bookmarks(
                 dest=target,
                 allow_prompt=True,
-                prompt_fn=lambda _prompt: "",
+                prompt_fn=lambda _prompt: "y",
                 print_fn=messages.append,
             )
 
@@ -973,6 +973,39 @@ class ConfigUnitTests(TestCase):
                     prompt_fn=lambda _prompt: "n",
                     print_fn=lambda _message: None,
                 )
+            self.assertFalse(target.exists())
+
+    def test_ensure_user_bookmarks_empty_enter_seeds_only_on_tty(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.config import ensure_user_bookmarks
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "config" / "bookmarks.json"
+            with patch("app.config.sys.stdin") as stdin:
+                stdin.isatty.return_value = True
+                result = ensure_user_bookmarks(
+                    dest=target,
+                    allow_prompt=True,
+                    prompt_fn=lambda _prompt: "",
+                    print_fn=lambda _message: None,
+                )
+            self.assertEqual(result, target)
+            self.assertTrue(target.is_file())
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "config" / "bookmarks.json"
+            with patch("app.config.sys.stdin") as stdin:
+                stdin.isatty.return_value = False
+                with self.assertRaises(FileNotFoundError):
+                    ensure_user_bookmarks(
+                        dest=target,
+                        allow_prompt=True,
+                        prompt_fn=lambda _prompt: "",
+                        print_fn=lambda _message: None,
+                    )
             self.assertFalse(target.exists())
 
     def test_seed_bookmarks_does_not_overwrite(self) -> None:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -922,6 +922,41 @@ class ConfigUnitTests(TestCase):
             self.assertTrue(
                 any("No bookmarks found" in message for message in messages)
             )
+            self.assertTrue(
+                any("Installed example bookmarks" in message for message in messages)
+            )
+            self.assertTrue(
+                any("personalize" in message.lower() for message in messages)
+            )
+
+    def test_ensure_user_bookmarks_returns_existing_on_seed_race(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.config import ensure_user_bookmarks
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "config" / "bookmarks.json"
+
+            def create_then_raise(_dest: Path) -> Path:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text('{"raced": true}\n', encoding="utf-8")
+                raise FileExistsError(str(target))
+
+            with patch(
+                "app.config.seed_bookmarks_from_example",
+                side_effect=create_then_raise,
+            ):
+                result = ensure_user_bookmarks(
+                    dest=target,
+                    allow_prompt=True,
+                    prompt_fn=lambda _prompt: "y",
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, target)
+            self.assertEqual(target.read_text(encoding="utf-8"), '{"raced": true}\n')
 
     def test_ensure_user_bookmarks_declines_seed_when_prompt_rejected(self) -> None:
         import tempfile

--- a/bunnify.json.example
+++ b/bunnify.json.example
@@ -1,42 +1,70 @@
 {
+  "bun": {
+    "description": "Bunnify source code",
+    "url": "https://github.com/the-hcma/bunnify"
+  },
   "c": {
     "description": "Google Calendar",
     "url": "https://calendar.google.com"
+  },
+  "docs": {
+    "description": "Google Docs",
+    "url": "https://docs.google.com/document/u/0/"
+  },
+  "drive": {
+    "description": "Google Drive",
+    "url": "https://drive.google.com"
   },
   "g": {
     "description": "Google Search",
     "url": "https://www.google.com/search?q=#{search_terms}"
   },
-  "gm": {
-    "description": "Gmail",
-    "url": "https://mail.google.com"
-  },
   "gh": {
     "description": "GitHub",
     "url": "https://github.com"
   },
-  "gtcl": {
-    "description": "Graphite CLI changelog",
-    "url": "https://graphite.com/docs/cli-changelog"
-  },
-  "pr": {
-    "description": "GitHub Pull Request (Usage: pr <org/repo> <pr_number>)",
-    "url": "https://github.com/#{repo}/pull/#{pr_number}"
+  "gm": {
+    "description": "Gmail",
+    "url": "https://mail.google.com"
   },
   "i": {
     "description": "GitHub Issue (Usage: i <org/repo> <issue_number>)",
     "url": "https://github.com/#{repo}/issues/#{issue_number}"
   },
-  "ih": {
-    "description": "the-hcma GitHub Issues (Usage: ih <repo>)",
-    "url": "https://github.com/the-hcma/#{repo}/issues"
+  "keep": {
+    "description": "Google Keep",
+    "url": "https://keep.google.com"
   },
-  "ihh": {
-    "description": "thehcma GitHub Issues (Usage: ihh <repo>)",
-    "url": "https://github.com/thehcma/#{repo}/issues"
+  "maps": {
+    "description": "Google Maps",
+    "url": "https://maps.google.com"
   },
-  "rpr": {
-    "description": "Request Copilot review for PR",
-    "url": "http://127.0.0.1:8000/review-pr/?pr=#{pr_id}"
+  "meet": {
+    "description": "Google Meet",
+    "url": "https://meet.google.com"
+  },
+  "photos": {
+    "description": "Google Photos",
+    "url": "https://photos.google.com"
+  },
+  "pr": {
+    "description": "GitHub Pull Request (Usage: pr <org/repo> <pr_number>)",
+    "url": "https://github.com/#{repo}/pull/#{pr_number}"
+  },
+  "sheets": {
+    "description": "Google Sheets",
+    "url": "https://docs.google.com/spreadsheets/u/0/"
+  },
+  "slides": {
+    "description": "Google Slides",
+    "url": "https://docs.google.com/presentation/u/0/"
+  },
+  "translate": {
+    "description": "Google Translate",
+    "url": "https://translate.google.com"
+  },
+  "yt": {
+    "description": "YouTube",
+    "url": "https://www.youtube.com"
   }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,6 +1,9 @@
 # Bunnify configuration
 
-`bunnify.json.example` is the template for creating your personal bookmarks file.
+`bunnify.json.example` (and the packaged `app/data/bookmarks.example.json`) is
+the template for creating your personal bookmarks file. It ships Google
+properties (Search, Gmail, Calendar, YouTube, Drive, Docs, and related),
+generic GitHub shortcuts, and a `bun` key for this repository’s source.
 
 ## XDG layout
 
@@ -12,10 +15,13 @@ to `~/.config/bunnify` when `XDG_CONFIG_HOME` is unset:
   `BUNNIFY_MODE`, `BUNNIFY_BASE_URL`, and `BUNNIFY_LOCAL_PORT`.
 - `run/` contains PID and selected-port files for the CLI-managed local server.
 
-Create `bookmarks.json` manually — the server does not seed the example file.
 These files are user data and are not tracked by Git.
 
 ## Setup
+
+When `bookmarks.json` is missing, interactive `bunnify setup` (and other
+prompting CLI paths) offer to install the example bookmarks in the correct
+location. Decline that prompt if you prefer to create the file yourself:
 
 ```bash
 mkdir -p ~/.config/bunnify
@@ -25,6 +31,9 @@ curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.
 
 In a development checkout you can instead `cp bunnify.json.example` from the
 repo root.
+
+Non-interactive starts (`bunnify-server --noninteractive`, CI, etc.) never
+seed automatically — create the file first.
 
 Run `bunnify setup` to write verified settings. Existing base-URL-only files
 remain supported; they are interpreted as remote mode.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -20,8 +20,8 @@ These files are user data and are not tracked by Git.
 ## Setup
 
 When `bookmarks.json` is missing, interactive `bunnify setup` (and other
-prompting CLI paths) offer to install the example bookmarks in the correct
-location. Decline that prompt if you prefer to create the file yourself:
+prompting CLI paths) offer to install the example bookmarks. Decline that
+prompt if you prefer to create the file yourself:
 
 ```bash
 mkdir -p ~/.config/bunnify
@@ -32,8 +32,12 @@ curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.
 In a development checkout you can instead `cp bunnify.json.example` from the
 repo root.
 
-Non-interactive starts (`bunnify-server --noninteractive`, CI, etc.) never
-seed automatically — create the file first.
+After install, edit that file directly to personalize shortcuts. The managed
+local server watches the bookmarks file and reloads on change
+(`watch_bookmarks`). The CLI resolves shortcuts through the server, so edits
+apply once the watcher reloads; in the interactive REPL run `refresh` to update
+Tab completion. Non-interactive starts (`bunnify-server --noninteractive`, CI,
+etc.) never seed automatically — create the file first.
 
 Run `bunnify setup` to write verified settings. Existing base-URL-only files
 remain supported; they are interpreted as remote mode.

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -27,8 +27,9 @@ In a development checkout, `./scripts/bunnify` and
 `./scripts/bunnify-server` prefer `uv run` when `uv` is on ``PATH``, otherwise
 they fall back to the checkout ``.venv`` (same entry points systemd uses).
 
-Setup defaults to **local** mode. It requires an existing bookmarks file (see
-[Configuration](CONFIG.md)), prompts for a free non-privileged listening port
+Setup defaults to **local** mode. When `bookmarks.json` is missing, it offers
+to install the example shortcuts (see [Configuration](CONFIG.md)). It then
+prompts for a free non-privileged listening port
 (default `8000`, or `0` for an OS-assigned port), starts a managed server,
 verifies `/health`, and records the selected port in `config.env` and under
 `$BUNNIFY_DATA_DIR/run/` (for example `~/scratch/bunnify/run` on service hosts).

--- a/docs/SYSTEMD.md
+++ b/docs/SYSTEMD.md
@@ -19,7 +19,7 @@ The unit **template** (with `@@REPO_DIR@@`) lives in this repo at
 - systemd user session available (`systemctl --user status` returns output)
 - `~/work/ai/repository-helpers` cloned locally
 - Bunnify dependencies installed (`uv sync`)
-- Bookmarks at `~/.config/bunnify/bookmarks.json` (create from `bunnify.json.example` before first start)
+- Bookmarks at `~/.config/bunnify/bookmarks.json` (from `bunnify setup` or `bunnify.json.example` before first start)
 - `~/.config/user-services-host` — short hostname label for the service host (or pass
   `--condition-host` on first `setup-service` run)
 - `~/.config/user-services-host-fqdn` — FQDN captured on the service host (or


### PR DESCRIPTION
## Summary
- During interactive `bunnify setup` (and other prompting CLI paths), offer to install example bookmarks when `bookmarks.json` is missing.
- Refresh `bunnify.json.example` / packaged `bookmarks.example.json` with Google properties (including YouTube), generic GitHub shortcuts, and a `bun` → bunnify source link — without personal org keys (`ih`/`ihh`).
- Modernize README (PyPI/CI/license/Python badges) and align CONFIG/LOCAL/onboarding docs.

## Stack
Stacked on #282 (`setup-port-stop/wait-port-free`).

## Test plan
- [x] `./scripts/checks` (unit + packaging + integration)
- [x] New `ensure_user_bookmarks` prompt accept/decline tests
- [ ] Manual: remove bookmarks file, run `bunnify setup`, accept install, confirm `~/.config/bunnify/bookmarks.json` and `bunnify bun`


Made with [Cursor](https://cursor.com)