### PR TITLE
fix: match REPL Tab completions as contiguous substrings

### DIFF
--- a/app/interactive.py
+++ b/app/interactive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import NamedTuple
@@ -18,7 +19,7 @@ from prompt_toolkit.completion import (
 )
 from prompt_toolkit.document import Document
 from prompt_toolkit.enums import EditingMode
-from prompt_toolkit.formatted_text import AnyFormattedText, StyleAndTextTuples
+from prompt_toolkit.formatted_text import AnyFormattedText
 from prompt_toolkit.history import FileHistory, InMemoryHistory
 
 from app.client import ClientError, KeyEntry
@@ -362,7 +363,8 @@ class _FuzzyMatch(NamedTuple):
 def _best_fuzzy_match(needle: str, haystack: str) -> tuple[int, int] | None:
     """Best case-insensitive contiguous substring: ``(match_length, start_pos)``.
 
-    Positions refer to the original ``haystack`` (ASCII-safe). Scattered
+    Positions and length refer to the original ``haystack`` (via ``re.IGNORECASE``
+    match spans), so Unicode case folding cannot shift indices. Scattered
     subsequence matches such as ``p…o…r…t…u`` across a long description are
     not accepted.
     """
@@ -370,12 +372,10 @@ def _best_fuzzy_match(needle: str, haystack: str) -> tuple[int, int] | None:
         return 0, 0
     if not haystack:
         return None
-    folded_needle = needle.casefold()
-    folded_haystack = haystack.casefold()
-    start = folded_haystack.find(folded_needle)
-    if start < 0:
+    match = re.search(re.escape(needle), haystack, flags=re.IGNORECASE)
+    if match is None:
         return None
