### PR TITLE
feat: add bunnify stop for the managed local server

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -23,6 +23,7 @@ curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.
 bunnify                         # interactive REPL
 bunnify onboard                 # post-install / upgrade checklist
 bunnify setup                   # configure local or remote server
+bunnify stop                    # stop the managed local server
 bunnify upgrade                 # pipx upgrade; prints which binary you ran
 bunnify --version               # package version, commit, and install path
 bunnify gh                      # open a shortcut (example key from bunnify.json.example)
@@ -36,6 +37,7 @@ bunnify --list-keys             # list keys from the running server
 ## Server
 
 ```bash
+bunnify stop                    # stop the managed local server (local mode)
 bunnify-server --help
 bunnify-server --foreground --noninteractive --port 8000   # foreground (systemd/debug)
 bunnify-server --port 8000 --noninteractive --pid-dir ~/.local/share/bunnify/run

--- a/README.md
+++ b/README.md
@@ -154,7 +154,13 @@ bunnify-server --stop --pid-dir ~/.local/share/bunnify/run
 curl --max-time 2 http://127.0.0.1:8000/health
 ```
 
-`bunnify setup` starts a managed local server for daily CLI use. Details:
+`bunnify setup` starts a managed local server for daily CLI use. Stop it with:
+
+```bash
+bunnify stop
+```
+
+That prints the URL and runtime directory before stopping. Details:
 [Local and remote setup](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md).
 
 **Linux production:**

--- a/app/cli.py
+++ b/app/cli.py
@@ -437,11 +437,9 @@ def run_stop(
             "the remote host yourself."
         )
     pid_dir = run_dir(environ=environ)
-    port = None
-    if preferences is not None and preferences.local_port is not None:
+    port = _managed_local_port(pid_dir)
+    if port is None and preferences is not None:
         port = preferences.local_port
