### PR TITLE
feat: add macOS dual-Control no-op overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
     - name: Validate bunnify-server script
       run: ./scripts/bunnify-server --help
 
+    - name: Validate bunnify-overlay script
+      run: ./scripts/bunnify-overlay --help
+
     - name: Run unit tests
       run: ./test_bunnify
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -181,6 +181,9 @@ jobs:
       - name: Validate bunnify-server script
         run: ./scripts/bunnify-server --help
 
+      - name: Validate bunnify-overlay script
+        run: ./scripts/bunnify-overlay --help
+
       - name: Run unit tests
         run: ./test_bunnify
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,9 @@ Individual gates: `uv run ruff check .`, `uv run ruff format --check .`,
 - One logical change per PR; use `gh stack` stacking when appropriate
   (see `.github/stacking-tool` and [AGENTS.md](AGENTS.md))
 - Update user-facing docs when behavior or install paths change
-- Keep `./scripts/bunnify` and `./scripts/bunnify-server` as thin wrappers
-  around the installed entry points
+- Keep `./scripts/bunnify`, `./scripts/bunnify-server`, and
+  `./scripts/bunnify-overlay` as thin wrappers around the installed entry
+  points
 
 ## Questions
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -32,6 +32,7 @@ bunnify pr the-hcma/bunnify 272 # parameterized shortcut (repo + PR number)
 bunnify --fzf                   # fuzzy-pick a shortcut (requires fzf on PATH)
 bunnify --print-url gh          # print resolved URL instead of opening browser
 bunnify --list-keys             # list keys from the running server
