### PR TITLE
feat: compare upgrade from/to builds and replace older local servers

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -24,7 +24,7 @@ bunnify                         # interactive REPL
 bunnify onboard                 # post-install / upgrade checklist
 bunnify setup                   # configure local or remote server
 bunnify stop                    # stop the managed local server
-bunnify upgrade                 # pipx upgrade; prints which binary you ran
+bunnify upgrade                 # preferred: pipx upgrade; prints from/to versions
 bunnify --version               # package version, commit, and install path
 bunnify gh                      # open a shortcut (example key from bunnify.json.example)
 bunnify bun                     # Bunnify source on GitHub

--- a/README.md
+++ b/README.md
@@ -58,23 +58,24 @@ Summary of what it covers:
 
 ### Upgrade
 
+Preferred:
+
 ```bash
-bunnify upgrade          # pipx upgrade + show which binary you ran
-# or:
-pipx upgrade bunnify
-command -v bunnify       # should be ~/.local/bin/bunnify
-bunnify --version
-bunnify onboard          # refresh next-step reminders
+bunnify upgrade
 ```
 
-`pipx upgrade` only updates the pipx app. If `bunnify --version` still shows a
-git checkout SHA, PATH is hitting `./scripts/bunnify` or a repo `.venv` — that
-process is the checkout, not the 0.x.y wheel. Use `~/.local/bin/bunnify` (after
-`pipx ensurepath`) or `bunnify upgrade` which prints the path it ran from.
+That prints the version/commit you are running **from**, the PyPI target, then
+the pipx app version/commit **to** after `pipx upgrade`. Use this instead of
+bare `pipx upgrade bunnify` so you can see when PATH is still a git checkout.
+
+`pipx upgrade` only updates `~/.local/bin/bunnify`. If `bunnify --version` still
+shows a checkout SHA, PATH is hitting `./scripts/bunnify` or a repo `.venv`.
+After `pipx ensurepath`, `command -v bunnify` should be `~/.local/bin/bunnify`.
 
 Bookmarks and `~/.config/bunnify/config.env` are user data — upgrades do not
 overwrite them. After a major server change, re-run `bunnify setup` only if