-    if port is None:
-        port = _managed_local_port(pid_dir)
     if port is None:
         raise ClientError(
             "No local Bunnify server is recorded. Start one with `bunnify setup`."
@@ -557,9 +555,12 @@ def _format_running_build(health: HealthStatus) -> str:
 def _managed_local_port(pid_dir: Path) -> int | None:
     """Return the port recorded for this CLI run dir, if any."""
     try:
-        return int((pid_dir / LOCAL_PORT_FILE_NAME).read_text(encoding="utf-8").strip())
+        port = int((pid_dir / LOCAL_PORT_FILE_NAME).read_text(encoding="utf-8").strip())
     except OSError, ValueError:
         return None
+    if not 1 <= port <= 65535:
+        return None
+    return port
 
 
 def _offer_restart_mismatched_server(

--- a/app/cli.py
+++ b/app/cli.py
@@ -418,6 +418,52 @@ def run_setup(
             raise ClientError("Setup aborted; settings were not changed")
 
 
+def run_stop(
+    *,
+    environ: dict[str, str] | None = None,
+    env_path: Path | None = None,
+    print_fn: Callable[[str], None] | None = None,
+    theme: Theme | None = None,
+) -> None:
+    """Stop the managed local server recorded for this CLI install."""
+    log = print_fn or click.echo
+    colors = theme if theme is not None else Theme(enabled=False)
+    path = env_path if env_path is not None else env_file_path(environ=environ)
+    preferences = load_preferences(environ=environ, env_path=path)
+    if preferences is not None and preferences.mode == "remote":
+        raise ClientError(
+            "Configured mode is remote; `bunnify stop` only stops a local "
+            "managed server. Re-run `bunnify setup` and choose local, or stop "
+            "the remote host yourself."
+        )
+    pid_dir = run_dir(environ=environ)
+    port = None
+    if preferences is not None and preferences.local_port is not None:
+        port = preferences.local_port
+    if port is None:
+        port = _managed_local_port(pid_dir)
+    if port is None:
+        raise ClientError(
+            "No local Bunnify server is recorded. Start one with `bunnify setup`."
+        )
+    base_url = f"http://127.0.0.1:{port}"
+    log(colors.header("Stopping local Bunnify"))
+    log(f"URL: {base_url}")
+    log(f"Runtime directory: {pid_dir}")
+    health = fetch_health(base_url)
+    if health.ok:
+        log(f"Running build: {_format_running_build(health)}")
+    else:
+        log(
+            colors.dim(
+                "Server did not respond to /health; stopping the managed "
+                "process anyway."
+            )
+        )
+    stop_local_server(pid_dir, port=port)
+    log(colors.ok(f"Stopped local Bunnify at {base_url}"))
+
+
 def run_upgrade(
     *,
     print_fn: Callable[[str], None] | None = None,
@@ -1145,6 +1191,12 @@ def _print_cli_version(
     help="Configure a verified local or remote server (also: `bunnify setup`).",
 )
 @click.option(
+    "--stop",
+    "stop_requested",
+    is_flag=True,
+    help="Stop the managed local server (also: `bunnify stop`).",
+)
+@click.option(
     "--upgrade",
     "upgrade_requested",
     is_flag=True,
@@ -1164,6 +1216,7 @@ def main(
     env_file: Path | None,
     onboard_requested: bool,
     setup_requested: bool,
+    stop_requested: bool,
     upgrade_requested: bool,
 ) -> None:
     """
@@ -1187,6 +1240,11 @@ def main(
     Server setup (`setup` is a reserved shortcut name):
       ./scripts/bunnify setup
       ./scripts/bunnify --setup
+
+    \b
+    Stop the local managed server (`stop` is a reserved shortcut name):
+      bunnify stop
+      bunnify --stop
 
     \b
     Build identity (`version` is a reserved shortcut name):
@@ -1227,6 +1285,13 @@ def main(
         else default_edit_mode_from_environ()
     )
     try:
+        if stop_requested or shortcut_args == ("stop",):
+            run_stop(
+                env_path=env_file,
+                print_fn=click.echo,
+                theme=theme,
+            )
+            return
         if upgrade_requested or shortcut_args == ("upgrade",):
             run_upgrade()
             return

--- a/app/local_server.py
+++ b/app/local_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import socket
 import subprocess
 import sys
@@ -120,6 +121,8 @@ def stop_local_server(
     When ``port`` is set, wait until that port can be bound again before
     returning so callers can restart on the same port.
     """
+    _validate_stop_port(port)
+    _validate_port_timeout_s(port_timeout_s)
     # Worst case: SIGTERM+SIGKILL waits for pid and listener, then port wait.
     stop_timeout_s = max(60.0, port_timeout_s + 35)
     try:
@@ -165,3 +168,15 @@ def wait_for_port_free(port: int, *, timeout_s: float = 15) -> bool:
             return True
         time.sleep(0.05)
     return port_is_free(port)
+
+
+def _validate_port_timeout_s(port_timeout_s: float) -> None:
+    if not math.isfinite(port_timeout_s) or port_timeout_s <= 0:
+        raise ValueError("port_timeout_s must be a positive finite number")
+
+
+def _validate_stop_port(port: int | None) -> None:
+    if port is None:
+        return
+    if port < 1 or port > 65535:
+        raise ValueError("Stop wait port must be between 1 and 65535")

--- a/app/tests.py
+++ b/app/tests.py
@@ -304,6 +304,33 @@ class LocalServerTests(SimpleTestCase):
         # match Django's runserver and treat the port as usable.
         self.assertTrue(port_is_free(port))
 
+    def test_port_is_free_enables_reuseaddr_on_probe_socket(self) -> None:
+        from app.local_server import port_is_free
+
+        with mock.patch("app.local_server.socket.socket") as socket_cls:
+            probe = socket_cls.return_value.__enter__.return_value
+            probe.bind.return_value = None
+            self.assertTrue(port_is_free(8123))
+            probe.setsockopt.assert_called_with(
+                socket.SOL_SOCKET,
+                socket.SO_REUSEADDR,
+                1,
+            )
+
+    def test_stop_rejects_ephemeral_wait_port(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with self.assertRaisesRegex(ValueError, "1 and 65535"):
+                stop_local_server(Path(temporary_directory), port=0)
+
+    def test_stop_rejects_non_positive_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with self.assertRaisesRegex(ValueError, "positive"):
+                stop_local_server(Path(temporary_directory), port_timeout_s=0)
+            with self.assertRaisesRegex(ValueError, "positive"):
+                stop_local_server(
+                    Path(temporary_directory), port_timeout_s=float("nan")
+                )
+
 
 class ServerCliVersionTests(SimpleTestCase):
     def test_version_uses_distribution_metadata(self) -> None:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1847,6 +1847,99 @@ class ConfigUnitTests(TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("pipx not found", result.output)
 
+    def test_stop_ignores_out_of_range_port_file(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import main
+        from app.config import (
+            LOCAL_PORT_FILE_NAME,
+            ServerPreferences,
+            run_dir,
+            save_preferences,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_home = Path(tmp) / "config"
+            data_home = Path(tmp) / "data"
+            env_path = config_home / "bunnify" / "config.env"
+            env_path.parent.mkdir(parents=True)
+            isolated = {
+                "XDG_CONFIG_HOME": str(config_home),
+                "XDG_DATA_HOME": str(data_home),
+            }
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=env_path,
+                environ=isolated,
+            )
+            port_file = run_dir(environ=isolated) / LOCAL_PORT_FILE_NAME
+            port_file.write_text("0\n", encoding="utf-8")
+            with (
+                patch("app.cli.fetch_health", return_value=_healthy_status()),
+                patch("app.cli.stop_local_server") as stop_server,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    ["stop", "--env-file", str(env_path)],
+                    env=isolated,
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(stop_server.call_args.kwargs.get("port"), 8123)
+
+    def test_stop_prefers_runtime_port_file_over_config(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import main
+        from app.config import (
+            LOCAL_PORT_FILE_NAME,
+            ServerPreferences,
+            run_dir,
+            save_preferences,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_home = Path(tmp) / "config"
+            data_home = Path(tmp) / "data"
+            env_path = config_home / "bunnify" / "config.env"
+            env_path.parent.mkdir(parents=True)
+            isolated = {
+                "XDG_CONFIG_HOME": str(config_home),
+                "XDG_DATA_HOME": str(data_home),
+            }
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=env_path,
+                environ=isolated,
+            )
+            port_file = run_dir(environ=isolated) / LOCAL_PORT_FILE_NAME
+            port_file.write_text("9000\n", encoding="utf-8")
+            with (
+                patch("app.cli.fetch_health", return_value=_healthy_status()),
+                patch("app.cli.stop_local_server") as stop_server,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    ["stop", "--env-file", str(env_path)],
+                    env=isolated,
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("http://127.0.0.1:9000", result.output)
+        self.assertEqual(stop_server.call_args.kwargs.get("port"), 9000)
+
     def test_stop_prints_url_and_stops_managed_server(self) -> None:
         import tempfile
         from pathlib import Path
@@ -1856,9 +1949,14 @@ class ConfigUnitTests(TestCase):
         from app.config import ServerPreferences, save_preferences
 
         with tempfile.TemporaryDirectory() as tmp:
-            config_home = Path(tmp)
+            config_home = Path(tmp) / "config"
+            data_home = Path(tmp) / "data"
             env_path = config_home / "bunnify" / "config.env"
             env_path.parent.mkdir(parents=True)
+            isolated = {
+                "XDG_CONFIG_HOME": str(config_home),
+                "XDG_DATA_HOME": str(data_home),
+            }
             save_preferences(
                 ServerPreferences(
                     mode="local",
@@ -1866,20 +1964,17 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=env_path,
+                environ=isolated,
             )
             healthy = _healthy_status(version="0.5.0", commit="abc123456789")
             with (
                 patch("app.cli.fetch_health", return_value=healthy),
                 patch("app.cli.stop_local_server") as stop_server,
-                patch(
-                    "app.cli.run_dir",
-                    return_value=Path(tmp) / "run",
-                ),
             ):
                 result = CliRunner().invoke(
                     main,
                     ["stop", "--env-file", str(env_path)],
-                    env={"XDG_CONFIG_HOME": str(config_home)},
+                    env=isolated,
                 )
 
         self.assertEqual(result.exit_code, 0, result.output)

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1847,6 +1847,70 @@ class ConfigUnitTests(TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("pipx not found", result.output)
 
+    def test_stop_prints_url_and_stops_managed_server(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import main
+        from app.config import ServerPreferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_home = Path(tmp)
+            env_path = config_home / "bunnify" / "config.env"
+            env_path.parent.mkdir(parents=True)
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=env_path,
+            )
+            healthy = _healthy_status(version="0.5.0", commit="abc123456789")
+            with (
+                patch("app.cli.fetch_health", return_value=healthy),
+                patch("app.cli.stop_local_server") as stop_server,
+                patch(
+                    "app.cli.run_dir",
+                    return_value=Path(tmp) / "run",
+                ),
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    ["stop", "--env-file", str(env_path)],
+                    env={"XDG_CONFIG_HOME": str(config_home)},
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("http://127.0.0.1:8123", result.output)
+        self.assertIn("0.5.0 (abc123456789)", result.output)
+        self.assertIn("Stopped local Bunnify", result.output)
+        stop_server.assert_called_once()
+        self.assertEqual(stop_server.call_args.kwargs.get("port"), 8123)
+
+    def test_stop_refuses_remote_mode(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import main
+        from app.config import ServerPreferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = Path(tmp) / "config.env"
+            save_preferences(
+                ServerPreferences(
+                    mode="remote",
+                    base_url="https://bunnify.example",
+                    local_port=None,
+                ),
+                env_path=env_path,
+            )
+            result = CliRunner().invoke(main, ["--stop", "--env-file", str(env_path)])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("remote", result.output.lower())
+
     def test_base_url_prepends_http_scheme(self) -> None:
         from app.config import resolve_base_url
 

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -48,6 +48,17 @@ BUNNIFY_LOCAL_PORT=8000
 `setup` is a reserved CLI shortcut name. Use `--base-url URL` for a one-time
 server override that is not persisted.
 
+To stop the managed local server:
+
+```bash
+bunnify stop
+# equivalent: bunnify --stop
+```
+
+That prints the URL and runtime directory, then stops the process recorded for
+this CLI install. Remote mode is unchanged — stop the host service there
+instead.
+
 ## Manual local workflow
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `bunnify stop` for the managed local server.
- Print the local URL and runtime directory before stopping.
- Reject invalid stop-wait ports so an ephemeral bind cannot look like success.

## Test plan
- [x] `scripts/checks --skip-integration` in the stack worktree
- [x] Unit tests for stop URL/runtime output and port validation
- [ ] CI green on this PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>