### PR TITLE
feat: share CLI REPL history with Spotty Bunny (#304)

### DIFF
--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -60,6 +60,11 @@ from Quartz import (
 )
 
 from app.spotty_bunny_cli import SpottyBunnyEventTapError
+from app.spotty_bunny_history import (
+    HistoryNavigator,
+    apply_history_selector,
+    load_history_lines,
+)
 from app.spotty_bunny_hotkey import (
     CONTROL_LEFT_KEYCODE,
     CONTROL_RIGHT_KEYCODE,
@@ -85,8 +90,17 @@ class SpottyBunnyController(NSObject):
     """Owns the floating search panel and toggles it from the Control chord."""
 
     def control_textView_doCommandBySelector_(self, _control, _text_view, selector):
-        """Dismiss on Esc/Return via the field editor (not NSTextField.keyDown_)."""
+        """History up/down; dismiss on Esc/Return via the field editor."""
         name = selector if isinstance(selector, str) else str(selector)
+        current = ""
+        if self.field is not None:
+            current = str(self.field.stringValue())
+        history_text = apply_history_selector(self._history, current, name)
+        if history_text is not None:
+            logger.debug("history %s → %r", name, history_text)
+            if self.field is not None:
+                self.field.setStringValue_(history_text)
+            return True
         if name in {"cancelOperation:", "insertNewline:"}:
             logger.info("field-editor command %s → hide", name)
             self.hide()
@@ -107,6 +121,7 @@ class SpottyBunnyController(NSObject):
         if self is None:
             return None
         self._became_key = False
+        self._history = HistoryNavigator()
         self.callback = None
         self.chord = ChordTracker()
         self.field = None
@@ -118,6 +133,7 @@ class SpottyBunnyController(NSObject):
         return self
 
     def show(self) -> None:
+        self._history = HistoryNavigator(load_history_lines())
         if self.field is not None:
             self.field.setStringValue_("")
         self._center_panel()

--- a/app/spotty_bunny_history.py
+++ b/app/spotty_bunny_history.py
@@ -25,20 +25,27 @@ class HistoryNavigator:
         """Newer entry, or the live draft past the newest line."""
         if self._cursor >= len(self._lines):
             return current
+        self._capture_draft(current)
         self._cursor += 1
         if self._cursor >= len(self._lines):
             return self._draft
         return self._lines[self._cursor]
 
     def up(self, current: str) -> str:
-        """Older entry. Saves *current* as the draft when leaving the live line."""
+        """Older entry. Saves *current* as the draft when it is not a stored line."""
         if not self._lines:
             return current
-        if self._cursor >= len(self._lines):
-            self._draft = current
+        self._capture_draft(current)
         if self._cursor > 0:
             self._cursor -= 1
         return self._lines[self._cursor]
+
+    def _capture_draft(self, current: str) -> None:
+        if self._cursor >= len(self._lines):
+            self._draft = current
+            return
+        if current != self._lines[self._cursor]:
+            self._draft = current
 
 
 def append_history_line(line: str, *, path: Path | None = None) -> None:
@@ -47,8 +54,11 @@ def append_history_line(line: str, *, path: Path | None = None) -> None:
     if not text:
         return
     dest = path if path is not None else history_file_path()
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    FileHistory(str(dest)).append_string(text)
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        FileHistory(str(dest)).append_string(text)
+    except OSError:
+        return
 
 
 def apply_history_selector(
@@ -69,6 +79,9 @@ def load_history_lines(*, path: Path | None = None) -> list[str]:
     dest = path if path is not None else history_file_path()
     if not dest.is_file():
         return []
-    newest_first = list(FileHistory(str(dest)).load_history_strings())
+    try:
+        newest_first = list(FileHistory(str(dest)).load_history_strings())
+    except OSError, UnicodeDecodeError:
+        return []
     newest_first.reverse()
     return newest_first

--- a/app/spotty_bunny_history.py
+++ b/app/spotty_bunny_history.py
@@ -1,0 +1,74 @@
+"""Shared REPL history for Spotty Bunny (prompt_toolkit FileHistory format)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from prompt_toolkit.history import FileHistory
+
+from app.interactive import history_file_path
+
+HISTORY_DOWN_SELECTORS = frozenset({"moveDown:"})
+HISTORY_UP_SELECTORS = frozenset({"moveUp:"})
+
+
+class HistoryNavigator:
+    """Walk REPL history with up/down. Newest entries are last."""
+
+    def __init__(self, lines: Sequence[str] | None = None) -> None:
+        self._draft = ""
+        self._lines = list(lines or ())
+        self._cursor = len(self._lines)
+
+    def down(self, current: str) -> str:
+        """Newer entry, or the live draft past the newest line."""
+        if self._cursor >= len(self._lines):
+            return current
+        self._cursor += 1
+        if self._cursor >= len(self._lines):
+            return self._draft
+        return self._lines[self._cursor]
+
+    def up(self, current: str) -> str:
+        """Older entry. Saves *current* as the draft when leaving the live line."""
+        if not self._lines:
+            return current
+        if self._cursor >= len(self._lines):
+            self._draft = current
+        if self._cursor > 0:
+            self._cursor -= 1
+        return self._lines[self._cursor]
+
+
+def append_history_line(line: str, *, path: Path | None = None) -> None:
+    """Append one query in FileHistory format for the CLI REPL to read back."""
+    text = line.strip()
+    if not text:
+        return
+    dest = path if path is not None else history_file_path()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    FileHistory(str(dest)).append_string(text)
+
+
+def apply_history_selector(
+    navigator: HistoryNavigator,
+    current: str,
+    selector: str,
+) -> str | None:
+    """Return new field text for an up/down selector, else ``None``."""
+    if selector in HISTORY_UP_SELECTORS:
+        return navigator.up(current)
+    if selector in HISTORY_DOWN_SELECTORS:
+        return navigator.down(current)
+    return None
+
+
+def load_history_lines(*, path: Path | None = None) -> list[str]:
+    """Load FileHistory strings (oldest first) from the shared REPL file."""
+    dest = path if path is not None else history_file_path()
+    if not dest.is_file():
+        return []
+    newest_first = list(FileHistory(str(dest)).load_history_strings())
+    newest_first.reverse()
+    return newest_first

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -16,6 +16,12 @@ from app.spotty_bunny_cli import (
     main,
     run_spotty_bunny,
 )
+from app.spotty_bunny_history import (
+    HistoryNavigator,
+    append_history_line,
+    apply_history_selector,
+    load_history_lines,
+)
 from app.spotty_bunny_hotkey import (
     CONTROL_LEFT_KEYCODE,
     CONTROL_RIGHT_KEYCODE,
@@ -232,6 +238,45 @@ class SpottyBunnyCliTests(SimpleTestCase):
         logged = self.log_file.read_text(encoding="utf-8")
         self.assertIn("spotty-bunny starting", logged)
         self.assertIn("log_level=DEBUG", logged)
+
+
+class SpottyBunnyHistoryTests(SimpleTestCase):
+    def test_append_round_trips_prompt_toolkit_file_history(self) -> None:
+        from prompt_toolkit.history import FileHistory
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "repl_history"
+            append_history_line("g hello", path=path)
+            append_history_line("  gh  ", path=path)
+            append_history_line("", path=path)
+            self.assertEqual(load_history_lines(path=path), ["g hello", "gh"])
+            self.assertEqual(
+                list(FileHistory(str(path)).load_history_strings()),
+                ["gh", "g hello"],
+            )
+
+    def test_apply_history_selector_ignores_return(self) -> None:
+        navigator = HistoryNavigator(["gh"])
+        self.assertIsNone(apply_history_selector(navigator, "", "insertNewline:"))
+
+    def test_down_restores_draft_after_up(self) -> None:
+        navigator = HistoryNavigator(["gh", "g hello"])
+        self.assertEqual(navigator.up("draft"), "g hello")
+        self.assertEqual(navigator.up("g hello"), "gh")
+        self.assertEqual(navigator.down("gh"), "g hello")
+        self.assertEqual(navigator.down("g hello"), "draft")
+
+    def test_up_on_empty_history_keeps_current(self) -> None:
+        navigator = HistoryNavigator()
+        self.assertEqual(navigator.up("typed"), "typed")
+        self.assertEqual(
+            apply_history_selector(navigator, "typed", "moveUp:"),
+            "typed",
+        )
+        self.assertEqual(
+            apply_history_selector(navigator, "typed", "moveDown:"),
+            "typed",
+        )
 
 
 class SpottyBunnyHotkeyTests(SimpleTestCase):

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -255,9 +255,19 @@ class SpottyBunnyHistoryTests(SimpleTestCase):
                 ["gh", "g hello"],
             )
 
+    def test_append_unwritable_parent_is_ignored(self) -> None:
+        with TemporaryDirectory() as tmp:
+            parent = Path(tmp) / "blocked"
+            parent.write_text("not-a-dir")
+            append_history_line("gh", path=parent / "repl_history")
+
     def test_apply_history_selector_ignores_return(self) -> None:
         navigator = HistoryNavigator(["gh"])
         self.assertIsNone(apply_history_selector(navigator, "", "insertNewline:"))
+
+    def test_down_at_live_line_keeps_current(self) -> None:
+        navigator = HistoryNavigator(["gh"])
+        self.assertEqual(navigator.down("typed"), "typed")
 
     def test_down_restores_draft_after_up(self) -> None:
         navigator = HistoryNavigator(["gh", "g hello"])
@@ -265,6 +275,30 @@ class SpottyBunnyHistoryTests(SimpleTestCase):
         self.assertEqual(navigator.up("g hello"), "gh")
         self.assertEqual(navigator.down("gh"), "g hello")
         self.assertEqual(navigator.down("g hello"), "draft")
+
+    def test_edit_recalled_line_becomes_draft(self) -> None:
+        navigator = HistoryNavigator(["gh", "g hello"])
+        self.assertEqual(navigator.up("abc"), "g hello")
+        self.assertEqual(navigator.up("g hello!"), "gh")
+        self.assertEqual(navigator.down("gh"), "g hello")
+        self.assertEqual(navigator.down("g hello"), "g hello!")
+
+    def test_load_invalid_utf8_returns_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "repl_history"
+            path.write_bytes(b"\xff\xfe")
+            self.assertEqual(load_history_lines(path=path), [])
+
+    def test_load_missing_file_returns_empty(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "missing" / "repl_history"
+            self.assertEqual(load_history_lines(path=path), [])
+
+    def test_up_at_oldest_stays_at_oldest(self) -> None:
+        navigator = HistoryNavigator(["gh", "g hello"])
+        self.assertEqual(navigator.up("draft"), "g hello")
+        self.assertEqual(navigator.up("g hello"), "gh")
+        self.assertEqual(navigator.up("gh"), "gh")
 
     def test_up_on_empty_history_keeps_current(self) -> None:
         navigator = HistoryNavigator()

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -103,8 +103,9 @@ spotty-bunny
 ```
 
 Hold **one** Control, then press the **other** to show the search box. Esc
-(or the same chord again) hides it. Ctrl-C in that terminal quits. Startup
-prints the log file path on stderr (`spotty-bunny: logging to …`).
+(or the same chord again) hides it. Up/down walks the CLI REPL history file
+(`platformdirs` cache `bunnify/repl_history`). Ctrl-C in that terminal quits.
+Startup prints the log file path on stderr (`spotty-bunny: logging to …`).
 
 If the chord does nothing, run with `--verbose` and watch stderr. Lines
 named `tap …` show whether key events arrive. If none appear while you press
@@ -115,8 +116,7 @@ never appears, HID may still miss right Control (`hid R=False`); Spotty Bunny
 also uses device flag bits and the event keycode. Re-run `--verbose` after
 this fix.
 
-Tab completion and opening shortcuts are not wired yet; this is a no-op
-panel for assessing the hotkey and window.
+Tab completion and opening shortcuts are not wired yet.
 
 ## macOS LaunchAgent
 


### PR DESCRIPTION
Closes #304.

## Summary
- Load and append the shared prompt_toolkit `FileHistory` file (`history_file_path()`).
- Up/down in the search box walks that list (newest last); writing on Enter is left to #306.

## Test plan
- [x] `./test_bunnify bookmarks.test_spotty_bunny`
- [ ] `./scripts/spotty-bunny --verbose` — type in the CLI REPL, then up/down in Spotty Bunny