-docs or release notes say so.
+docs or release notes say so. Setup will offer to stop an older local server
+and start this CLI's build when the port is already in use.
 
 Source and docs: [github.com/the-hcma/bunnify](https://github.com/the-hcma/bunnify).
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ After `pipx ensurepath`, `command -v bunnify` should be `~/.local/bin/bunnify`.
 
 Bookmarks and `~/.config/bunnify/config.env` are user data — upgrades do not
 overwrite them. After a major server change, re-run `bunnify setup` only if
-docs or release notes say so. Setup will offer to stop an older local server
-and start this CLI's build when the port is already in use.
+docs or release notes say so. Setup will offer to stop a different local
+Bunnify build and start this CLI's build when the port is already in use.
 
 Source and docs: [github.com/the-hcma/bunnify](https://github.com/the-hcma/bunnify).
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import json
+import os
 import shutil
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
 
 import click
+from packaging.version import InvalidVersion, Version
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.shortcuts import CompleteStyle
 
@@ -212,9 +217,8 @@ def format_onboarding_text() -> str:
             "",
             "4. Try it:  bunnify gh   (or address-bar keyword, e.g. b gh)",
             "",
-            "Upgrade later:",
-            "     bunnify upgrade   # pipx upgrade, then show which binary you ran",
-            "     # or: pipx upgrade bunnify && command -v bunnify",
+            "Upgrade later (preferred):",
+            "     bunnify upgrade   # shows from/to versions, then pipx upgrade",
             "   Bookmarks and config.env are kept across upgrades.",
             "   If --version still shows a checkout SHA, PATH is using",
             "   ./scripts/bunnify or a repo .venv — the pipx app lives in",
@@ -468,25 +472,36 @@ def run_upgrade(
     pipx_bin: str | None = None,
     run_fn: Callable[..., subprocess.CompletedProcess[str]] | None = None,
 ) -> None:
-    """Upgrade the pipx install and explain which binary this process is."""
+    """Upgrade the pipx install and report from/to versions with commits."""
     log = print_fn or click.echo
     package, commit = get_build_info()
+    from_label = f"{package} ({commit})"
     command_path = running_command_path()
-    log(f"This CLI is {package} ({commit})")
-    log(f"running from {command_path}")
+    log(f"From: {from_label}")
+    log(f"      {command_path}")
     if is_source_checkout():
         log(
             "This process is a git checkout, not the pipx app. "
-            "`pipx upgrade` updates ~/.local/bin/bunnify and will not change "
-            "this checkout's pyproject version or commit."
+            "`bunnify upgrade` updates ~/.local/bin/bunnify and will not "
+            "change this checkout's pyproject version or commit."
         )
-        log("Verify the published install with:  command -v bunnify")
 
     pipx = pipx_bin or shutil.which("pipx")
     if pipx is None:
         raise ClientError(
-            "pipx not found on PATH. Install pipx, then run: pipx upgrade bunnify"
+            "pipx not found on PATH. Install pipx, then run: bunnify upgrade"
         )
+    pypi_version = _pypi_latest_version()
+    pipx_app = _pipx_bunnify_path()
+    before_pipx = _read_executable_build(pipx_app) if pipx_app is not None else None
+    if before_pipx is not None and pipx_app is not None:
+        log(f"pipx app now: {before_pipx}")
+        log(f"              {pipx_app}")
+    if pypi_version is not None:
+        log(f"To:   {pypi_version} (PyPI latest; commit confirmed after upgrade)")
+    else:
+        log("To:   (querying PyPI failed; will show the pipx app after upgrade)")
+
     runner = run_fn or subprocess.run
     try:
         completed = runner(
@@ -499,7 +514,22 @@ def run_upgrade(
         raise ClientError("Timed out running `pipx upgrade bunnify`") from exc
     if completed.returncode != 0:
         raise ClientError("pipx upgrade bunnify failed")
-    log("pipx upgrade finished. Re-run `bunnify --version` using ~/.local/bin/bunnify.")
+
+    pipx_app = _pipx_bunnify_path() or pipx_app
+    after_pipx = _read_executable_build(pipx_app) if pipx_app is not None else None
+    if after_pipx is not None and pipx_app is not None:
+        log(f"To:   {after_pipx}")
+        log(f"      {pipx_app}")
+    else:
+        log(
+            "pipx upgrade finished, but could not read ~/.local/bin/bunnify "
+            "--version. Run that binary directly to confirm."
+        )
+    if from_label != after_pipx and is_source_checkout():
+        log(
+            "This process is still the checkout. Use the pipx path above "
+            "(after `pipx ensurepath`) for the upgraded app."
+        )
 
 
 def matching_keys(keys: list[str], prefix: str) -> list[str]:
@@ -518,6 +548,17 @@ def _builds_match(health: HealthStatus) -> bool:
         return False
     local_version, local_commit = get_build_info()
     return health.version == local_version and health.commit == local_commit
+
+
+def _cli_is_newer_than(health: HealthStatus) -> bool:
+    """Return whether this CLI's package version is newer than ``health``."""
+    if health.version is None:
+        return False
+    local_version, _local_commit = get_build_info()
+    try:
+        return Version(health.version) < Version(local_version)
+    except InvalidVersion:
+        return False
 
 
 def _confirm_explicit_yes(prompt_fn: Callable[[str], str], message: str) -> bool:
@@ -576,9 +617,6 @@ def _offer_restart_mismatched_server(
 
     Returns the port when the caller should reuse or restart into it, or
     ``None`` when the prompt loop should continue (stop failed / still busy).
-
-    Restart is only offered when ``pid_dir`` records this same ``port``, so we
-    do not SIGTERM an unrelated managed server or loop when stop is a no-op.
     """
     local_version, local_commit = get_build_info()
     local_label = f"{local_version} ({local_commit})"
@@ -592,28 +630,81 @@ def _offer_restart_mismatched_server(
                 f"Could not determine the running build (this CLI is {local_label})."
             )
         )
+        prompt = f"Stop it and start {local_label} on port {port}? [y/N]: "
+    elif _cli_is_newer_than(health):
+        print_fn(theme.warn(f"That server is older than this CLI ({local_label})."))
+        prompt = f"Stop {running_label} and start {local_label} on port {port}? [y/N]: "
     else:
         print_fn(theme.warn(f"Running build differs from this CLI ({local_label})."))
+        prompt = f"Restart with this CLI ({local_label}) on port {port}? [y/N]: "
     if _managed_local_port(pid_dir) != port:
         print_fn(
             theme.warn(
-                "Not managed by this CLI run directory; reusing the running server. "
-                "Stop it yourself (or choose another port) to start a fresh build."
+                "Not recorded in this CLI run directory; confirming will stop "
+                "the Bunnify process listening on that port."
             )
         )
-        return port
-    if not _confirm_explicit_yes(
-        prompt_fn,
-        "Restart the managed local server with this CLI? [y/N]: ",
-    ):
+    if not _confirm_explicit_yes(prompt_fn, prompt):
+        print_fn(theme.dim(f"Reusing the running server ({running_label})."))
         return port
     try:
-        stop_local_server(pid_dir, port=port)
+        stop_local_server(
+            pid_dir,
+            port=port,
+            replace_foreign_bunnify=True,
+        )
     except RuntimeError as exc:
         print_fn(theme.warn(f"Could not stop the managed server: {exc}"))
         return None
     print_fn(theme.ok(f"✓ Stopped previous server; port {port} is free"))
     return port
+
+
+def _parse_version_line(output: str) -> str | None:
+    """Return ``0.5.0 (abc1234)`` from a ``bunnify --version`` first line."""
+    first = output.splitlines()[0].strip() if output else ""
+    if not first:
+        return None
+    prefix = "bunnify "
+    if first.startswith(prefix):
+        return first[len(prefix) :].strip() or None
+    return first or None
+
+
+def _pipx_bunnify_path() -> Path | None:
+    """Return the pipx ``bunnify`` app path when it exists."""
+    override = os.environ.get("PIPX_BIN_DIR", "").strip()
+    candidates = []
+    if override:
+        candidates.append(Path(override) / "bunnify")
+    candidates.append(Path.home() / ".local" / "bin" / "bunnify")
+    for candidate in candidates:
+        if candidate.is_file():
+            try:
+                return candidate.resolve()
+            except OSError:
+                return candidate
+    return None
+
+
+def _pypi_latest_version() -> str | None:
+    """Return the latest bunnify version on PyPI, or None on failure."""
+    try:
+        with urllib.request.urlopen(
+            "https://pypi.org/pypi/bunnify/json",
+            timeout=8,
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (
+        OSError,
+        TimeoutError,
+        ValueError,
+        json.JSONDecodeError,
+        urllib.error.URLError,
+    ):
+        return None
+    version = payload.get("info", {}).get("version")
+    return version if isinstance(version, str) and version else None
 
 
 def _prompt_local_port(
@@ -692,6 +783,23 @@ def _prompt_local_port(
                 )
             )
         return found
+
+
+def _read_executable_build(executable: Path) -> str | None:
+    """Return version/commit from ``executable --version``, if readable."""
+    try:
+        completed = subprocess.run(
+            [str(executable), "--version"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=15,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return None
+    if completed.returncode != 0:
+        return None
+    return _parse_version_line(completed.stdout or "")
 
 
 def _retry_requested(prompt_fn: Callable[[str], str], message: str) -> bool:

--- a/app/cli.py
+++ b/app/cli.py
@@ -291,8 +291,7 @@ def run_setup(
     path = env_path if env_path is not None else env_file_path(environ=environ)
     existing = load_preferences(environ=environ, env_path=path)
 
-    log(colors.header("Bunnify setup"))
-    log(colors.dim(build_version()))
+    log(colors.header(_command_banner("setup")))
     log(colors.dim(f"running from {running_command_path()}"))
     log(colors.dim("Press Enter to accept the value in [brackets]."))
 
@@ -471,12 +470,15 @@ def run_upgrade(
     print_fn: Callable[[str], None] | None = None,
     pipx_bin: str | None = None,
     run_fn: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    theme: Theme | None = None,
 ) -> None:
     """Upgrade the pipx install and report from/to versions with commits."""
     log = print_fn or click.echo
+    colors = theme if theme is not None else Theme(enabled=False)
     package, commit = get_build_info()
     from_label = f"{package} ({commit})"
     command_path = running_command_path()
+    log(colors.header(_command_banner("upgrade")))
     log(f"From: {from_label}")
     log(f"      {command_path}")
     if is_source_checkout():
@@ -559,6 +561,11 @@ def _cli_is_newer_than(health: HealthStatus) -> bool:
         return Version(health.version) < Version(local_version)
     except InvalidVersion:
         return False
+
+
+def _command_banner(action: str) -> str:
+    """Return ``Bunnify version X.Y.Z (commit) - action`` for CLI headers."""
+    return f"Bunnify version {build_version()} - {action}"
 
 
 def _confirm_explicit_yes(prompt_fn: Callable[[str], str], message: str) -> bool:
@@ -1402,7 +1409,7 @@ def main(
             )
             return
         if upgrade_requested or shortcut_args == ("upgrade",):
-            run_upgrade()
+            run_upgrade(print_fn=click.echo, theme=theme)
             return
         if setup_requested or shortcut_args == ("setup",):
             run_setup(

--- a/app/cli.py
+++ b/app/cli.py
@@ -644,13 +644,20 @@ def _offer_restart_mismatched_server(
     else:
         print_fn(theme.warn(f"Running build differs from this CLI ({local_label})."))
         prompt = f"Restart with this CLI ({local_label}) on port {port}? [y/N]: "
-    if _managed_local_port(pid_dir) != port:
+    managed = _managed_local_port(pid_dir)
+    if managed != port:
         print_fn(
             theme.warn(
                 "Not recorded in this CLI run directory; confirming will stop "
                 "the Bunnify process listening on that port."
             )
         )
+        if managed is not None:
+            print_fn(
+                theme.warn(
+                    f"This CLI's managed server on port {managed} will also be stopped."
+                )
+            )
     if not _confirm_explicit_yes(prompt_fn, prompt):
         print_fn(theme.dim(f"Reusing the running server ({running_label})."))
         return port

--- a/app/local_server.py
+++ b/app/local_server.py
@@ -115,28 +115,37 @@ def stop_local_server(
     *,
     port: int | None = None,
     port_timeout_s: float = 15,
+    replace_foreign_bunnify: bool = False,
 ) -> None:
     """Stop the managed local server associated with ``pid_dir``.
 
     When ``port`` is set, wait until that port can be bound again before
     returning so callers can restart on the same port.
+
+    ``replace_foreign_bunnify`` also stops a Bunnify listener on ``port`` that
+    was started with a different ``--pid-dir`` (explicit setup replacement).
     """
     _validate_stop_port(port)
     _validate_port_timeout_s(port_timeout_s)
+    if replace_foreign_bunnify and port is None:
+        raise ValueError("replace_foreign_bunnify requires a port")
     # Worst case: SIGTERM+SIGKILL waits for pid and listener, then port wait.
     stop_timeout_s = max(60.0, port_timeout_s + 35)
+    command = [
+        sys.executable,
+        "-m",
+        "app.server_cli",
+        "--stop",
+        "--pid-dir",
+        str(pid_dir),
+        "--port-timeout",
+        str(port_timeout_s),
+    ]
+    if replace_foreign_bunnify and port is not None:
+        command.extend(["--replace-on-port", str(port)])
     try:
         completed = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "app.server_cli",
-                "--stop",
-                "--pid-dir",
-                str(pid_dir),
-                "--port-timeout",
-                str(port_timeout_s),
-            ],
+            command,
             capture_output=True,
             check=False,
             text=True,

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -34,6 +34,7 @@ class ServerOptions:
     pid_dir: Path
     port: int
     port_timeout_s: float
+    replace_on_port: int | None
     stop: bool
 
 
@@ -107,6 +108,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--replace-on-port",
+        type=_port_value,
+        default=None,
+        help=(
+            "With --stop, also SIGTERM a Bunnify listener on this port even if "
+            "it was started with a different --pid-dir."
+        ),
+    )
+    parser.add_argument(
         "--stop",
         action="store_true",
         help="Stop the server identified by files under --pid-dir.",
@@ -127,6 +137,7 @@ def main(argv: list[str] | None = None) -> int:
         return _stop_managed_server(
             options.pid_dir,
             port_timeout_s=options.port_timeout_s,
+            replace_on_port=options.replace_on_port,
         )
 
     try:
@@ -294,6 +305,7 @@ def _parse_options(argv: list[str] | None) -> ServerOptions:
         pid_dir=(namespace.pid_dir or run_dir()).expanduser(),
         port=namespace.port,
         port_timeout_s=float(namespace.port_timeout),
+        replace_on_port=namespace.replace_on_port,
         stop=bool(namespace.stop),
     )
 
@@ -556,11 +568,14 @@ def _stop_managed_server(
     *,
     quiet: bool = False,
     port_timeout_s: float = 15,
+    replace_on_port: int | None = None,
 ) -> int:
     """SIGTERM the managed server, wait for exit, then confirm its port is free."""
     pid_file, port_file, _watcher_pid_file = _pid_paths(pid_dir)
     pid = _read_pid(pid_file)
     port = _read_port(port_file)
+    if replace_on_port is not None:
+        port = replace_on_port
     if pid == os.getpid():
         return 0
 
@@ -579,20 +594,25 @@ def _stop_managed_server(
                         f"Refusing to stop unrelated process {pid}; "
                         "removed stale PID files."
                     )
-            return 0
-        if port is None:
-            command = _process_command(pid)
-            if command is not None:
-                port = _port_from_command(command)
-        _terminate_pid(pid)
-        signaled_pids.append(pid)
+            pid = None
+            if replace_on_port is None:
+                return 0
+        else:
+            if port is None:
+                command = _process_command(pid)
+                if command is not None:
+                    port = _port_from_command(command)
+            _terminate_pid(pid)
+            signaled_pids.append(pid)
 
     if port is not None and not _port_is_free(port):
         for listener_pid in _listener_pids(port):
             if listener_pid == os.getpid() or listener_pid in signaled_pids:
                 continue
-            if not _process_managed_by_pid_dir(listener_pid, pid_dir):
-                continue
+            managed = _process_managed_by_pid_dir(listener_pid, pid_dir)
+            if not managed:
+                if replace_on_port is None or not _is_bunnify_process(listener_pid):
+                    continue
             _terminate_pid(listener_pid)
             signaled_pids.append(listener_pid)
 

--- a/app/tests.py
+++ b/app/tests.py
@@ -233,6 +233,28 @@ class LocalServerTests(SimpleTestCase):
 
     @mock.patch("app.local_server.wait_for_port_free", return_value=True)
     @mock.patch("app.local_server.subprocess.run")
+    def test_stop_passes_replace_on_port(
+        self,
+        run: mock.Mock,
+        wait_for_port: mock.Mock,
+    ) -> None:
+        run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+
+            stop_local_server(
+                pid_dir,
+                port=8123,
+                replace_foreign_bunnify=True,
+            )
+
+        command = run.call_args.args[0]
+        self.assertIn("--replace-on-port", command)
+        self.assertEqual(command[command.index("--replace-on-port") + 1], "8123")
+        wait_for_port.assert_called_once_with(8123, timeout_s=15)
+
+    @mock.patch("app.local_server.wait_for_port_free", return_value=True)
+    @mock.patch("app.local_server.subprocess.run")
     def test_stop_waits_for_requested_port(
         self,
         run: mock.Mock,
@@ -430,6 +452,37 @@ class ServerStopTests(SimpleTestCase):
 
             terminate.assert_not_called()
             wait_for_port.assert_not_called()
+
+    def test_stop_replace_on_port_terminates_foreign_bunnify_listener(self) -> None:
+        from app.server_cli import _stop_managed_server
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            pid_dir = Path(temporary_directory)
+
+            with (
+                mock.patch("app.server_cli._port_is_free", return_value=False),
+                mock.patch("app.server_cli._listener_pids", return_value=[4242]),
+                mock.patch(
+                    "app.server_cli._process_managed_by_pid_dir",
+                    return_value=False,
+                ),
+                mock.patch(
+                    "app.server_cli._is_bunnify_process",
+                    return_value=True,
+                ),
+                mock.patch("app.server_cli._terminate_pid") as terminate,
+                mock.patch("app.server_cli._wait_for_port_free", return_value=True),
+            ):
+                self.assertEqual(
+                    _stop_managed_server(
+                        pid_dir,
+                        quiet=True,
+                        replace_on_port=8123,
+                    ),
+                    0,
+                )
+
+            terminate.assert_called_once_with(4242)
 
     def test_process_managed_by_pid_dir_defaults_missing_flag(self) -> None:
         from app.server_cli import _process_managed_by_pid_dir

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1247,7 +1247,8 @@ class ConfigUnitTests(TestCase):
             self.assertEqual(result, "http://127.0.0.1:8123")
             self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
             joined = "\n".join(messages)
-            self.assertIn("Bunnify setup", joined)
+            self.assertIn("Bunnify version", joined)
+            self.assertIn("- setup", joined)
             self.assertIn("running from", joined)
             self.assertIn("Port 8000 is free", joined)
             self.assertIn("Local Bunnify is healthy", joined)
@@ -1891,6 +1892,8 @@ class ConfigUnitTests(TestCase):
             result = CliRunner().invoke(main, ["upgrade"])
 
         self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Bunnify version", result.output)
+        self.assertIn("- upgrade", result.output)
         self.assertIn("From: ", result.output)
         self.assertIn("To:   0.5.0 (PyPI latest", result.output)
         self.assertIn("To:   0.5.0 (newnewnewnew)", result.output)

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1534,10 +1534,11 @@ class ConfigUnitTests(TestCase):
             self.assertEqual(result, "http://127.0.0.1:8000")
             stop_server.assert_called_once()
             self.assertEqual(stop_server.call_args.kwargs.get("port"), 8000)
+            self.assertTrue(stop_server.call_args.kwargs.get("replace_foreign_bunnify"))
             self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
             joined = "\n".join(messages)
             self.assertIn("already serving Bunnify 0.2.0 (oldoldoldold)", joined)
-            self.assertIn("differs from this CLI", joined)
+            self.assertIn("older than this CLI", joined)
             self.assertIn("Stopped previous server", joined)
 
     def test_setup_local_reports_stop_failure_when_port_stays_busy(self) -> None:
@@ -1588,7 +1589,9 @@ class ConfigUnitTests(TestCase):
             self.assertIn("Could not stop the managed server", joined)
             self.assertIn("still busy after stop", joined)
 
-    def test_setup_local_reuses_unmanaged_mismatched_server(self) -> None:
+    def test_setup_local_reuses_unmanaged_mismatched_server_when_declined(
+        self,
+    ) -> None:
         import tempfile
         from pathlib import Path
 
@@ -1622,8 +1625,59 @@ class ConfigUnitTests(TestCase):
             stop_server.assert_not_called()
             self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
             joined = "\n".join(messages)
-            self.assertIn("Not managed by this CLI run directory", joined)
-            self.assertIn("differs from this CLI", joined)
+            self.assertIn("older than this CLI", joined)
+            self.assertIn("Not recorded in this CLI run directory", joined)
+            self.assertIn("Reusing the running server", joined)
+
+    def test_setup_local_replaces_older_unmanaged_server_on_confirm(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import run_setup
+
+        remote = _healthy_status(version="0.2.0", commit="oldoldoldold")
+        responses = iter(["local", "", "y"])
+        messages: list[str] = []
+        port_state = {"free": False}
+
+        def port_free(_port: int) -> bool:
+            return port_state["free"]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8000", 8000),
+                ) as ensure_server,
+                patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.port_is_free", side_effect=port_free),
+                patch(
+                    "app.cli.stop_local_server",
+                    side_effect=lambda _pid_dir, **_kwargs: port_state.__setitem__(
+                        "free", True
+                    ),
+                ) as stop_server,
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                    env_path=path,
+                    print_fn=messages.append,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8000")
+            stop_server.assert_called_once()
+            self.assertEqual(stop_server.call_args.kwargs.get("port"), 8000)
+            self.assertTrue(stop_server.call_args.kwargs.get("replace_foreign_bunnify"))
+            self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
+            joined = "\n".join(messages)
+            self.assertIn("older than this CLI", joined)
+            self.assertIn("Stopped previous server", joined)
 
     def test_setup_local_normalizes_privileged_saved_port_default(self) -> None:
         import tempfile
@@ -1801,7 +1855,7 @@ class ConfigUnitTests(TestCase):
         self.assertIn("bunnify setup", result.output)
         self.assertIn("CHROME_SETUP.md", result.output)
         self.assertIn("bunnify upgrade", result.output)
-        self.assertIn("pipx upgrade bunnify", result.output)
+        self.assertIn("preferred", result.output.lower())
 
         flagged = CliRunner().invoke(main, ["--onboard"])
         self.assertEqual(flagged.exit_code, 0)
@@ -1809,6 +1863,7 @@ class ConfigUnitTests(TestCase):
 
     def test_upgrade_runs_pipx_and_explains_checkout(self) -> None:
         import subprocess
+        from pathlib import Path
         from unittest.mock import patch
 
         from app.cli import main
@@ -1822,13 +1877,23 @@ class ConfigUnitTests(TestCase):
         with (
             patch("app.cli.is_source_checkout", return_value=True),
             patch("app.cli.shutil.which", return_value="/usr/bin/pipx"),
+            patch("app.cli._pypi_latest_version", return_value="0.5.0"),
+            patch(
+                "app.cli._pipx_bunnify_path",
+                return_value=Path("/Users/me/.local/bin/bunnify"),
+            ),
+            patch(
+                "app.cli._read_executable_build",
+                side_effect=["0.4.0 (oldoldoldold)", "0.5.0 (newnewnewnew)"],
+            ),
             patch("app.cli.subprocess.run", return_value=completed) as run,
         ):
             result = CliRunner().invoke(main, ["upgrade"])
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("This CLI is", result.output)
-        self.assertIn("running from", result.output)
+        self.assertIn("From: ", result.output)
+        self.assertIn("To:   0.5.0 (PyPI latest", result.output)
+        self.assertIn("To:   0.5.0 (newnewnewnew)", result.output)
         self.assertIn("git checkout", result.output)
         run.assert_called_once()
         self.assertEqual(run.call_args.args[0], ["/usr/bin/pipx", "upgrade", "bunnify"])

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1680,6 +1680,58 @@ class ConfigUnitTests(TestCase):
             self.assertIn("older than this CLI", joined)
             self.assertIn("Stopped previous server", joined)
 
+    def test_setup_local_discloses_stopping_managed_server_on_other_port(
+        self,
+    ) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import run_setup
+        from app.config import LOCAL_PORT_FILE_NAME, run_dir
+
+        remote = _healthy_status(version="0.2.0", commit="oldoldoldold")
+        responses = iter(["local", "", "y"])
+        messages: list[str] = []
+        port_state = {"free": False}
+
+        def port_free(_port: int) -> bool:
+            return port_state["free"]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            environ = {"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp}
+            managed = run_dir(environ=environ)
+            managed.mkdir(parents=True, exist_ok=True)
+            (managed / LOCAL_PORT_FILE_NAME).write_text("8123\n", encoding="utf-8")
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8000", 8000),
+                ),
+                patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.port_is_free", side_effect=port_free),
+                patch(
+                    "app.cli.stop_local_server",
+                    side_effect=lambda _pid_dir, **_kwargs: port_state.__setitem__(
+                        "free", True
+                    ),
+                ),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    environ=environ,
+                    env_path=path,
+                    print_fn=messages.append,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8000")
+            joined = "\n".join(messages)
+            self.assertIn("managed server on port 8123 will also be stopped", joined)
+
     def test_setup_local_normalizes_privileged_saved_port_default(self) -> None:
         import tempfile
         from pathlib import Path

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -30,9 +30,12 @@ they fall back to the checkout ``.venv`` (same entry points systemd uses).
 Setup defaults to **local** mode. When `bookmarks.json` is missing, it offers
 to install the example shortcuts (see [Configuration](CONFIG.md)). It then
 prompts for a free non-privileged listening port
-(default `8000`, or `0` for an OS-assigned port), starts a managed server,
-verifies `/health`, and records the selected port in `config.env` and under
-`$BUNNIFY_DATA_DIR/run/` (for example `~/scratch/bunnify/run` on service hosts).
+(default `8000`, or `0` for an OS-assigned port). If that port already serves
+an **older** Bunnify, setup asks whether to stop it and start this CLI's build
+(even when the process was started with a different run directory). It then
+starts a managed server, verifies `/health`, and records the selected port in
+`config.env` and under `$BUNNIFY_DATA_DIR/run/` (for example
+`~/scratch/bunnify/run` on service hosts).
 Remote mode prompts for a URL and saves it only after its `/health` response is
 HTTP 200 with body `ok`.
 

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -31,8 +31,8 @@ Setup defaults to **local** mode. When `bookmarks.json` is missing, it offers
 to install the example shortcuts (see [Configuration](CONFIG.md)). It then
 prompts for a free non-privileged listening port
 (default `8000`, or `0` for an OS-assigned port). If that port already serves
-an **older** Bunnify, setup asks whether to stop it and start this CLI's build
-(even when the process was started with a different run directory). It then
+a **different** Bunnify build, setup asks whether to stop it and start this
+CLI's build (even when the process was started with a different run directory). It then
 starts a managed server, verifies `/health`, and records the selected port in
 `config.env` and under `$BUNNIFY_DATA_DIR/run/` (for example
 `~/scratch/bunnify/run` on service hosts).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -50,5 +50,14 @@ bunnify --version
 bunnify-server --help
 ```
 
+To move to a newer PyPI release, prefer:
+
+```bash
+bunnify upgrade
+```
+
+That prints the version/commit you are running from and the pipx app you
+upgraded to. Bare `pipx upgrade bunnify` also works but does not compare builds.
+
 For runtime configuration and server setup, see
 [Configuration](CONFIG.md) and [Local and remote setup](LOCAL.md).


### PR DESCRIPTION
## Summary
- Make `bunnify upgrade` the documented path and print this process versus the pipx/PyPI target with commits.
- Setup asks before stopping an older Bunnify on the chosen port, including servers from another run dir.
- Use a single header: `Bunnify version 0.5.0 (sha) - setup` (same pattern for upgrade).

## Test plan
- [x] `scripts/checks --skip-integration` in the stack worktree
- [x] Unit tests for upgrade from/to output and setup/upgrade banners
- [ ] CI green on this PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>