+bunnify overlay                 # macOS search box (requires extra macos)
 ```
 
 ## Server

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ pipx installs `bunnify` and `bunnify-server` under **`~/.local/bin`** by default
 running either command. Prefer the pipx apps over any checkout
 `./scripts/bunnify` still on `PATH`.
 
-The wheel installs **`bunnify`** (CLI) and **`bunnify-server`** (Django
-server). No repository checkout or `uv` is required at runtime.
+The wheel installs **`bunnify`** (CLI), **`bunnify-server`** (Django
+server), and **`bunnify-overlay`** (macOS search box; needs extra
+`macos`). No repository checkout or `uv` is required at runtime.
 
 Package on PyPI: [pypi.org/project/bunnify](https://pypi.org/project/bunnify/).
 
@@ -135,6 +136,7 @@ Unknown keys exit non-zero in direct mode (no search-engine fallback).
 ## Features
 
 - **CLI / REPL** — fuzzy Tab completion, fzf mode, Vim/Emacs edit keys
+- **macOS overlay** — dual-Control search box (`bunnify-overlay`; extra `macos`)
 - **Web** — `/cmd/` command palette, `/list/` browser, smart `/search/`
 - **Chrome / Edge** — OpenSearch at `/opensearch.xml`
   ([setup guide](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md))

--- a/app/cli.py
+++ b/app/cli.py
@@ -1360,6 +1360,11 @@ def main(
       bunnify --onboard
 
     \b
+    macOS overlay (`overlay` is a reserved shortcut name):
+      bunnify overlay
+      ./scripts/bunnify-overlay
+
+    \b
     Server setup (`setup` is a reserved shortcut name):
       ./scripts/bunnify setup
       ./scripts/bunnify --setup
@@ -1392,6 +1397,11 @@ def main(
     if onboard_requested or shortcut_args == ("onboard",):
         click.echo(format_onboarding_text())
         return
+
+    if shortcut_args and shortcut_args[0] == "overlay":
+        from app.overlay_cli import main as overlay_main
+
+        raise SystemExit(overlay_main(list(shortcut_args[1:])))
 
     theme = Theme(enabled=stdout_color_enabled(color_mode.lower()))
 

--- a/app/overlay_app.py
+++ b/app/overlay_app.py
@@ -24,6 +24,7 @@ from Cocoa import (
     NSWindowStyleMaskFullSizeContentView,
     NSWindowStyleMaskTitled,
 )
+from PyObjCTools import AppHelper
 from Quartz import (
     CFMachPortCreateRunLoopSource,
     CFRunLoopAddSource,
@@ -52,6 +53,7 @@ from app.overlay_hotkey import (
     CONTROL_LEFT_KEYCODE,
     CONTROL_RIGHT_KEYCODE,
     ChordTracker,
+    apply_hid_snapshot,
 )
 
 PANEL_HEIGHT = 80.0
@@ -60,6 +62,14 @@ PANEL_WIDTH = 640.0
 
 class OverlayController(NSObject):
     """Owns the floating search panel and toggles it from the Control chord."""
+
+    def control_textView_doCommandBySelector_(self, _control, _text_view, selector):
+        """Dismiss on Esc/Return via the field editor (not NSTextField.keyDown_)."""
+        name = selector if isinstance(selector, str) else str(selector)
+        if name in {"cancelOperation:", "insertNewline:"}:
+            self.hide()
+            return True
+        return False
 
     def hide(self) -> None:
         panel = getattr(self, "panel", None)
@@ -120,7 +130,7 @@ class OverlayController(NSObject):
         panel.setReleasedWhenClosed_(False)
         panel.setDelegate_(self)
 
-        field = OverlayTextField.alloc().initWithFrame_(
+        field = NSTextField.alloc().initWithFrame_(
             NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, 40.0)
         )
         field.setEditable_(True)
@@ -129,7 +139,7 @@ class OverlayController(NSObject):
         field.setFont_(NSFont.systemFontOfSize_(20.0))
         field.setPlaceholderString_("Type a shortcut…")
         field.setBackgroundColor_(NSColor.textBackgroundColor())
-        field.overlayController = self
+        field.setDelegate_(self)
         panel.contentView().addSubview_(field)
 
         self.field = field
@@ -148,21 +158,6 @@ class OverlayController(NSObject):
         self.panel.setFrameOrigin_((origin_x, origin_y))
 
 
-class OverlayTextField(NSTextField):
-    """Dismiss the overlay on Escape or Return (completion is not wired yet)."""
-
-    overlayController = objc.ivar()
-
-    def keyDown_(self, event) -> None:
-        keycode = int(event.keyCode())
-        if keycode in {_ESCAPE_KEYCODE, _RETURN_KEYCODE}:
-            controller = self.overlayController
-            if controller is not None:
-                controller.hide()
-            return
-        objc.super(OverlayTextField, self).keyDown_(event)
-
-
 def run_overlay_app() -> int:
     """Run NSApplication until the process is interrupted."""
     NSApplication.sharedApplication()
@@ -175,14 +170,11 @@ def run_overlay_app() -> int:
         file=sys.stderr,
     )
     try:
-        NSApp.run()
+        AppHelper.runEventLoop()
     except KeyboardInterrupt:
+        AppHelper.stopEventLoop()
         return 0
     return 0
-
-
-_ESCAPE_KEYCODE = 53
-_RETURN_KEYCODE = 36
 
 
 def _control_key_down(keycode: int) -> bool:
@@ -215,7 +207,9 @@ def _install_event_tap(controller: OverlayController) -> None:
             CONTROL_RIGHT_KEYCODE,
         }:
             return event
-        if controller.chord.sync(
+        if apply_hid_snapshot(
+            controller.chord,
+            keycode=keycode,
             left_down=_control_key_down(CONTROL_LEFT_KEYCODE),
             right_down=_control_key_down(CONTROL_RIGHT_KEYCODE),
         ):

--- a/app/overlay_app.py
+++ b/app/overlay_app.py
@@ -1,0 +1,250 @@
+# pyright: reportMissingImports=false
+"""macOS overlay UI (PyObjC). Imported only after Cocoa/Quartz are available."""
+
+from __future__ import annotations
+
+import sys
+
+import objc
+from Cocoa import (
+    NSApp,
+    NSApplication,
+    NSApplicationActivationPolicyAccessory,
+    NSBackingStoreBuffered,
+    NSColor,
+    NSFloatingWindowLevel,
+    NSFont,
+    NSMakeRect,
+    NSObject,
+    NSPanel,
+    NSScreen,
+    NSTextField,
+    NSWindowCollectionBehaviorCanJoinAllSpaces,
+    NSWindowCollectionBehaviorFullScreenAuxiliary,
+    NSWindowStyleMaskFullSizeContentView,
+    NSWindowStyleMaskTitled,
+)
+from Quartz import (
+    CFMachPortCreateRunLoopSource,
+    CFRunLoopAddSource,
+    CFRunLoopGetCurrent,
+    CGEventGetIntegerValueField,
+    CGEventMaskBit,
+    CGEventSourceKeyState,
+    CGEventTapCreate,
+    CGEventTapEnable,
+    kCFRunLoopCommonModes,
+    kCGEventFlagsChanged,
+    kCGEventKeyDown,
+    kCGEventKeyUp,
+    kCGEventSourceStateHIDSystemState,
+    kCGEventTapDisabledByTimeout,
+    kCGEventTapDisabledByUserInput,
+    kCGEventTapOptionListenOnly,
+    kCGHeadInsertEventTap,
+    kCGHIDEventTap,
+    kCGKeyboardEventKeycode,
+    kCGSessionEventTap,
+)
+
+from app.overlay_cli import OverlayEventTapError
+from app.overlay_hotkey import (
+    CONTROL_LEFT_KEYCODE,
+    CONTROL_RIGHT_KEYCODE,
+    ChordTracker,
+)
+
+PANEL_HEIGHT = 80.0
+PANEL_WIDTH = 640.0
+
+
+class OverlayController(NSObject):
+    """Owns the floating search panel and toggles it from the Control chord."""
+
+    def hide(self) -> None:
+        panel = getattr(self, "panel", None)
+        if panel is not None:
+            panel.orderOut_(None)
+        self.visible = False
+
+    def init(self):
+        self = objc.super(OverlayController, self).init()
+        if self is None:
+            return None
+        self.callback = None
+        self.chord = ChordTracker()
+        self.field = None
+        self.panel = None
+        self.source = None
+        self.tap = None
+        self.visible = False
+        self._build_panel()
+        return self
+
+    def show(self) -> None:
+        if self.field is not None:
+            self.field.setStringValue_("")
+        self._center_panel()
+        if self.panel is not None:
+            self.panel.makeKeyAndOrderFront_(None)
+        NSApp.activateIgnoringOtherApps_(True)
+        if self.panel is not None and self.field is not None:
+            self.panel.makeFirstResponder_(self.field)
+        self.visible = True
+
+    def toggle(self) -> None:
+        if self.visible:
+            self.hide()
+        else:
+            self.show()
+
+    def windowDidResignKey_(self, _notification) -> None:
+        self.hide()
+
+    def _build_panel(self) -> None:
+        style = NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView
+        panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
+            NSMakeRect(0.0, 0.0, PANEL_WIDTH, PANEL_HEIGHT),
+            style,
+            NSBackingStoreBuffered,
+            False,
+        )
+        panel.setTitle_("bunnify")
+        panel.setTitlebarAppearsTransparent_(True)
+        panel.setLevel_(NSFloatingWindowLevel)
+        panel.setCollectionBehavior_(
+            NSWindowCollectionBehaviorCanJoinAllSpaces
+            | NSWindowCollectionBehaviorFullScreenAuxiliary
+        )
+        panel.setHidesOnDeactivate_(True)
+        panel.setReleasedWhenClosed_(False)
+        panel.setDelegate_(self)
+
+        field = OverlayTextField.alloc().initWithFrame_(
+            NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, 40.0)
+        )
+        field.setEditable_(True)
+        field.setSelectable_(True)
+        field.setBezeled_(True)
+        field.setFont_(NSFont.systemFontOfSize_(20.0))
+        field.setPlaceholderString_("Type a shortcut…")
+        field.setBackgroundColor_(NSColor.textBackgroundColor())
+        field.overlayController = self
+        panel.contentView().addSubview_(field)
+
+        self.field = field
+        self.panel = panel
+
+    def _center_panel(self) -> None:
+        if self.panel is None:
+            return
+        screen = NSScreen.mainScreen()
+        if screen is None:
+            return
+        visible = screen.visibleFrame()
+        frame = self.panel.frame()
+        origin_x = visible.origin.x + (visible.size.width - frame.size.width) / 2.0
+        origin_y = visible.origin.y + (visible.size.height - frame.size.height) * 0.55
+        self.panel.setFrameOrigin_((origin_x, origin_y))
+
+
+class OverlayTextField(NSTextField):
+    """Dismiss the overlay on Escape or Return (completion is not wired yet)."""
+
+    overlayController = objc.ivar()
+
+    def keyDown_(self, event) -> None:
+        keycode = int(event.keyCode())
+        if keycode in {_ESCAPE_KEYCODE, _RETURN_KEYCODE}:
+            controller = self.overlayController
+            if controller is not None:
+                controller.hide()
+            return
+        objc.super(OverlayTextField, self).keyDown_(event)
+
+
+def run_overlay_app() -> int:
+    """Run NSApplication until the process is interrupted."""
+    NSApplication.sharedApplication()
+    NSApp.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+    controller = OverlayController.alloc().init()
+    _install_event_tap(controller)
+    print(
+        "bunnify-overlay: hold one Control, press the other for the search box "
+        "(Ctrl-C to quit)",
+        file=sys.stderr,
+    )
+    try:
+        NSApp.run()
+    except KeyboardInterrupt:
+        return 0
+    return 0
+
+
+_ESCAPE_KEYCODE = 53
+_RETURN_KEYCODE = 36
+
+
+def _control_key_down(keycode: int) -> bool:
+    return bool(CGEventSourceKeyState(kCGEventSourceStateHIDSystemState, keycode))
+
+
+def _event_mask() -> int:
+    return (
+        CGEventMaskBit(kCGEventKeyDown)
+        | CGEventMaskBit(kCGEventKeyUp)
+        | CGEventMaskBit(kCGEventFlagsChanged)
+    )
+
+
+def _install_event_tap(controller: OverlayController) -> None:
+    tap_holder: dict[str, object] = {}
+
+    def callback(_proxy, event_type, event, _refcon):
+        tap = tap_holder.get("tap")
+        if event_type in (
+            kCGEventTapDisabledByTimeout,
+            kCGEventTapDisabledByUserInput,
+        ):
+            if tap is not None:
+                CGEventTapEnable(tap, True)
+            return event
+        keycode = int(CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode))
+        if event_type != kCGEventFlagsChanged and keycode not in {
+            CONTROL_LEFT_KEYCODE,
+            CONTROL_RIGHT_KEYCODE,
+        }:
+            return event
+        if controller.chord.sync(
+            left_down=_control_key_down(CONTROL_LEFT_KEYCODE),
+            right_down=_control_key_down(CONTROL_RIGHT_KEYCODE),
+        ):
+            controller.toggle()
+        return event
+
+    tap = CGEventTapCreate(
+        kCGSessionEventTap,
+        kCGHeadInsertEventTap,
+        kCGEventTapOptionListenOnly,
+        _event_mask(),
+        callback,
+        None,
+    )
+    if tap is None:
+        tap = CGEventTapCreate(
+            kCGHIDEventTap,
+            kCGHeadInsertEventTap,
+            kCGEventTapOptionListenOnly,
+            _event_mask(),
+            callback,
+            None,
+        )
+    if tap is None:
+        raise OverlayEventTapError("event tap was not created")
+    tap_holder["tap"] = tap
+    source = CFMachPortCreateRunLoopSource(None, tap, 0)
+    CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes)
+    CGEventTapEnable(tap, True)
+    controller.callback = callback
+    controller.source = source
+    controller.tap = tap

--- a/app/overlay_cli.py
+++ b/app/overlay_cli.py
@@ -1,0 +1,81 @@
+"""Installed command-line entry point for the macOS shortcut overlay."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable, Sequence
+
+from app.version import build_version
+
+EVENT_TAP_FAILED_MESSAGE = """\
+bunnify-overlay: could not listen for the Control chord.
+
+Grant Accessibility and Input Monitoring to this Python interpreter
+(or Terminal) in System Settings → Privacy & Security, then re-run.
+"""
+
+MACOS_EXTRA_HINT = """\
+bunnify-overlay: PyObjC is required (optional extra 'macos').
+
+  pipx install 'bunnify[macos]'
+  # development checkout:
+  uv sync --extra macos
+"""
+
+NOT_MACOS_MESSAGE = "bunnify-overlay: this command is only available on macOS."
+
+
+class OverlayEventTapError(RuntimeError):
+    """Raised when a listen-only Control chord tap cannot be created."""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``bunnify-overlay`` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="bunnify-overlay",
+        description=(
+            "macOS Spotlight-style overlay: hold one Control, press the other "
+            "to show a search box. Shortcut completion is not wired yet."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {build_version()}",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the installed overlay command."""
+    args = list(argv) if argv is not None else None
+    build_parser().parse_args(args)
+    return run_overlay()
+
+
+def run_overlay() -> int:
+    """Start the Cocoa overlay, or exit with an install / permission hint."""
+    if sys.platform != "darwin":
+        print(NOT_MACOS_MESSAGE, file=sys.stderr)
+        return 1
+    try:
+        run_overlay_app = _load_run_overlay_app()
+    except ImportError:
+        print(MACOS_EXTRA_HINT, file=sys.stderr)
+        return 1
+    try:
+        return run_overlay_app()
+    except OverlayEventTapError:
+        print(EVENT_TAP_FAILED_MESSAGE, file=sys.stderr)
+        return 1
+
+
+def _load_run_overlay_app() -> Callable[[], int]:
+    from app.overlay_app import run_overlay_app
+
+    return run_overlay_app
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/overlay_hotkey.py
+++ b/app/overlay_hotkey.py
@@ -18,6 +18,14 @@ class ChordTracker:
         self._held_left = False
         self._held_right = False
 
+    @property
+    def held_left(self) -> bool:
+        return self._held_left
+
+    @property
+    def held_right(self) -> bool:
+        return self._held_right
+
     def sync(self, *, left_down: bool, right_down: bool) -> bool:
         """Update held state. Return True when the chord completes."""
         fired = (left_down and not self._held_left and self._held_right) or (
@@ -26,3 +34,28 @@ class ChordTracker:
         self._held_left = left_down
         self._held_right = right_down
         return fired
+
+
+def apply_hid_snapshot(
+    tracker: ChordTracker,
+    *,
+    keycode: int,
+    left_down: bool,
+    right_down: bool,
+) -> bool:
+    """Apply a HID snapshot from one Control key event.
+
+    When both keys already read down but the tracker is idle (batched
+    ``flagsChanged``), treat *keycode* as the completing press so a fast
+    hold-one-then-the-other still fires. A single ``sync(True, True)`` from
+    idle still does not fire.
+    """
+    idle = not tracker.held_left and not tracker.held_right
+    if idle and left_down and right_down:
+        if keycode == CONTROL_LEFT_KEYCODE:
+            tracker.sync(left_down=False, right_down=True)
+            return tracker.sync(left_down=True, right_down=True)
+        if keycode == CONTROL_RIGHT_KEYCODE:
+            tracker.sync(left_down=True, right_down=False)
+            return tracker.sync(left_down=True, right_down=True)
+    return tracker.sync(left_down=left_down, right_down=right_down)

--- a/app/overlay_hotkey.py
+++ b/app/overlay_hotkey.py
@@ -1,0 +1,28 @@
+"""Dual-Control chord tracker (pure Python, no AppKit)."""
+
+from __future__ import annotations
+
+CONTROL_LEFT_KEYCODE = 59
+CONTROL_RIGHT_KEYCODE = 62
+
+
+class ChordTracker:
+    """Fire once when the second Control key goes down while the first is held.
+
+    Hold left *or* right Control, then press the other. Releasing either key
+    returns to a one-held or idle state so a later press can fire again.
+    Pressing both from idle in a single update does not fire.
+    """
+
+    def __init__(self) -> None:
+        self._held_left = False
+        self._held_right = False
+
+    def sync(self, *, left_down: bool, right_down: bool) -> bool:
+        """Update held state. Return True when the chord completes."""
+        fired = (left_down and not self._held_left and self._held_right) or (
+            right_down and not self._held_right and self._held_left
+        )
+        self._held_left = left_down
+        self._held_right = right_down
+        return fired

--- a/bookmarks/test_overlay.py
+++ b/bookmarks/test_overlay.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from django.test import SimpleTestCase
+
+from app.overlay_cli import (
+    MACOS_EXTRA_HINT,
+    NOT_MACOS_MESSAGE,
+    OverlayEventTapError,
+    main,
+    run_overlay,
+)
+from app.overlay_hotkey import ChordTracker
+
+
+class OverlayCliTests(SimpleTestCase):
+    def test_help_exits_zero(self) -> None:
+        stdout = StringIO()
+        with (
+            patch("sys.stdout", stdout),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            main(["--help"])
+        self.assertEqual(raised.exception.code, 0)
+        self.assertIn("search box", stdout.getvalue())
+
+    def test_missing_pyobjc_prints_extra_hint(self) -> None:
+        def boom() -> int:
+            raise ImportError("No module named 'Cocoa'")
+
+        stderr = StringIO()
+        with (
+            patch("app.overlay_cli.sys.platform", "darwin"),
+            patch("app.overlay_cli._load_run_overlay_app", side_effect=boom),
+            patch("app.overlay_cli.sys.stderr", stderr),
+        ):
+            self.assertEqual(run_overlay(), 1)
+        self.assertIn("bunnify[macos]", stderr.getvalue())
+        self.assertIn("uv sync --extra macos", stderr.getvalue())
+        self.assertIn("PyObjC", MACOS_EXTRA_HINT)
+
+    def test_not_macos_prints_hint(self) -> None:
+        stderr = StringIO()
+        with (
+            patch("app.overlay_cli.sys.platform", "linux"),
+            patch("app.overlay_cli.sys.stderr", stderr),
+        ):
+            self.assertEqual(main([]), 1)
+        self.assertIn("only available on macOS", stderr.getvalue())
+        self.assertIn("macOS", NOT_MACOS_MESSAGE)
+
+    def test_overlay_shortcut_dispatches_to_overlay_cli(self) -> None:
+        from app.cli import main
+
+        with patch("app.overlay_cli.main", return_value=0) as overlay:
+            result = CliRunner().invoke(main, ["overlay"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        overlay.assert_called_once_with([])
+
+    def test_tap_failure_prints_permission_hint(self) -> None:
+        def fail_tap() -> int:
+            raise OverlayEventTapError("event tap was not created")
+
+        stderr = StringIO()
+        with (
+            patch("app.overlay_cli.sys.platform", "darwin"),
+            patch("app.overlay_cli._load_run_overlay_app", return_value=fail_tap),
+            patch("app.overlay_cli.sys.stderr", stderr),
+        ):
+            self.assertEqual(run_overlay(), 1)
+        self.assertIn("Accessibility", stderr.getvalue())
+        self.assertIn("Input Monitoring", stderr.getvalue())
+
+
+class OverlayHotkeyTests(SimpleTestCase):
+    def test_both_from_idle_does_not_fire(self) -> None:
+        tracker = ChordTracker()
+        self.assertFalse(tracker.sync(left_down=True, right_down=True))
+
+    def test_hold_left_then_right_fires_once(self) -> None:
+        tracker = ChordTracker()
+        self.assertFalse(tracker.sync(left_down=True, right_down=False))
+        self.assertTrue(tracker.sync(left_down=True, right_down=True))
+        self.assertFalse(tracker.sync(left_down=True, right_down=True))
+
+    def test_hold_right_then_left_fires_once(self) -> None:
+        tracker = ChordTracker()
+        self.assertFalse(tracker.sync(left_down=False, right_down=True))
+        self.assertTrue(tracker.sync(left_down=True, right_down=True))
+
+    def test_release_one_then_press_again_fires(self) -> None:
+        tracker = ChordTracker()
+        tracker.sync(left_down=True, right_down=False)
+        tracker.sync(left_down=True, right_down=True)
+        self.assertFalse(tracker.sync(left_down=True, right_down=False))
+        self.assertTrue(tracker.sync(left_down=True, right_down=True))
+
+    def test_sequential_singles_do_not_fire(self) -> None:
+        tracker = ChordTracker()
+        self.assertFalse(tracker.sync(left_down=True, right_down=False))
+        self.assertFalse(tracker.sync(left_down=False, right_down=False))
+        self.assertFalse(tracker.sync(left_down=False, right_down=True))

--- a/bookmarks/test_overlay.py
+++ b/bookmarks/test_overlay.py
@@ -6,14 +6,13 @@ from unittest.mock import patch
 from click.testing import CliRunner
 from django.test import SimpleTestCase
 
-from app.overlay_cli import (
-    MACOS_EXTRA_HINT,
-    NOT_MACOS_MESSAGE,
-    OverlayEventTapError,
-    main,
-    run_overlay,
+from app.overlay_cli import OverlayEventTapError, main, run_overlay
+from app.overlay_hotkey import (
+    CONTROL_LEFT_KEYCODE,
+    CONTROL_RIGHT_KEYCODE,
+    ChordTracker,
+    apply_hid_snapshot,
 )
-from app.overlay_hotkey import ChordTracker
 
 
 class OverlayCliTests(SimpleTestCase):
@@ -40,7 +39,6 @@ class OverlayCliTests(SimpleTestCase):
             self.assertEqual(run_overlay(), 1)
         self.assertIn("bunnify[macos]", stderr.getvalue())
         self.assertIn("uv sync --extra macos", stderr.getvalue())
-        self.assertIn("PyObjC", MACOS_EXTRA_HINT)
 
     def test_not_macos_prints_hint(self) -> None:
         stderr = StringIO()
@@ -50,15 +48,23 @@ class OverlayCliTests(SimpleTestCase):
         ):
             self.assertEqual(main([]), 1)
         self.assertIn("only available on macOS", stderr.getvalue())
-        self.assertIn("macOS", NOT_MACOS_MESSAGE)
+
+    def test_overlay_shortcut_dispatches_extra_args(self) -> None:
+        from app.cli import main as cli_main
+
+        with patch("app.overlay_cli.main", return_value=1) as overlay:
+            result = CliRunner().invoke(cli_main, ["overlay", "foo"])
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        overlay.assert_called_once_with(["foo"])
 
     def test_overlay_shortcut_dispatches_to_overlay_cli(self) -> None:
-        from app.cli import main
+        from app.cli import main as cli_main
 
-        with patch("app.overlay_cli.main", return_value=0) as overlay:
-            result = CliRunner().invoke(main, ["overlay"])
+        with patch("app.overlay_cli.main", return_value=1) as overlay:
+            result = CliRunner().invoke(cli_main, ["overlay"])
 
-        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(result.exit_code, 1, result.output)
         overlay.assert_called_once_with([])
 
     def test_tap_failure_prints_permission_hint(self) -> None:
@@ -77,6 +83,26 @@ class OverlayCliTests(SimpleTestCase):
 
 
 class OverlayHotkeyTests(SimpleTestCase):
+    def test_batched_hid_both_down_fires_on_completing_keycode(self) -> None:
+        tracker = ChordTracker()
+        self.assertTrue(
+            apply_hid_snapshot(
+                tracker,
+                keycode=CONTROL_RIGHT_KEYCODE,
+                left_down=True,
+                right_down=True,
+            )
+        )
+        tracker = ChordTracker()
+        self.assertTrue(
+            apply_hid_snapshot(
+                tracker,
+                keycode=CONTROL_LEFT_KEYCODE,
+                left_down=True,
+                right_down=True,
+            )
+        )
+
     def test_both_from_idle_does_not_fire(self) -> None:
         tracker = ChordTracker()
         self.assertFalse(tracker.sync(left_down=True, right_down=True))

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -91,8 +91,7 @@ Foreground process (no login agent yet). Needs the optional `macos` extra
 pipx install 'bunnify[macos]'
 bunnify-overlay
 
-# development checkout
-uv sync --extra macos
+# development checkout (wrapper syncs extra macos)
 ./scripts/bunnify-overlay
 ```
 

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -81,6 +81,31 @@ written to `~/.local/share/bunnify/run/.bunnify.port`. Set
 `BUNNIFY_DATA_DIR` to relocate the SQLite database, logs, and managed runtime
 files together.
 
