### PR TITLE
feat: show build identity on setup, REPL, and pipx upgrade

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -23,6 +23,8 @@ curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.
 bunnify                         # interactive REPL
 bunnify onboard                 # post-install / upgrade checklist
 bunnify setup                   # configure local or remote server
+bunnify upgrade                 # pipx upgrade; prints which binary you ran
+bunnify --version               # package version, commit, and install path
 bunnify gh                      # open a shortcut (example key from bunnify.json.example)
 bunnify bun                     # Bunnify source on GitHub
 bunnify pr the-hcma/bunnify 272 # parameterized shortcut (repo + PR number)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Bunnify
 
 [![PyPI version](https://img.shields.io/pypi/v/bunnify.svg)](https://pypi.org/project/bunnify/)
-[![Python versions](https://img.shields.io/pypi/pyversions/bunnify.svg)](https://pypi.org/project/bunnify/)
-[![License](https://img.shields.io/pypi/l/bunnify.svg)](https://github.com/the-hcma/bunnify/blob/main/LICENSE)
+[![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://pypi.org/project/bunnify/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/the-hcma/bunnify/blob/main/LICENSE)
 [![CI](https://github.com/the-hcma/bunnify/actions/workflows/ci.yml/badge.svg)](https://github.com/the-hcma/bunnify/actions/workflows/ci.yml)
 
 A Python bookmark manager and URL shortcut system: terminal CLI, web command
@@ -59,10 +59,18 @@ Summary of what it covers:
 ### Upgrade
 
 ```bash
+bunnify upgrade          # pipx upgrade + show which binary you ran
+# or:
 pipx upgrade bunnify
+command -v bunnify       # should be ~/.local/bin/bunnify
 bunnify --version
-bunnify onboard    # refresh next-step reminders
+bunnify onboard          # refresh next-step reminders
 ```
+
+`pipx upgrade` only updates the pipx app. If `bunnify --version` still shows a
+git checkout SHA, PATH is hitting `./scripts/bunnify` or a repo `.venv` — that
+process is the checkout, not the 0.x.y wheel. Use `~/.local/bin/bunnify` (after
+`pipx ensurepath`) or `bunnify upgrade` which prints the path it ran from.
 
 Bookmarks and `~/.config/bunnify/config.env` are user data — upgrades do not
 overwrite them. After a major server change, re-run `bunnify setup` only if

--- a/app/cli.py
+++ b/app/cli.py
@@ -57,7 +57,13 @@ from app.interactive import (
 from app.local_server import ensure_local_server, port_is_free, stop_local_server
 from app.theme import Theme, stdout_color_enabled
 from app.usage import format_key_usage_lines
-from app.version import build_info, get_build_info
+from app.version import (
+    build_info,
+    build_version,
+    get_build_info,
+    is_source_checkout,
+    running_command_path,
+)
 
 BUILD_INFO = build_info()
 
@@ -207,9 +213,12 @@ def format_onboarding_text() -> str:
             "4. Try it:  bunnify gh   (or address-bar keyword, e.g. b gh)",
             "",
             "Upgrade later:",
-            "     pipx upgrade bunnify",
-            "     bunnify --version",
+            "     bunnify upgrade   # pipx upgrade, then show which binary you ran",
+            "     # or: pipx upgrade bunnify && command -v bunnify",
             "   Bookmarks and config.env are kept across upgrades.",
+            "   If --version still shows a checkout SHA, PATH is using",
+            "   ./scripts/bunnify or a repo .venv — the pipx app lives in",
+            "   ~/.local/bin/bunnify.",
             "",
             "Docs: https://github.com/the-hcma/bunnify",
             "Re-print this message anytime:  bunnify onboard",
@@ -279,6 +288,8 @@ def run_setup(
     existing = load_preferences(environ=environ, env_path=path)
 
     log(colors.header("Bunnify setup"))
+    log(colors.dim(build_version()))
+    log(colors.dim(f"running from {running_command_path()}"))
     log(colors.dim("Press Enter to accept the value in [brackets]."))
 
     while True:
@@ -405,6 +416,46 @@ def run_setup(
             + "Try another URL? [Y/n]: ",
         ):
             raise ClientError("Setup aborted; settings were not changed")
+
+
+def run_upgrade(
+    *,
+    print_fn: Callable[[str], None] | None = None,
+    pipx_bin: str | None = None,
+    run_fn: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> None:
+    """Upgrade the pipx install and explain which binary this process is."""
+    log = print_fn or click.echo
+    package, commit = get_build_info()
+    command_path = running_command_path()
+    log(f"This CLI is {package} ({commit})")
+    log(f"running from {command_path}")
+    if is_source_checkout():
+        log(
+            "This process is a git checkout, not the pipx app. "
+            "`pipx upgrade` updates ~/.local/bin/bunnify and will not change "
+            "this checkout's pyproject version or commit."
+        )
+        log("Verify the published install with:  command -v bunnify")
+
+    pipx = pipx_bin or shutil.which("pipx")
+    if pipx is None:
+        raise ClientError(
+            "pipx not found on PATH. Install pipx, then run: pipx upgrade bunnify"
+        )
+    runner = run_fn or subprocess.run
+    try:
+        completed = runner(
+            [pipx, "upgrade", "bunnify"],
+            check=False,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ClientError("Timed out running `pipx upgrade bunnify`") from exc
+    if completed.returncode != 0:
+        raise ClientError("pipx upgrade bunnify failed")
+    log("pipx upgrade finished. Re-run `bunnify --version` using ~/.local/bin/bunnify.")
 
 
 def matching_keys(keys: list[str], prefix: str) -> list[str]:
@@ -641,6 +692,12 @@ def _print_repl_help(theme: Theme) -> None:
     )
 
 
+def _echo_version() -> None:
+    """Print package version, commit, and the path of this process."""
+    click.echo(BUILD_INFO)
+    click.echo(f"running from {running_command_path()}")
+
+
 def _expand_query(
     query: str,
     *,
@@ -722,7 +779,7 @@ def _run_repl(
     entries = fetch_key_entries(base_url=base_url)
     keys = [entry.key for entry in entries]
     click.echo(
-        f"{theme.brand('bunnify')} "
+        f"{theme.brand('bunnify')} {theme.dim(build_version())} "
         f"{theme.dim('interactive — Tab fuzzy-completes; quit to exit')}"
     )
     click.echo(
@@ -983,13 +1040,27 @@ def _run(
     )
 
 
+def _print_cli_version(
+    ctx: click.Context,
+    _param: click.Parameter,
+    value: bool,
+) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    _echo_version()
+    ctx.exit()
+
+
 @click.command(
     context_settings={"help_option_names": ["-h", "--help"]},
 )
-@click.version_option(
-    version=BUILD_INFO.removeprefix("bunnify "),
-    prog_name="bunnify",
-    message="%(prog)s %(version)s",
+@click.option(
+    "--version",
+    is_flag=True,
+    is_eager=True,
+    expose_value=False,
+    callback=_print_cli_version,
+    help="Show the version and exit.",
 )
 @click.argument("shortcut_args", nargs=-1)
 @click.option(
@@ -1073,6 +1144,12 @@ def _run(
     is_flag=True,
     help="Configure a verified local or remote server (also: `bunnify setup`).",
 )
+@click.option(
+    "--upgrade",
+    "upgrade_requested",
+    is_flag=True,
+    help="Upgrade the pipx install (also: `bunnify upgrade`).",
+)
 def main(
     shortcut_args: tuple[str, ...],
     base_url_option: str | None,
@@ -1087,6 +1164,7 @@ def main(
     env_file: Path | None,
     onboard_requested: bool,
     setup_requested: bool,
+    upgrade_requested: bool,
 ) -> None:
     """
     Open a Bunnify shortcut in your default browser.
@@ -1116,13 +1194,18 @@ def main(
       ./scripts/bunnify --version
 
     \b
+    Upgrade the pipx install (`upgrade` is a reserved shortcut name):
+      bunnify upgrade
+      bunnify --upgrade
+
+    \b
     Fuzzy pick (fzf) for argv / shell completion workflows:
       ./scripts/bunnify --fzf
       ./scripts/bunnify --list-keys | fzf
       ./scripts/bunnify --list-usage
     """
     if shortcut_args == ("version",):
-        click.echo(BUILD_INFO)
+        _echo_version()
         return
 
     if onboard_requested or shortcut_args == ("onboard",):
@@ -1144,6 +1227,9 @@ def main(
         else default_edit_mode_from_environ()
     )
     try:
+        if upgrade_requested or shortcut_args == ("upgrade",):
+            run_upgrade()
+            return
         if setup_requested or shortcut_args == ("setup",):
             run_setup(
                 prompt_fn=prompt_fn,

--- a/app/tests.py
+++ b/app/tests.py
@@ -114,6 +114,16 @@ class BuildInfoTests(SimpleTestCase):
             self.assertEqual(shown, shim.absolute())
             self.assertNotEqual(shown, venv_binary.resolve())
 
+    def test_running_command_path_looks_up_bare_command_on_path(self) -> None:
+        located = Path("/Users/me/.local/bin/bunnify")
+        with (
+            mock.patch("app.version.sys.argv", ["bunnify-on-path"]),
+            mock.patch("app.version.shutil.which", return_value=str(located)) as which,
+        ):
+            shown = running_command_path()
+        which.assert_called_once_with("bunnify-on-path")
+        self.assertEqual(shown, located)
+
 
 class CliVersionTests(SimpleTestCase):
     def test_version_uses_distribution_metadata(self) -> None:

--- a/app/tests.py
+++ b/app/tests.py
@@ -90,19 +90,32 @@ class BuildInfoTests(SimpleTestCase):
                     "1.2.3",
                 )
 
+    def test_is_source_checkout_detects_git_dir(self) -> None:
+        from app.version import is_source_checkout
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            self.assertFalse(is_source_checkout(repository=root))
+            (root / ".git").mkdir()
+            self.assertTrue(is_source_checkout(repository=root))
+
 
 class CliVersionTests(SimpleTestCase):
     def test_version_uses_distribution_metadata(self) -> None:
         result = CliRunner().invoke(cli_main, ["--version"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.output, f"{build_info()}\n")
+        lines = result.output.splitlines()
+        self.assertEqual(lines[0], build_info())
+        self.assertTrue(lines[1].startswith("running from "))
 
     def test_version_command_prints_build_info(self) -> None:
         result = CliRunner().invoke(cli_main, ["version"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.output, f"{build_info()}\n")
+        lines = result.output.splitlines()
+        self.assertEqual(lines[0], build_info())
+        self.assertTrue(lines[1].startswith("running from "))
 
 
 class ConfigDataDirTests(SimpleTestCase):

--- a/app/tests.py
+++ b/app/tests.py
@@ -124,6 +124,22 @@ class BuildInfoTests(SimpleTestCase):
         which.assert_called_once_with("bunnify-on-path")
         self.assertEqual(shown, located)
 
+    def test_running_command_path_prefers_path_over_cwd_file(self) -> None:
+        located = Path("/Users/me/.local/bin/bunnify")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            cwd_file = Path(temporary_directory) / "bunnify"
+            cwd_file.write_text("not the CLI\n")
+            with (
+                mock.patch("app.version.sys.argv", ["bunnify"]),
+                mock.patch(
+                    "app.version.shutil.which",
+                    return_value=str(located),
+                ) as which,
+            ):
+                shown = running_command_path()
+        which.assert_called_once_with("bunnify")
+        self.assertEqual(shown, located)
+
 
 class CliVersionTests(SimpleTestCase):
     def test_version_uses_distribution_metadata(self) -> None:

--- a/app/tests.py
+++ b/app/tests.py
@@ -26,6 +26,7 @@ from app.version import (
     get_build_info,
     git_commit,
     package_version,
+    running_command_path,
 )
 
 
@@ -98,6 +99,20 @@ class BuildInfoTests(SimpleTestCase):
             self.assertFalse(is_source_checkout(repository=root))
             (root / ".git").mkdir()
             self.assertTrue(is_source_checkout(repository=root))
+
+    def test_running_command_path_keeps_console_script_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            venv_binary = root / "pipx" / "venvs" / "bunnify" / "bin" / "bunnify"
+            venv_binary.parent.mkdir(parents=True)
+            venv_binary.write_text("#!/bin/sh\n")
+            shim = root / "bin" / "bunnify"
+            shim.parent.mkdir()
+            shim.symlink_to(venv_binary)
+            with mock.patch("app.version.sys.argv", [str(shim)]):
+                shown = running_command_path()
+            self.assertEqual(shown, shim.absolute())
+            self.assertNotEqual(shown, venv_binary.resolve())
 
 
 class CliVersionTests(SimpleTestCase):

--- a/app/version.py
+++ b/app/version.py
@@ -100,7 +100,7 @@ def running_command_path() -> Path:
     with ``shutil.which`` so PATH launches do not report ``$PWD/bunnify``.
     """
     argv0 = Path(sys.argv[0]).expanduser()
-    if not argv0.is_absolute() and not argv0.exists():
+    if not argv0.is_absolute():
         located = shutil.which(os.fspath(argv0))
         if located:
             argv0 = Path(located)

--- a/app/version.py
+++ b/app/version.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import tomllib
 from collections.abc import Mapping
 from functools import lru_cache
@@ -71,6 +72,12 @@ def git_commit(
     return result.stdout.strip() or "unknown"
 
 
+def is_source_checkout(*, repository: Path | None = None) -> bool:
+    """Return whether this process is running from a git checkout of bunnify."""
+    checkout = repository or Path(__file__).resolve().parents[1]
+    return (checkout / ".git").exists()
+
+
 def package_version(*, pyproject_path: Path | None = None) -> str:
     """Return the distribution version, with a source-checkout fallback."""
     embedded = getattr(_build_metadata, "EMBEDDED_VERSION", "")
@@ -81,6 +88,15 @@ def package_version(*, pyproject_path: Path | None = None) -> str:
     except PackageNotFoundError:
         path = pyproject_path or Path(__file__).resolve().parents[1] / "pyproject.toml"
         return _pyproject_version(path)
+
+
+def running_command_path() -> Path:
+    """Return the resolved path of the command that started this process."""
+    argv0 = Path(sys.argv[0])
+    try:
+        return argv0.expanduser().resolve()
+    except OSError:
+        return argv0
 
 
 def _normalize_commit(token: str) -> str:

--- a/app/version.py
+++ b/app/version.py
@@ -91,10 +91,15 @@ def package_version(*, pyproject_path: Path | None = None) -> str:
 
 
 def running_command_path() -> Path:
-    """Return the resolved path of the command that started this process."""
-    argv0 = Path(sys.argv[0])
+    """Return the path of the command that started this process.
+
+    The path is made absolute without following console-script symlinks so a
+    pipx or uv-tool install prints the PATH entry (``~/.local/bin/bunnify``)
+    rather than the venv target.
+    """
+    argv0 = Path(sys.argv[0]).expanduser()
     try:
-        return argv0.expanduser().resolve()
+        return argv0.absolute()
     except OSError:
         return argv0
 

--- a/app/version.py
+++ b/app/version.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -95,9 +96,14 @@ def running_command_path() -> Path:
 
     The path is made absolute without following console-script symlinks so a
     pipx or uv-tool install prints the PATH entry (``~/.local/bin/bunnify``)
-    rather than the venv target.
+    rather than the venv target. Bare names such as ``bunnify`` are looked up
+    with ``shutil.which`` so PATH launches do not report ``$PWD/bunnify``.
     """
     argv0 = Path(sys.argv[0]).expanduser()
+    if not argv0.is_absolute() and not argv0.exists():
+        located = shutil.which(os.fspath(argv0))
+        if located:
+            argv0 = Path(located)
     try:
         return argv0.absolute()
     except OSError:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -291,6 +291,27 @@ class CliUnitTests(TestCase):
             "gh", base_url="http://127.0.0.1:8000", strict=True
         )
 
+    @patch("app.cli.fetch_key_entries")
+    def test_repl_banner_includes_version(self, mock_fetch_entries) -> None:
+        from app.version import build_version
+
+        mock_fetch_entries.return_value = [KeyEntry(key="gh")]
+        captured = StringIO()
+        with patch("sys.stdout", captured):
+            _run(
+                shortcut_args=(),
+                base_url="http://127.0.0.1:8000",
+                list_keys=False,
+                use_fzf=False,
+                fzf_query="",
+                print_url=False,
+                open_browser=False,
+                input_fn=lambda _prompt: "quit",
+            )
+        output = captured.getvalue()
+        self.assertIn(build_version(), output)
+        self.assertIn("interactive", output)
+
     @patch("app.cli.resolve_shortcut")
     @patch("app.cli.fetch_key_entries")
     def test_interactive_loop_runs_multiple_commands(
@@ -1226,6 +1247,8 @@ class ConfigUnitTests(TestCase):
             self.assertEqual(result, "http://127.0.0.1:8123")
             self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
             joined = "\n".join(messages)
+            self.assertIn("Bunnify setup", joined)
+            self.assertIn("running from", joined)
             self.assertIn("Port 8000 is free", joined)
             self.assertIn("Local Bunnify is healthy", joined)
             self.assertIn("Configured local Bunnify server", joined)
@@ -1777,11 +1800,52 @@ class ConfigUnitTests(TestCase):
         self.assertIn("bookmarks.json", result.output)
         self.assertIn("bunnify setup", result.output)
         self.assertIn("CHROME_SETUP.md", result.output)
+        self.assertIn("bunnify upgrade", result.output)
         self.assertIn("pipx upgrade bunnify", result.output)
 
         flagged = CliRunner().invoke(main, ["--onboard"])
         self.assertEqual(flagged.exit_code, 0)
         self.assertIn("bunnify setup", flagged.output)
+
+    def test_upgrade_runs_pipx_and_explains_checkout(self) -> None:
+        import subprocess
+        from unittest.mock import patch
+
+        from app.cli import main
+
+        completed = subprocess.CompletedProcess(
+            ["pipx", "upgrade", "bunnify"],
+            0,
+            "",
+            "",
+        )
+        with (
+            patch("app.cli.is_source_checkout", return_value=True),
+            patch("app.cli.shutil.which", return_value="/usr/bin/pipx"),
+            patch("app.cli.subprocess.run", return_value=completed) as run,
+        ):
+            result = CliRunner().invoke(main, ["upgrade"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("This CLI is", result.output)
+        self.assertIn("running from", result.output)
+        self.assertIn("git checkout", result.output)
+        run.assert_called_once()
+        self.assertEqual(run.call_args.args[0], ["/usr/bin/pipx", "upgrade", "bunnify"])
+
+    def test_upgrade_errors_when_pipx_missing(self) -> None:
+        from unittest.mock import patch
+
+        from app.cli import main
+
+        with (
+            patch("app.cli.is_source_checkout", return_value=False),
+            patch("app.cli.shutil.which", return_value=None),
+        ):
+            result = CliRunner().invoke(main, ["--upgrade"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("pipx not found", result.output)
 
     def test_base_url_prepends_http_scheme(self) -> None:
         from app.config import resolve_base_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,13 @@ name = "bunnify"
 version = "0.5.0"
 description = "Smart bookmark manager and URL shortcut system"
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.14"
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
+]
 dependencies = [
     "asgiref==3.12.1",
     "click>=8.4.2",


### PR DESCRIPTION
## Summary
- Print version and commit at setup and interactive start.
- Record MIT/Python classifiers so README badges are accurate.
- Add `bunnify upgrade` so a checkout on PATH is not mistaken for the pipx wheel.

## Test plan
- [x] `scripts/checks --skip-integration` in the stack worktree
- [x] `./test_bunnify` covers setup/REPL version output
- [ ] CI green on this PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>