### PR TITLE
feat: resolve Spotty Bunny Enter and open URLs (#306)

### DIFF
--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -69,6 +69,7 @@ from app.spotty_bunny_cli import SpottyBunnyEventTapError
 from app.spotty_bunny_complete import (
     CompletionRow,
     apply_completion,
+    completion_still_current,
     completions_for,
     make_spotty_completer,
 )
@@ -102,6 +103,12 @@ logger = logging.getLogger(__name__)
 
 class SpottyBunnyController(NSObject):
     """Owns the floating search panel and toggles it from the Control chord."""
+
+    def controlTextDidChange_(self, _notification) -> None:
+        if self._applying_completion:
+            return
+        if self._completion_rows:
+            self._hide_completions()
 
     def control_textView_doCommandBySelector_(self, _control, _text_view, selector):
         """Tab completions, history up/down, dismiss on Esc/Return."""
@@ -141,10 +148,12 @@ class SpottyBunnyController(NSObject):
         self = objc.super(SpottyBunnyController, self).init()
         if self is None:
             return None
+        self._applying_completion = False
         self._became_key = False
         self._completer = None
         self._completion_prefix = ""
         self._completion_rows: list[CompletionRow] = []
+        self._completion_seq = 0
         self._history = HistoryNavigator()
         self._io = ThreadIo()
         self.callback = None
@@ -293,8 +302,18 @@ class SpottyBunnyController(NSObject):
 
         _run_on_main(apply)
 
-    def _completions_ready(self, result: object) -> None:
+    def _completions_ready(self, result: object, *, seq: int) -> None:
         def apply() -> None:
+            field = str(self.field.stringValue()) if self.field is not None else ""
+            if not completion_still_current(
+                expected_seq=seq,
+                field=field,
+                prefix=self._completion_prefix,
+                seq=self._completion_seq,
+            ):
+                return
+            if not self.visible:
+                return
             if isinstance(result, Exception):
                 logger.warning("completion failed: %s", result)
                 return
@@ -303,6 +322,7 @@ class SpottyBunnyController(NSObject):
         _run_on_main(apply)
 
     def _hide_completions(self) -> None:
+        self._completion_seq += 1
         self._completion_prefix = ""
         self._completion_rows = []
         if self.table is not None:
@@ -310,7 +330,7 @@ class SpottyBunnyController(NSObject):
         self._set_table_visible(False)
 
     def _load_completer(self) -> object:
-        base_url = resolve_base_url(persist=False)
+        base_url = resolve_base_url(persist=False, allow_prompt=False)
         entries = fetch_key_entries(base_url=base_url)
         return make_spotty_completer(
             entries=entries,
@@ -332,7 +352,7 @@ class SpottyBunnyController(NSObject):
             False,
         )
         row = self._completion_rows[idx]
-        self.field.setStringValue_(apply_completion(self._completion_prefix, row))
+        self._set_field_text(apply_completion(self._completion_prefix, row))
 
     def _request_completions(self) -> None:
         if self._completer is None or self.field is None:
@@ -340,11 +360,22 @@ class SpottyBunnyController(NSObject):
             return
         text = str(self.field.stringValue())
         self._completion_prefix = text
+        self._completion_seq += 1
+        seq = self._completion_seq
         completer = self._completer
         self._io.submit(
             lambda: completions_for(text, completer),
-            self._completions_ready,
+            lambda result: self._completions_ready(result, seq=seq),
         )
+
+    def _set_field_text(self, text: str) -> None:
+        if self.field is None:
+            return
+        self._applying_completion = True
+        try:
+            self.field.setStringValue_(text)
+        finally:
+            self._applying_completion = False
 
     def _set_table_visible(self, visible: bool) -> None:
         if self.scroll is None or self.panel is None or self.field is None:
@@ -370,9 +401,7 @@ class SpottyBunnyController(NSObject):
             self._hide_completions()
             return
         if self.field is not None:
-            self.field.setStringValue_(
-                apply_completion(self._completion_prefix, rows[0])
-            )
+            self._set_field_text(apply_completion(self._completion_prefix, rows[0]))
         if self.table is not None:
             self.table.reloadData()
             self.table.selectRowIndexes_byExtendingSelection_(

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -384,6 +384,8 @@ class SpottyBunnyController(NSObject):
     def _request_completions(self) -> None:
         if self._completer is None or self.field is None:
             logger.warning("tab ignored (completer not ready)")
+            if self._completer is None:
+                self._set_status("could not load shortcuts")
             return
         text = str(self.field.stringValue())
         self._completion_rows = []

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -141,6 +141,8 @@ class SpottyBunnyController(NSObject):
 
     def hide(self) -> None:
         logger.info("hide panel (was visible=%s)", self.visible)
+        self._resolve_seq += 1
+        self._resolving = False
         self._hide_completions()
         self._set_status("")
         panel = getattr(self, "panel", None)
@@ -162,6 +164,7 @@ class SpottyBunnyController(NSObject):
         self._completion_seq = 0
         self._history = HistoryNavigator()
         self._io = ThreadIo()
+        self._resolve_seq = 0
         self._resolving = False
         self.callback = None
         self.chord = ChordTracker()
@@ -396,11 +399,11 @@ class SpottyBunnyController(NSObject):
             lambda result: self._completions_ready(result, seq=seq),
         )
 
-    def _resolve_ready(self, result: object) -> None:
+    def _resolve_ready(self, result: object, *, seq: int) -> None:
         def apply() -> None:
-            self._resolving = False
-            if not self.visible:
+            if seq != self._resolve_seq:
                 return
+            self._resolving = False
             if isinstance(result, Exception):
                 logger.warning("resolve failed: %s", result)
                 self._hide_completions()
@@ -467,6 +470,8 @@ class SpottyBunnyController(NSObject):
         if not query:
             self.hide()
             return
+        self._resolve_seq += 1
+        seq = self._resolve_seq
         self._resolving = True
         self._set_status("")
         base_url = self._base_url or resolve_base_url(persist=False, allow_prompt=False)
@@ -474,7 +479,7 @@ class SpottyBunnyController(NSObject):
         def work() -> str:
             return resolve_query(query, base_url=base_url)
 
-        self._io.submit(work, self._resolve_ready)
+        self._io.submit(work, lambda result: self._resolve_ready(result, seq=seq))
 
 
 def run_spotty_bunny_app() -> int:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -162,6 +162,7 @@ class SpottyBunnyController(NSObject):
         self._completion_seq = 0
         self._history = HistoryNavigator()
         self._io = ThreadIo()
+        self._resolving = False
         self.callback = None
         self.chord = ChordTracker()
         self.field = None
@@ -181,6 +182,7 @@ class SpottyBunnyController(NSObject):
     def show(self) -> None:
         self._history = HistoryNavigator(load_history_lines())
         self._hide_completions()
+        self._set_status("")
         if self.field is not None:
             self.field.setStringValue_("")
         self._center_panel()
@@ -396,6 +398,9 @@ class SpottyBunnyController(NSObject):
 
     def _resolve_ready(self, result: object) -> None:
         def apply() -> None:
+            self._resolving = False
+            if not self.visible:
+                return
             if isinstance(result, Exception):
                 logger.warning("resolve failed: %s", result)
                 self._hide_completions()
@@ -456,14 +461,15 @@ class SpottyBunnyController(NSObject):
         self._set_table_visible(len(rows) > 1)
 
     def _submit_query(self) -> None:
-        if self.field is None:
+        if self.field is None or self._resolving:
             return
         query = str(self.field.stringValue()).strip()
         if not query:
             self.hide()
             return
+        self._resolving = True
         self._set_status("")
-        base_url = self._base_url or resolve_base_url(persist=False)
+        base_url = self._base_url or resolve_base_url(persist=False, allow_prompt=False)
 
         def work() -> str:
             return resolve_query(query, base_url=base_url)

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -22,6 +22,9 @@ from Cocoa import (
     NSObject,
     NSPanel,
     NSScreen,
+    NSScrollView,
+    NSTableColumn,
+    NSTableView,
     NSTextField,
     NSWindowCollectionBehaviorCanJoinAllSpaces,
     NSWindowCollectionBehaviorFullScreenAuxiliary,
@@ -29,6 +32,7 @@ from Cocoa import (
     NSWindowStyleMaskNonactivatingPanel,
     NSWindowStyleMaskTitled,
 )
+from Foundation import NSIndexSet, NSOperationQueue, NSThread
 from PyObjCTools import MachSignals
 from Quartz import (
     CFMachPortCreateRunLoopSource,
@@ -59,7 +63,15 @@ from Quartz import (
     kCGSessionEventTap,
 )
 
+from app.client import fetch_key_entries, fetch_suggestions
+from app.config import resolve_base_url
 from app.spotty_bunny_cli import SpottyBunnyEventTapError
+from app.spotty_bunny_complete import (
+    CompletionRow,
+    apply_completion,
+    completions_for,
+    make_spotty_completer,
+)
 from app.spotty_bunny_history import (
     HistoryNavigator,
     apply_history_selector,
@@ -74,6 +86,7 @@ from app.spotty_bunny_hotkey import (
     apply_control_event,
     describe_key,
 )
+from app.spotty_bunny_io import ThreadIo
 from app.spotty_bunny_quit import (
     WAKE_EVENT_SELECTOR,
     post_application_wake_event,
@@ -82,6 +95,7 @@ from app.spotty_bunny_quit import (
 
 PANEL_HEIGHT = 80.0
 PANEL_WIDTH = 640.0
+TABLE_HEIGHT = 140.0
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +104,14 @@ class SpottyBunnyController(NSObject):
     """Owns the floating search panel and toggles it from the Control chord."""
 
     def control_textView_doCommandBySelector_(self, _control, _text_view, selector):
-        """History up/down; dismiss on Esc/Return via the field editor."""
+        """Tab completions, history up/down, dismiss on Esc/Return."""
         name = selector if isinstance(selector, str) else str(selector)
+        if name == "insertTab:":
+            self._request_completions()
+            return True
+        if self._completion_rows and name in {"moveDown:", "moveUp:"}:
+            self._move_completion(name)
+            return True
         current = ""
         if self.field is not None:
             current = str(self.field.stringValue())
@@ -110,6 +130,7 @@ class SpottyBunnyController(NSObject):
 
     def hide(self) -> None:
         logger.info("hide panel (was visible=%s)", self.visible)
+        self._hide_completions()
         panel = getattr(self, "panel", None)
         if panel is not None:
             panel.orderOut_(None)
@@ -121,19 +142,29 @@ class SpottyBunnyController(NSObject):
         if self is None:
             return None
         self._became_key = False
+        self._completer = None
+        self._completion_prefix = ""
+        self._completion_rows: list[CompletionRow] = []
         self._history = HistoryNavigator()
+        self._io = ThreadIo()
         self.callback = None
         self.chord = ChordTracker()
         self.field = None
         self.panel = None
+        self.scroll = None
         self.source = None
+        self.table = None
         self.tap = None
         self.visible = False
         self._build_panel()
         return self
 
+    def numberOfRowsInTableView_(self, _table) -> int:
+        return len(self._completion_rows)
+
     def show(self) -> None:
         self._history = HistoryNavigator(load_history_lines())
+        self._hide_completions()
         if self.field is not None:
             self.field.setStringValue_("")
         self._center_panel()
@@ -147,6 +178,18 @@ class SpottyBunnyController(NSObject):
             self.panel.makeKeyAndOrderFront_(None)
         if self.panel is not None and self.field is not None:
             self.panel.makeFirstResponder_(self.field)
+        self._io.submit(self._load_completer, self._completer_loaded)
+
+    def tableView_objectValueForTableColumn_row_(self, _table, column, row: int):
+        if row < 0 or row >= len(self._completion_rows):
+            return ""
+        item = self._completion_rows[row]
+        ident = str(column.identifier())
+        if ident == "key":
+            return item.insert
+        if ident == "meta":
+            return item.meta
+        return ""
 
     def toggle(self) -> None:
         logger.info("toggle (visible=%s)", self.visible)
@@ -203,8 +246,30 @@ class SpottyBunnyController(NSObject):
         field.setDelegate_(self)
         panel.contentView().addSubview_(field)
 
+        scroll = NSScrollView.alloc().initWithFrame_(
+            NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, TABLE_HEIGHT - 8.0)
+        )
+        scroll.setHasVerticalScroller_(True)
+        scroll.setHidden_(True)
+        table = NSTableView.alloc().init()
+        key_col = NSTableColumn.alloc().initWithIdentifier_("key")
+        key_col.setTitle_("Shortcut")
+        key_col.setWidth_(160.0)
+        meta_col = NSTableColumn.alloc().initWithIdentifier_("meta")
+        meta_col.setTitle_("Description")
+        meta_col.setWidth_(400.0)
+        table.addTableColumn_(key_col)
+        table.addTableColumn_(meta_col)
+        table.setDataSource_(self)
+        table.setDelegate_(self)
+        table.setHeaderView_(None)
+        scroll.setDocumentView_(table)
+        panel.contentView().addSubview_(scroll)
+
         self.field = field
         self.panel = panel
+        self.scroll = scroll
+        self.table = table
 
     def _center_panel(self) -> None:
         if self.panel is None:
@@ -217,6 +282,104 @@ class SpottyBunnyController(NSObject):
         origin_x = visible.origin.x + (visible.size.width - frame.size.width) / 2.0
         origin_y = visible.origin.y + (visible.size.height - frame.size.height) * 0.55
         self.panel.setFrameOrigin_((origin_x, origin_y))
+
+    def _completer_loaded(self, result: object) -> None:
+        def apply() -> None:
+            if isinstance(result, Exception):
+                logger.warning("could not load shortcuts: %s", result)
+                return
+            self._completer = result
+            logger.info("shortcut completer ready")
+
+        _run_on_main(apply)
+
+    def _completions_ready(self, result: object) -> None:
+        def apply() -> None:
+            if isinstance(result, Exception):
+                logger.warning("completion failed: %s", result)
+                return
+            self._show_completions(result)  # type: ignore[arg-type]
+
+        _run_on_main(apply)
+
+    def _hide_completions(self) -> None:
+        self._completion_prefix = ""
+        self._completion_rows = []
+        if self.table is not None:
+            self.table.reloadData()
+        self._set_table_visible(False)
+
+    def _load_completer(self) -> object:
+        base_url = resolve_base_url(persist=False)
+        entries = fetch_key_entries(base_url=base_url)
+        return make_spotty_completer(
+            entries=entries,
+            suggestions_fn=lambda query: fetch_suggestions(query, base_url=base_url),
+        )
+
+    def _move_completion(self, selector: str) -> None:
+        if not self._completion_rows or self.table is None or self.field is None:
+            return
+        idx = int(self.table.selectedRow())
+        if idx < 0:
+            idx = 0
+        if selector == "moveUp:":
+            idx = max(0, idx - 1)
+        else:
+            idx = min(len(self._completion_rows) - 1, idx + 1)
+        self.table.selectRowIndexes_byExtendingSelection_(
+            NSIndexSet.indexSetWithIndex_(idx),
+            False,
+        )
+        row = self._completion_rows[idx]
+        self.field.setStringValue_(apply_completion(self._completion_prefix, row))
+
+    def _request_completions(self) -> None:
+        if self._completer is None or self.field is None:
+            logger.debug("tab ignored (completer not ready)")
+            return
+        text = str(self.field.stringValue())
+        self._completion_prefix = text
+        completer = self._completer
+        self._io.submit(
+            lambda: completions_for(text, completer),
+            self._completions_ready,
+        )
+
+    def _set_table_visible(self, visible: bool) -> None:
+        if self.scroll is None or self.panel is None or self.field is None:
+            return
+        self.scroll.setHidden_(not visible)
+        frame = self.panel.frame()
+        frame.size.height = PANEL_HEIGHT + (TABLE_HEIGHT if visible else 0.0)
+        self.panel.setFrame_display_(frame, True)
+        if visible:
+            self.field.setFrame_(
+                NSMakeRect(16.0, 16.0 + TABLE_HEIGHT, PANEL_WIDTH - 32.0, 40.0)
+            )
+            self.scroll.setFrame_(
+                NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, TABLE_HEIGHT - 8.0)
+            )
+        else:
+            self.field.setFrame_(NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, 40.0))
+        self._center_panel()
+
+    def _show_completions(self, rows: list[CompletionRow]) -> None:
+        self._completion_rows = rows
+        if not rows:
+            self._hide_completions()
+            return
+        if self.field is not None:
+            self.field.setStringValue_(
+                apply_completion(self._completion_prefix, rows[0])
+            )
+        if self.table is not None:
+            self.table.reloadData()
+            self.table.selectRowIndexes_byExtendingSelection_(
+                NSIndexSet.indexSetWithIndex_(0),
+                False,
+            )
+        self._set_table_visible(len(rows) > 1)
 
 
 def run_spotty_bunny_app() -> int:
@@ -389,3 +552,12 @@ def _post_wake_event() -> None:
 def _quit_on_sigint(_signum: int) -> None:
     logger.info("SIGINT received; stopping NSApp")
     quit_ns_app(ns_app=NSApp, post_wake=_post_wake_event)
+
+
+def _run_on_main(fn: object) -> None:
+    """Run *fn* on the AppKit thread (completion callbacks arrive off-main)."""
+    callback = fn if callable(fn) else lambda: None
+    if NSThread.isMainThread():
+        callback()
+        return
+    NSOperationQueue.mainQueue().addOperationWithBlock_(callback)

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -356,7 +356,7 @@ class SpottyBunnyController(NSObject):
 
     def _request_completions(self) -> None:
         if self._completer is None or self.field is None:
-            logger.debug("tab ignored (completer not ready)")
+            logger.warning("tab ignored (completer not ready)")
             return
         text = str(self.field.stringValue())
         self._completion_rows = []

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -359,6 +359,10 @@ class SpottyBunnyController(NSObject):
             logger.debug("tab ignored (completer not ready)")
             return
         text = str(self.field.stringValue())
+        self._completion_rows = []
+        if self.table is not None:
+            self.table.reloadData()
+        self._set_table_visible(False)
         self._completion_prefix = text
         self._completion_seq += 1
         seq = self._completion_seq

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -93,6 +93,7 @@ from app.spotty_bunny_quit import (
     post_application_wake_event,
     quit_ns_app,
 )
+from app.spotty_bunny_resolve import resolve_query
 
 PANEL_HEIGHT = 80.0
 PANEL_WIDTH = 640.0
@@ -128,9 +129,12 @@ class SpottyBunnyController(NSObject):
             if self.field is not None:
                 self.field.setStringValue_(history_text)
             return True
-        if name in {"cancelOperation:", "insertNewline:"}:
+        if name in {"cancelOperation:"}:
             logger.info("field-editor command %s → hide", name)
             self.hide()
+            return True
+        if name == "insertNewline:":
+            self._submit_query()
             return True
         logger.debug("field-editor command ignored: %s", name)
         return False
@@ -138,6 +142,7 @@ class SpottyBunnyController(NSObject):
     def hide(self) -> None:
         logger.info("hide panel (was visible=%s)", self.visible)
         self._hide_completions()
+        self._set_status("")
         panel = getattr(self, "panel", None)
         if panel is not None:
             panel.orderOut_(None)
@@ -150,6 +155,7 @@ class SpottyBunnyController(NSObject):
             return None
         self._applying_completion = False
         self._became_key = False
+        self._base_url = ""
         self._completer = None
         self._completion_prefix = ""
         self._completion_rows: list[CompletionRow] = []
@@ -162,6 +168,7 @@ class SpottyBunnyController(NSObject):
         self.panel = None
         self.scroll = None
         self.source = None
+        self.status = None
         self.table = None
         self.tap = None
         self.visible = False
@@ -255,6 +262,17 @@ class SpottyBunnyController(NSObject):
         field.setDelegate_(self)
         panel.contentView().addSubview_(field)
 
+        status = NSTextField.alloc().initWithFrame_(
+            NSMakeRect(16.0, 4.0, PANEL_WIDTH - 32.0, 14.0)
+        )
+        status.setEditable_(False)
+        status.setSelectable_(False)
+        status.setBezeled_(False)
+        status.setDrawsBackground_(False)
+        status.setFont_(NSFont.systemFontOfSize_(11.0))
+        status.setStringValue_("")
+        panel.contentView().addSubview_(status)
+
         scroll = NSScrollView.alloc().initWithFrame_(
             NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, TABLE_HEIGHT - 8.0)
         )
@@ -278,6 +296,7 @@ class SpottyBunnyController(NSObject):
         self.field = field
         self.panel = panel
         self.scroll = scroll
+        self.status = status
         self.table = table
 
     def _center_panel(self) -> None:
@@ -297,7 +316,9 @@ class SpottyBunnyController(NSObject):
             if isinstance(result, Exception):
                 logger.warning("could not load shortcuts: %s", result)
                 return
-            self._completer = result
+            completer, base_url = result  # type: ignore[misc]
+            self._completer = completer
+            self._base_url = base_url
             logger.info("shortcut completer ready")
 
         _run_on_main(apply)
@@ -332,10 +353,11 @@ class SpottyBunnyController(NSObject):
     def _load_completer(self) -> object:
         base_url = resolve_base_url(persist=False, allow_prompt=False)
         entries = fetch_key_entries(base_url=base_url)
-        return make_spotty_completer(
+        completer = make_spotty_completer(
             entries=entries,
             suggestions_fn=lambda query: fetch_suggestions(query, base_url=base_url),
         )
+        return completer, base_url
 
     def _move_completion(self, selector: str) -> None:
         if not self._completion_rows or self.table is None or self.field is None:
@@ -372,6 +394,18 @@ class SpottyBunnyController(NSObject):
             lambda result: self._completions_ready(result, seq=seq),
         )
 
+    def _resolve_ready(self, result: object) -> None:
+        def apply() -> None:
+            if isinstance(result, Exception):
+                logger.warning("resolve failed: %s", result)
+                self._hide_completions()
+                self._set_status(str(result))
+                return
+            logger.info("opened %s", result)
+            self.hide()
+
+        _run_on_main(apply)
+
     def _set_field_text(self, text: str) -> None:
         if self.field is None:
             return
@@ -380,6 +414,13 @@ class SpottyBunnyController(NSObject):
             self.field.setStringValue_(text)
         finally:
             self._applying_completion = False
+
+    def _set_status(self, message: str) -> None:
+        if self.status is None:
+            return
+        self.status.setStringValue_(message)
+        color = NSColor.systemRedColor() if message else NSColor.secondaryLabelColor()
+        self.status.setTextColor_(color)
 
     def _set_table_visible(self, visible: bool) -> None:
         if self.scroll is None or self.panel is None or self.field is None:
@@ -413,6 +454,21 @@ class SpottyBunnyController(NSObject):
                 False,
             )
         self._set_table_visible(len(rows) > 1)
+
+    def _submit_query(self) -> None:
+        if self.field is None:
+            return
+        query = str(self.field.stringValue()).strip()
+        if not query:
+            self.hide()
+            return
+        self._set_status("")
+        base_url = self._base_url or resolve_base_url(persist=False)
+
+        def work() -> str:
+            return resolve_query(query, base_url=base_url)
+
+        self._io.submit(work, self._resolve_ready)
 
 
 def run_spotty_bunny_app() -> int:

--- a/app/spotty_bunny_complete.py
+++ b/app/spotty_bunny_complete.py
@@ -24,11 +24,22 @@ class CompletionRow:
 
 
 def apply_completion(current: str, row: CompletionRow) -> str:
-    """Replace the in-progress token in *current* with *row.insert*."""
-    start = row.start_position
-    if start < 0:
-        return current[: len(current) + start] + row.insert
-    return current[:start] + row.insert
+    """Apply *row* like prompt_toolkit (start_position is relative to the cursor)."""
+    begin = len(current) + row.start_position
+    if begin < 0:
+        begin = 0
+    return current[:begin] + row.insert
+
+
+def completion_still_current(
+    *,
+    expected_seq: int,
+    field: str,
+    prefix: str,
+    seq: int,
+) -> bool:
+    """True when an async Tab result still matches the field that requested it."""
+    return seq == expected_seq and field == prefix
 
 
 def completions_for(text: str, completer: Completer) -> list[CompletionRow]:

--- a/app/spotty_bunny_complete.py
+++ b/app/spotty_bunny_complete.py
@@ -1,0 +1,74 @@
+"""Headless CLI completer wrapper for Spotty Bunny (no AppKit)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from prompt_toolkit.completion import CompleteEvent, Completer
+from prompt_toolkit.document import Document
+from prompt_toolkit.formatted_text import to_formatted_text, to_plain_text
+
+from app.client import KeyEntry
+from app.interactive import FirstTokenFuzzyCompleter, ShortcutCompleter
+from app.theme import Theme
+
+
+@dataclass(frozen=True)
+class CompletionRow:
+    """One completion candidate for the search box / table."""
+
+    insert: str
+    meta: str
+    start_position: int
+
+
+def apply_completion(current: str, row: CompletionRow) -> str:
+    """Replace the in-progress token in *current* with *row.insert*."""
+    start = row.start_position
+    if start < 0:
+        return current[: len(current) + start] + row.insert
+    return current[:start] + row.insert
+
+
+def completions_for(text: str, completer: Completer) -> list[CompletionRow]:
+    """Ask *completer* for Tab candidates at the end of *text*."""
+    document = Document(text=text, cursor_position=len(text))
+    event = CompleteEvent(text_inserted=False, completion_requested=True)
+    rows: list[CompletionRow] = []
+    for item in completer.get_completions(document, event):
+        rows.append(
+            CompletionRow(
+                insert=item.text,
+                meta=_plain(item.display_meta),
+                start_position=item.start_position,
+            )
+        )
+    return rows
+
+
+def make_spotty_completer(
+    *,
+    entries: Iterable[KeyEntry],
+    param_suggest_fn: Callable[..., list[str]] | None = None,
+    suggestions_fn: Callable[[str], list[str]] | None = None,
+) -> FirstTokenFuzzyCompleter:
+    """FirstTokenFuzzyCompleter over ShortcutCompleter (no REPL meta commands)."""
+    listing = list(entries)
+    inner = ShortcutCompleter(
+        [entry.key for entry in listing],
+        theme=Theme(enabled=False),
+        include_meta=False,
+        suggestions_fn=suggestions_fn,
+        entries=listing,
+        param_suggest_fn=param_suggest_fn,
+    )
+    return FirstTokenFuzzyCompleter(inner)
+
+
+def _plain(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return to_plain_text(to_formatted_text(value))

--- a/app/spotty_bunny_io.py
+++ b/app/spotty_bunny_io.py
@@ -1,0 +1,53 @@
+"""Run blocking Spotty Bunny I/O with ``asyncio.to_thread``."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable
+from typing import Any
+
+
+class ImmediateIo:
+    """Run work on the caller (unit tests)."""
+
+    def submit(
+        self,
+        fn: Callable[[], Any],
+        on_done: Callable[[Any], None],
+    ) -> None:
+        try:
+            on_done(fn())
+        except Exception as exc:
+            on_done(exc)
+
+
+class ThreadIo:
+    """Background asyncio loop; each job uses ``asyncio.to_thread``."""
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        thread = threading.Thread(
+            target=self._run,
+            name="spotty-bunny-io",
+            daemon=True,
+        )
+        thread.start()
+
+    def submit(
+        self,
+        fn: Callable[[], Any],
+        on_done: Callable[[Any], None],
+    ) -> None:
+        async def work() -> None:
+            try:
+                result = await asyncio.to_thread(fn)
+            except Exception as exc:
+                result = exc
+            on_done(result)
+
+        asyncio.run_coroutine_threadsafe(work(), self._loop)
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()

--- a/app/spotty_bunny_resolve.py
+++ b/app/spotty_bunny_resolve.py
@@ -1,0 +1,37 @@
+"""Resolve a Spotty Bunny query the same way as the CLI (strict)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from app.cli import open_url
+from app.client import resolve_shortcut
+from app.spotty_bunny_history import append_history_line
+
+
+def resolve_query(
+    query: str,
+    *,
+    base_url: str,
+    append_fn: Callable[[str], None] | None = None,
+    open_fn: Callable[..., None] | None = None,
+    resolve_fn: Callable[..., object] | None = None,
+) -> str:
+    """Resolve *query* strictly, open the URL, then append REPL history.
+
+    Returns the opened URL. Raises ``ClientError`` (or the resolver's error)
+    on failure; history is not written then.
+    """
+    text = query.strip()
+    if not text:
+        raise ValueError("empty query")
+    resolve = resolve_fn or resolve_shortcut
+    opener = open_fn or open_url
+    append = append_fn or append_history_line
+    resolved = resolve(text, base_url=base_url, strict=True)
+    url = getattr(resolved, "url", None)
+    if not isinstance(url, str) or not url:
+        raise ValueError("resolve response missing url")
+    opener(url)
+    append(text)
+    return url

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -241,11 +241,30 @@ class SpottyBunnyCliTests(SimpleTestCase):
 
 
 class SpottyBunnyCompleteTests(SimpleTestCase):
+    def test_apply_completion_appends_when_start_position_is_zero(self) -> None:
+        from app.spotty_bunny_complete import CompletionRow, apply_completion
+
+        row = CompletionRow(insert="the-hcma/bunnify", meta="", start_position=0)
+        self.assertEqual(apply_completion("pr ", row), "pr the-hcma/bunnify")
+
     def test_apply_completion_replaces_prefix(self) -> None:
         from app.spotty_bunny_complete import CompletionRow, apply_completion
 
         row = CompletionRow(insert="gh", meta="GitHub", start_position=-1)
         self.assertEqual(apply_completion("g", row), "gh")
+
+    def test_completion_still_current_requires_matching_seq_and_field(self) -> None:
+        from app.spotty_bunny_complete import completion_still_current
+
+        self.assertTrue(
+            completion_still_current(expected_seq=2, field="gh", prefix="gh", seq=2)
+        )
+        self.assertFalse(
+            completion_still_current(expected_seq=2, field="gho", prefix="gh", seq=2)
+        )
+        self.assertFalse(
+            completion_still_current(expected_seq=2, field="gh", prefix="gh", seq=3)
+        )
 
     def test_first_token_fuzzy_matches_description(self) -> None:
         from app.client import KeyEntry
@@ -284,7 +303,11 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
 
     def test_param_suggest_fn_is_used(self) -> None:
         from app.client import KeyEntry
-        from app.spotty_bunny_complete import completions_for, make_spotty_completer
+        from app.spotty_bunny_complete import (
+            apply_completion,
+            completions_for,
+            make_spotty_completer,
+        )
 
         completer = make_spotty_completer(
             entries=[
@@ -294,6 +317,8 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         )
         rows = completions_for("pr ", completer)
         self.assertEqual([row.insert for row in rows], ["the-hcma/bunnify"])
+        self.assertEqual(rows[0].start_position, 0)
+        self.assertEqual(apply_completion("pr ", rows[0]), "pr the-hcma/bunnify")
 
     def test_wrapper_asks_first_token_fuzzy_completer(self) -> None:
         from prompt_toolkit.completion import Completion

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -240,6 +240,78 @@ class SpottyBunnyCliTests(SimpleTestCase):
         self.assertIn("log_level=DEBUG", logged)
 
 
+class SpottyBunnyCompleteTests(SimpleTestCase):
+    def test_apply_completion_replaces_prefix(self) -> None:
+        from app.spotty_bunny_complete import CompletionRow, apply_completion
+
+        row = CompletionRow(insert="gh", meta="GitHub", start_position=-1)
+        self.assertEqual(apply_completion("g", row), "gh")
+
+    def test_first_token_fuzzy_matches_description(self) -> None:
+        from app.client import KeyEntry
+        from app.spotty_bunny_complete import completions_for, make_spotty_completer
+
+        completer = make_spotty_completer(
+            entries=[
+                KeyEntry(key="gh", description="GitHub"),
+                KeyEntry(key="g", description="Google"),
+            ]
+        )
+        rows = completions_for("hub", completer)
+        self.assertEqual([row.insert for row in rows], ["gh"])
+
+    def test_meta_commands_are_excluded(self) -> None:
+        from app.spotty_bunny_complete import completions_for, make_spotty_completer
+
+        rows = completions_for("q", make_spotty_completer(entries=[]))
+        self.assertEqual(rows, [])
+
+    def test_open_search_uses_suggestions_fn(self) -> None:
+        from app.client import KeyEntry
+        from app.spotty_bunny_complete import completions_for, make_spotty_completer
+
+        def suggestions(query: str) -> list[str]:
+            if query.startswith("g "):
+                return [f"{query} news"]
+            return []
+
+        completer = make_spotty_completer(
+            entries=[KeyEntry(key="g", description="Google")],
+            suggestions_fn=suggestions,
+        )
+        rows = completions_for("g hello", completer)
+        self.assertEqual([row.insert for row in rows], ["g hello news"])
+
+    def test_param_suggest_fn_is_used(self) -> None:
+        from app.client import KeyEntry
+        from app.spotty_bunny_complete import completions_for, make_spotty_completer
+
+        completer = make_spotty_completer(
+            entries=[
+                KeyEntry(key="pr", description="PR", params=("org/repo", "n")),
+            ],
+            param_suggest_fn=lambda **_kwargs: ["the-hcma/bunnify"],
+        )
+        rows = completions_for("pr ", completer)
+        self.assertEqual([row.insert for row in rows], ["the-hcma/bunnify"])
+
+    def test_wrapper_asks_first_token_fuzzy_completer(self) -> None:
+        from prompt_toolkit.completion import Completion
+
+        from app.spotty_bunny_complete import completions_for
+
+        completer = MagicMock()
+        completer.get_completions.return_value = [
+            Completion("gh", start_position=-1, display_meta="GitHub"),
+        ]
+        rows = completions_for("g", completer)
+        completer.get_completions.assert_called_once()
+        document = completer.get_completions.call_args[0][0]
+        self.assertEqual(document.text, "g")
+        self.assertEqual([row.insert for row in rows], ["gh"])
+        self.assertEqual(rows[0].meta, "GitHub")
+
+
 class SpottyBunnyHistoryTests(SimpleTestCase):
     def test_append_round_trips_prompt_toolkit_file_history(self) -> None:
         from prompt_toolkit.history import FileHistory

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -802,6 +802,57 @@ class SpottyBunnyQuitTests(SimpleTestCase):
         )
 
 
+class SpottyBunnyResolveTests(SimpleTestCase):
+    def test_failure_does_not_append_history(self) -> None:
+        from app.client import ClientError
+        from app.spotty_bunny_resolve import resolve_query
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "repl_history"
+
+            def append(line: str) -> None:
+                append_history_line(line, path=path)
+
+            def boom(*_args: object, **_kwargs: object) -> object:
+                raise ClientError("unknown shortcut")
+
+            with self.assertRaises(ClientError):
+                resolve_query(
+                    "nope",
+                    base_url="http://127.0.0.1:9",
+                    append_fn=append,
+                    open_fn=lambda _url: None,
+                    resolve_fn=boom,
+                )
+            self.assertEqual(load_history_lines(path=path), [])
+
+    def test_success_appends_shared_history_and_opens(self) -> None:
+        from app.client import ResolvedShortcut
+        from app.spotty_bunny_resolve import resolve_query
+
+        opened: list[str] = []
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "repl_history"
+
+            def append(line: str) -> None:
+                append_history_line(line, path=path)
+
+            url = resolve_query(
+                "  gh  ",
+                base_url="http://127.0.0.1:8000",
+                append_fn=append,
+                open_fn=opened.append,
+                resolve_fn=lambda query, **_kwargs: ResolvedShortcut(
+                    url="https://github.com",
+                    kind="shortcut",
+                    key=query,
+                ),
+            )
+            self.assertEqual(url, "https://github.com")
+            self.assertEqual(opened, ["https://github.com"])
+            self.assertEqual(load_history_lines(path=path), ["gh"])
+
+
 class _FakeClock:
     def __init__(self) -> None:
         self.t = 0.0

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -826,31 +826,64 @@ class SpottyBunnyResolveTests(SimpleTestCase):
                 )
             self.assertEqual(load_history_lines(path=path), [])
 
-    def test_success_appends_shared_history_and_opens(self) -> None:
-        from app.client import ResolvedShortcut
+    def test_open_failure_does_not_append_history(self) -> None:
+        from app.client import ClientError, ResolvedShortcut
         from app.spotty_bunny_resolve import resolve_query
 
-        opened: list[str] = []
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / "repl_history"
 
             def append(line: str) -> None:
                 append_history_line(line, path=path)
 
+            def boom_open(_url: str) -> None:
+                raise ClientError("no browser")
+
+            with self.assertRaises(ClientError):
+                resolve_query(
+                    "gh",
+                    base_url="http://127.0.0.1:8000",
+                    append_fn=append,
+                    open_fn=boom_open,
+                    resolve_fn=lambda query, **_kwargs: ResolvedShortcut(
+                        url="https://github.com",
+                        kind="shortcut",
+                        key=query,
+                    ),
+                )
+            self.assertEqual(load_history_lines(path=path), [])
+
+    def test_success_appends_shared_history_and_opens(self) -> None:
+        from app.client import ResolvedShortcut
+        from app.spotty_bunny_resolve import resolve_query
+
+        opened: list[str] = []
+        seen: dict[str, object] = {}
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "repl_history"
+
+            def append(line: str) -> None:
+                append_history_line(line, path=path)
+
+            def resolve_fn(query: str, **kwargs: object) -> ResolvedShortcut:
+                seen.update(kwargs)
+                return ResolvedShortcut(
+                    url="https://github.com",
+                    kind="shortcut",
+                    key=query,
+                )
+
             url = resolve_query(
                 "  gh  ",
                 base_url="http://127.0.0.1:8000",
                 append_fn=append,
                 open_fn=opened.append,
-                resolve_fn=lambda query, **_kwargs: ResolvedShortcut(
-                    url="https://github.com",
-                    kind="shortcut",
-                    key=query,
-                ),
+                resolve_fn=resolve_fn,
             )
             self.assertEqual(url, "https://github.com")
             self.assertEqual(opened, ["https://github.com"])
             self.assertEqual(load_history_lines(path=path), ["gh"])
+            self.assertIs(seen.get("strict"), True)
 
 
 class _FakeClock:

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -106,8 +106,10 @@ Hold **one** Control, then press the **other** to show the search box. Esc
 (or the same chord again) hides it. Up/down walks the CLI REPL history file
 (`platformdirs` cache `bunnify/repl_history`). Tab uses the same completers as
 the CLI (`FirstTokenFuzzyCompleter` / `ShortcutCompleter`) and lists matches
-under the field. Ctrl-C in that terminal quits. Startup prints the log file
-path on stderr (`spotty-bunny: logging to …`).
+under the field. Enter resolves via `/api/resolve/?strict=1` and opens the URL
+in the default browser (unknown keys stay in the panel with an error). Ctrl-C
+in that terminal quits. Startup prints the log file path on stderr
+(`spotty-bunny: logging to …`).
 
 If the chord does nothing, run with `--verbose` and watch stderr. Lines
 named `tap …` show whether key events arrive. If none appear while you press
@@ -117,8 +119,6 @@ Settings → Privacy & Security, then re-run. If events arrive but `fired=True`
 never appears, HID may still miss right Control (`hid R=False`); Spotty Bunny
 also uses device flag bits and the event keycode. Re-run `--verbose` after
 this fix.
-
-Opening shortcuts with Enter is not wired yet.
 
 ## macOS LaunchAgent
 

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -104,8 +104,10 @@ spotty-bunny
 
 Hold **one** Control, then press the **other** to show the search box. Esc
 (or the same chord again) hides it. Up/down walks the CLI REPL history file
-(`platformdirs` cache `bunnify/repl_history`). Ctrl-C in that terminal quits.
-Startup prints the log file path on stderr (`spotty-bunny: logging to …`).
+(`platformdirs` cache `bunnify/repl_history`). Tab uses the same completers as
+the CLI (`FirstTokenFuzzyCompleter` / `ShortcutCompleter`) and lists matches
+under the field. Ctrl-C in that terminal quits. Startup prints the log file
+path on stderr (`spotty-bunny: logging to …`).
 
 If the chord does nothing, run with `--verbose` and watch stderr. Lines
 named `tap …` show whether key events arrive. If none appear while you press
@@ -116,7 +118,7 @@ never appears, HID may still miss right Control (`hid R=False`); Spotty Bunny
 also uses device flag bits and the event keycode. Re-run `--verbose` after
 this fix.
 
-Tab completion and opening shortcuts are not wired yet.
+Opening shortcuts with Enter is not wired yet.
 
 ## macOS LaunchAgent
 


### PR DESCRIPTION
Closes #306.

Stacked on #312.

## Summary
- Enter runs `resolve_shortcut(..., strict=True)` then `open_url`.
- Success dismisses the panel, opens the browser, and appends the query to the shared REPL history.
- Failure keeps the panel open and shows the error.

## Test plan
- [x] Mocked resolve/open/history tests
- [ ] Enter `gh` with the server up; unknown key stays in the panel