+## macOS overlay
+
+Foreground process (no login agent yet). Needs the optional `macos` extra
+(PyObjC):
+
+```bash
+# pipx
+pipx install 'bunnify[macos]'
+bunnify-overlay
+
+# development checkout
+uv sync --extra macos
+./scripts/bunnify-overlay
+```
+
+Hold **one** Control, then press the **other** to show the search box. Esc
+(or the same chord again) hides it. Ctrl-C in the terminal quits.
+
+If the chord does nothing, grant **Accessibility** and **Input Monitoring**
+to the Python interpreter (or Terminal) in System Settings → Privacy &
+Security, then re-run.
+
+Tab completion and opening shortcuts are not wired yet; this is a no-op
+panel for assessing the hotkey and window.
+
 ## macOS LaunchAgent
 
 Copy `etc/launchd/com.thehcma.bunnify.plist.example` to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,16 @@ dependencies = [
     "typing-extensions==4.16.0",
 ]
 
+[project.optional-dependencies]
+macos = [
+    "pyobjc-core==12.2.1",
+    "pyobjc-framework-Cocoa==12.2.1",
+    "pyobjc-framework-Quartz==12.2.1",
+]
+
 [project.scripts]
 bunnify = "app.cli:main"
+bunnify-overlay = "app.overlay_cli:main"
 bunnify-server = "app.server_cli:main"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ dependencies = [
 
 [project.optional-dependencies]
 macos = [
-    "pyobjc-core==12.2.1",
-    "pyobjc-framework-Cocoa==12.2.1",
-    "pyobjc-framework-Quartz==12.2.1",
+    "pyobjc-core==12.2.1; sys_platform == 'darwin'",
+    "pyobjc-framework-Cocoa==12.2.1; sys_platform == 'darwin'",
+    "pyobjc-framework-Quartz==12.2.1; sys_platform == 'darwin'",
 ]
 
 [project.scripts]

--- a/scripts/bunnify-overlay
+++ b/scripts/bunnify-overlay
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root" || exit 1
+
+overlay_module="app.overlay_cli"
+
+if command -v uv >/dev/null 2>&1; then
+  exec uv run bunnify-overlay "$@"
+fi
+
+venv_overlay="${repo_root}/.venv/bin/bunnify-overlay"
+if [[ -x "$venv_overlay" ]]; then
+  exec "$venv_overlay" "$@"
+fi
+
+venv_python="${repo_root}/.venv/bin/python"
+if [[ -x "$venv_python" ]]; then
+  exec "$venv_python" -m "$overlay_module" "$@"
+fi
+
+echo "bunnify-overlay: install uv (https://docs.astral.sh/uv/) or run 'uv sync' in ${repo_root}" >&2
+exit 1

--- a/scripts/bunnify-overlay
+++ b/scripts/bunnify-overlay
@@ -7,7 +7,7 @@ cd "$repo_root" || exit 1
 overlay_module="app.overlay_cli"
 
 if command -v uv >/dev/null 2>&1; then
-  exec uv run bunnify-overlay "$@"
+  exec uv run --extra macos bunnify-overlay "$@"
 fi
 
 venv_overlay="${repo_root}/.venv/bin/bunnify-overlay"
@@ -20,5 +20,5 @@ if [[ -x "$venv_python" ]]; then
   exec "$venv_python" -m "$overlay_module" "$@"
 fi
 
-echo "bunnify-overlay: install uv (https://docs.astral.sh/uv/) or run 'uv sync' in ${repo_root}" >&2
+echo "bunnify-overlay: install uv (https://docs.astral.sh/uv/) or run 'uv sync --extra macos' in ${repo_root}" >&2
 exit 1

--- a/test_packaging
+++ b/test_packaging
@@ -84,6 +84,8 @@ if [[ "$version_line" == *"(unknown)"* ]]; then
 fi
 "$bin_dir/bunnify-server" --help >/dev/null
 "$bin_dir/bunnify-server" --version
+"$bin_dir/bunnify-overlay" --help >/dev/null
+"$bin_dir/bunnify-overlay" --version
 
 echo "🐰 Starting installed server outside the repository..."
 "$bin_dir/bunnify-server" \

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,13 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 
+[package.optional-dependencies]
+macos = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pyright" },
@@ -53,9 +60,13 @@ requires-dist = [
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "platformdirs", specifier = ">=4.11.1" },
     { name = "prompt-toolkit", specifier = ">=3.0.53" },
+    { name = "pyobjc-core", marker = "extra == 'macos'", specifier = "==12.2.1" },
+    { name = "pyobjc-framework-cocoa", marker = "extra == 'macos'", specifier = "==12.2.1" },
+    { name = "pyobjc-framework-quartz", marker = "extra == 'macos'", specifier = "==12.2.1" },
     { name = "rpds-py", specifier = ">=2026.6.3" },
     { name = "typing-extensions", specifier = "==4.16.0" },
 ]