-    return len(folded_needle), start
+    return match.end() - match.start(), match.start()
 
 
 def _fuzzy_highlight_display(
@@ -386,20 +386,16 @@ def _fuzzy_highlight_display(
     needle: str,
 ) -> AnyFormattedText:
     """Highlight a contiguous substring match on a completion label."""
+    del needle
     if match_length == 0:
         return word
 
-    result: StyleAndTextTuples = []
-    result.append(("class:fuzzymatch.outside", word[:start_pos]))
-    characters = list(needle.casefold())
-    for char in word[start_pos : start_pos + match_length]:
-        classname = "class:fuzzymatch.inside"
-        if characters and char.casefold() == characters[0]:
-            classname += ".character"
-            del characters[0]
-        result.append((classname, char))
-    result.append(("class:fuzzymatch.outside", word[start_pos + match_length :]))
-    return result
+    end = start_pos + match_length
+    return [
+        ("class:fuzzymatch.outside", word[:start_pos]),
+        ("class:fuzzymatch.inside.character", word[start_pos:end]),
+        ("class:fuzzymatch.outside", word[end:]),
+    ]
 
 
 class FirstTokenFuzzyCompleter(Completer):

--- a/app/interactive.py
+++ b/app/interactive.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import NamedTuple
@@ -361,27 +360,22 @@ class _FuzzyMatch(NamedTuple):
 
 
 def _best_fuzzy_match(needle: str, haystack: str) -> tuple[int, int] | None:
-    """Best prompt_toolkit-style subsequence match: ``(match_length, start_pos)``.
+    """Best case-insensitive contiguous substring: ``(match_length, start_pos)``.
 
-    Matching is case-insensitive (``str.casefold``); positions refer to the
-    original ``haystack`` (ASCII-safe; same approach as prompt_toolkit's
-    ``re.IGNORECASE`` fuzzy completer).
+    Positions refer to the original ``haystack`` (ASCII-safe). Scattered
+    subsequence matches such as ``p…o…r…t…u`` across a long description are
+    not accepted.
     """
     if not needle:
         return 0, 0
     if not haystack:
         return None
-    # Casefold both sides so "Translate" matches "Google Translate …".
     folded_needle = needle.casefold()
     folded_haystack = haystack.casefold()
-    pat = ".*?".join(map(re.escape, folded_needle))
-    pat = f"(?=({pat}))"
-    regex = re.compile(pat)
-    matches = list(regex.finditer(folded_haystack))
-    if not matches:
+    start = folded_haystack.find(folded_needle)
+    if start < 0:
         return None
-    best = min(matches, key=lambda match: (match.start(), len(match.group(1))))
-    return len(best.group(1)), best.start()
+    return len(folded_needle), start
 
 
 def _fuzzy_highlight_display(
@@ -391,7 +385,7 @@ def _fuzzy_highlight_display(
     start_pos: int,
     needle: str,
 ) -> AnyFormattedText:
-    """Highlight subsequence matches on a completion label (prompt_toolkit parity)."""
+    """Highlight a contiguous substring match on a completion label."""
     if match_length == 0:
         return word
 
@@ -409,11 +403,11 @@ def _fuzzy_highlight_display(
 
 
 class FirstTokenFuzzyCompleter(Completer):
-    """Fuzzy-match the first token against shortcut keys *and* descriptions.
+    """Match the first token as a substring of shortcut keys *and* descriptions.
 
-    Matching is case-insensitive. Offered completions always insert/display the
-    command key (or meta name); descriptions are used only for matching and
-    ranking.
+    Matching is case-insensitive and contiguous (the typed text must appear as
+    a single span). Offered completions always insert/display the command key
+    (or meta name); descriptions are used only for matching and ranking.
     """
 
     def __init__(self, inner: ShortcutCompleter) -> None:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -2315,6 +2315,42 @@ class ConfigUnitTests(TestCase):
         self.assertEqual(texts[0], "tr")
         self.assertIn("gtre", texts)
 
+    def test_fuzzy_completer_requires_contiguous_substring(self) -> None:
+        from prompt_toolkit.document import Document
+
+        from app.interactive import FirstTokenFuzzyCompleter, ShortcutCompleter
+        from app.theme import Theme
+
+        entries = [
+            KeyEntry(
+                key="gtrp",
+                description="Google Translate - Portuguese to English",
+                url="https://translate.google.com/?sl=pt&tl=en&text=#{phrase}",
+                params=("phrase",),
+            ),
+            KeyEntry(
+                key="hgpr",
+                description=(
+                    "Graphite PR review for the-hcma org "
+                    "(Usage: hgpr <repo> <pr_number>)"
+                ),
+                url="https://app.graphite.com/github/pr/the-hcma/#{repo}/#{pr_number}",
+                params=("repo", "pr_number"),
+            ),
+        ]
+        completer = FirstTokenFuzzyCompleter(
+            ShortcutCompleter(
+                [entry.key for entry in entries],
+                theme=Theme(enabled=False),
+                include_meta=False,
+                entries=entries,
+            )
+        )
+        completions = list(
+            completer.get_completions(Document("portu"), complete_event=None)  # type: ignore[arg-type]
+        )
+        self.assertEqual([c.text for c in completions], ["gtrp"])
+
     @patch("app.cli.fetch_key_entries")
     def test_interactive_refresh_updates_keys(self, mock_fetch_entries) -> None:
         mock_fetch_entries.side_effect = [

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -2351,6 +2351,17 @@ class ConfigUnitTests(TestCase):
         )
         self.assertEqual([c.text for c in completions], ["gtrp"])
 
+    def test_fuzzy_match_indices_use_original_haystack(self) -> None:
+        from app.interactive import _best_fuzzy_match
+
+        matched = _best_fuzzy_match("PORTU", "…Portuguese…")
+        self.assertIsNotNone(matched)
+        assert matched is not None
+        match_length, start_pos = matched
+        self.assertEqual(start_pos, 1)
+        self.assertEqual(match_length, 5)
+        self.assertEqual("…Portuguese…"[start_pos : start_pos + match_length], "Portu")
+
     @patch("app.cli.fetch_key_entries")
     def test_interactive_refresh_updates_keys(self, mock_fetch_entries) -> None:
         mock_fetch_entries.side_effect = [


### PR DESCRIPTION
## Summary
- Require Tab completion to match the typed text as a contiguous substring in the shortcut key or description.
- Stops scattered letter hits such as `portu` matching `hgpr` via Graphite / for / the / Usage.

## Test plan
- [x] `scripts/checks --skip-integration` in the stack worktree
- [x] Unit test: `portu` completes `gtrp` and not `hgpr`
- [ ] CI green on this PR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>