+provides-extras = ["macos"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -171,6 +182,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b1/729f7458a63758bd21716648a8abcd9a0c8f2d2e9897763c8a1a1c7fd31b/pyobjc_core-12.2.1.tar.gz", hash = "sha256:7a7b9b018402342cf32bf1956366896350fbe5c0478cb3ef59778f77abed7f07", size = 1063383, upload-time = "2026-06-19T16:19:39.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/8a/cfa4f56939d554dbb342ec6e5226a441e2f552bc2002a0ddf7705bb11bef/pyobjc_core-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:2b8fc0531c27277325e113ac00b8a72a82e6145f0a88175b9425d8de814ff69a", size = 6429289, upload-time = "2026-06-19T16:05:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/42/74/446c89bc18103aaa4a00d1fb85ff8acace9a0dc3f362d9678ebf7571e275/pyobjc_core-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9bef500f979e22d54f9da3aaebf6a48f873234b324858bd69256055a318955c7", size = 6690181, upload-time = "2026-06-19T16:05:06.201Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c7/0121ee4c616af07ad2de8cd1a286f6978dc9a227eb58b7c2e875cb68a1df/pyobjc_core-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:047c226eeb58a2993ace5e8904e71cc9426ee20d064c617f8fbf32717d37093e", size = 6487078, upload-time = "2026-06-19T16:05:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a8/cb9fcc150f97d0bf22a2028f88b24cc35949beb1bcc7b8bc5c17d4401677/pyobjc_core-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:1188613805336270279570467e4455b74cb6c0f60913ac74c917ee1c37cfaecb", size = 6733064, upload-time = "2026-06-19T16:05:14.313Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/c8/b90baa8f3592eded79b4be98fb59d2b8dc16b62361e34292bd95806ebd9f/pyobjc_framework_cocoa-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:b386c324d64ae565c1f6b7dfb77be68f640a1c7c23caa6966ab661131f519561", size = 388357, upload-time = "2026-06-19T16:07:43.364Z" },
+    { url = "https://files.pythonhosted.org/packages/98/d8/64a94651b9294702d55e748d94de30e25bc59d0784526be7643f4467eccd/pyobjc_framework_cocoa-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a6c584e2af0813cb2f6103b184e632665a26f58c1bd5b08ffd6e95a19c617f7b", size = 392404, upload-time = "2026-06-19T16:07:44.955Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/cc/26e8a7bf1f5e8caa38b7f80d486296f9fd3c97e71ad7e5444ef22e802758/pyobjc_framework_cocoa-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:b6023657b8d6cc049a21bd6b4752425f2f53c42f9f0b02d64c7608cc484bf103", size = 388589, upload-time = "2026-06-19T16:07:46.276Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/eedf743a303ea742b8e082afe3613fb4d6618bc1a48cf2568b004ce906f7/pyobjc_framework_cocoa-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:c685ccd8e266a07cf912a2c5a13b1f2eff2a868a1aff163b4801b4687bd425e1", size = 392691, upload-time = "2026-06-19T16:07:47.477Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/5d/85ffd9d433989205d572a50d625c63b29c05e0c5235a725f15ae1023672c/pyobjc_framework_quartz-12.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ceb56939c337b36d9d81185ade31f77dc52c85cf79bb16e53e9b32f54b6bb3f5", size = 219769, upload-time = "2026-06-19T16:16:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d6/b917e4b63d72ea84a27121076f3033f23f6497c0e6ce8d304766c899897f/pyobjc_framework_quartz-12.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8105c98b798f2bf81c05c54bddeeadbf62f0b5dfec13bd6e719dd2cdf7e1cddf", size = 224717, upload-time = "2026-06-19T16:16:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e2/f3c1ed3228f7430ef5ade23db6f1fcbae99290f177ce5653348fd9e05f4d/pyobjc_framework_quartz-12.2.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:bbc214f1a216b5d3651bc832d0ac4589f029f3f37cd6cbb370aac12a7c77942c", size = 219825, upload-time = "2026-06-19T16:16:11.433Z" },
+    { url = "https://files.pythonhosted.org/packages/66/2a/2c99a5ad2fe0a11600ea123b8e9a08ff138fcb2ad1e13e376f4bd4aa1d96/pyobjc_framework_quartz-12.2.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:ca61624a0b0e6286d8a0f97f47eb9011e4e81e9a339db436d48af527e7065bb1", size = 224770, upload-time = "2026-06-19T16:16:13.035Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [package.optional-dependencies]
 macos = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 
 [package.dev-dependencies]
@@ -60,9 +60,9 @@ requires-dist = [
     { name = "pathspec", specifier = "==1.1.1" },
     { name = "platformdirs", specifier = ">=4.11.1" },
     { name = "prompt-toolkit", specifier = ">=3.0.53" },
-    { name = "pyobjc-core", marker = "extra == 'macos'", specifier = "==12.2.1" },
-    { name = "pyobjc-framework-cocoa", marker = "extra == 'macos'", specifier = "==12.2.1" },
-    { name = "pyobjc-framework-quartz", marker = "extra == 'macos'", specifier = "==12.2.1" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin' and extra == 'macos'", specifier = "==12.2.1" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' and extra == 'macos'", specifier = "==12.2.1" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' and extra == 'macos'", specifier = "==12.2.1" },
     { name = "rpds-py", specifier = ">=2026.6.3" },
     { name = "typing-extensions", specifier = "==4.16.0" },
 ]


### PR DESCRIPTION
## Summary

- Add a foreground **`bunnify-overlay`** process (optional extra `macos` / PyObjC): hold one Control, press the other, get an empty Spotlight-style search box.
- Same chord again, Esc, or Return dismisses. No Tab completion, history, URL resolve, or login LaunchAgent yet (those are #304–#307).
- Closes #303 (epic #302).

## Test plan

- [x] `./test_bunnify` including `bookmarks.test_overlay` (chord state machine + CLI hints)
- [x] `uv run ruff check .` / `ruff format --check` / `pyright --warnings`
- [ ] On a Mac with `uv sync --extra macos`: `./scripts/bunnify-overlay`, grant Accessibility / Input Monitoring if needed, confirm the chord shows and hides the box
- [ ] Linux CI: overlay `--help` / `--version` without PyObjC