### PR TITLE
feat: resolve Spotty Bunny Enter and open URLs (#306)

### DIFF
--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -64,7 +64,7 @@ from Quartz import (
 )
 
 from app.cli import open_url
-from app.client import ClientError, fetch_key_entries, fetch_suggestions
+from app.client import fetch_key_entries, fetch_suggestions
 from app.config import resolve_base_url
 from app.spotty_bunny_cli import SpottyBunnyEventTapError
 from app.spotty_bunny_complete import (
@@ -408,7 +408,7 @@ class SpottyBunnyController(NSObject):
             lambda result: self._completions_ready(result, seq=seq),
         )
 
-    def _resolve_ready(self, result: object, *, query: str, seq: int) -> None:
+    def _resolve_ready(self, result: object, *, seq: int) -> None:
         def apply() -> None:
             if not resolve_still_current(expected_seq=seq, seq=self._resolve_seq):
                 return
@@ -418,21 +418,7 @@ class SpottyBunnyController(NSObject):
                 self._hide_completions()
                 self._set_status(str(result))
                 return
-            url = result if isinstance(result, str) else ""
-            if not url:
-                logger.warning("resolve failed: missing url")
-                self._hide_completions()
-                self._set_status("resolve response missing url")
-                return
-            try:
-                open_url(url)
-                append_history_line(query)
-            except ClientError as exc:
-                logger.warning("open failed: %s", exc)
-                self._hide_completions()
-                self._set_status(str(exc))
-                return
-            logger.info("opened %s", url)
+            logger.info("opened %s", result)
             self.hide()
 
         _run_on_main(apply)
@@ -503,11 +489,14 @@ class SpottyBunnyController(NSObject):
             base_url = cached_base or resolve_base_url(
                 persist=False, allow_prompt=False
             )
-            return lookup_resolved_url(query, base_url=base_url)
+            url = lookup_resolved_url(query, base_url=base_url)
+            if not resolve_still_current(expected_seq=seq, seq=self._resolve_seq):
+                return url
+            open_url(url)
+            append_history_line(query)
+            return url
 
-        self._io.submit(
-            work, lambda result: self._resolve_ready(result, query=query, seq=seq)
-        )
+        self._io.submit(work, lambda result: self._resolve_ready(result, seq=seq))
 
 
 def run_spotty_bunny_app() -> int:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -384,6 +384,8 @@ class SpottyBunnyController(NSObject):
     def _request_completions(self) -> None:
         if self._completer is None or self.field is None:
             logger.warning("tab ignored (completer not ready)")
+            if self._completer is None:
+                self._set_status("could not load shortcuts")
             return
         text = str(self.field.stringValue())
         self._completion_rows = []

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -63,7 +63,8 @@ from Quartz import (
     kCGSessionEventTap,
 )
 
-from app.client import fetch_key_entries, fetch_suggestions
+from app.cli import open_url
+from app.client import ClientError, fetch_key_entries, fetch_suggestions
 from app.config import resolve_base_url
 from app.spotty_bunny_cli import SpottyBunnyEventTapError
 from app.spotty_bunny_complete import (
@@ -75,6 +76,7 @@ from app.spotty_bunny_complete import (
 )
 from app.spotty_bunny_history import (
     HistoryNavigator,
+    append_history_line,
     apply_history_selector,
     load_history_lines,
 )
@@ -93,7 +95,7 @@ from app.spotty_bunny_quit import (
     post_application_wake_event,
     quit_ns_app,
 )
-from app.spotty_bunny_resolve import resolve_query
+from app.spotty_bunny_resolve import lookup_resolved_url, resolve_still_current
 
 PANEL_HEIGHT = 80.0
 PANEL_WIDTH = 640.0
@@ -166,6 +168,7 @@ class SpottyBunnyController(NSObject):
         self._io = ThreadIo()
         self._resolve_seq = 0
         self._resolving = False
+        self._shortcuts_load_failed = False
         self.callback = None
         self.chord = ChordTracker()
         self.field = None
@@ -186,6 +189,7 @@ class SpottyBunnyController(NSObject):
         self._history = HistoryNavigator(load_history_lines())
         self._hide_completions()
         self._set_status("")
+        self._shortcuts_load_failed = False
         if self.field is not None:
             self.field.setStringValue_("")
         self._center_panel()
@@ -320,10 +324,13 @@ class SpottyBunnyController(NSObject):
         def apply() -> None:
             if isinstance(result, Exception):
                 logger.warning("could not load shortcuts: %s", result)
+                self._shortcuts_load_failed = True
                 return
             completer, base_url = result  # type: ignore[misc]
             self._completer = completer
             self._base_url = base_url
+            self._shortcuts_load_failed = False
+            self._set_status("")
             logger.info("shortcut completer ready")
 
         _run_on_main(apply)
@@ -384,7 +391,7 @@ class SpottyBunnyController(NSObject):
     def _request_completions(self) -> None:
         if self._completer is None or self.field is None:
             logger.warning("tab ignored (completer not ready)")
-            if self._completer is None:
+            if self._completer is None and self._shortcuts_load_failed:
                 self._set_status("could not load shortcuts")
             return
         text = str(self.field.stringValue())
@@ -401,9 +408,9 @@ class SpottyBunnyController(NSObject):
             lambda result: self._completions_ready(result, seq=seq),
         )
 
-    def _resolve_ready(self, result: object, *, seq: int) -> None:
+    def _resolve_ready(self, result: object, *, query: str, seq: int) -> None:
         def apply() -> None:
-            if seq != self._resolve_seq:
+            if not resolve_still_current(expected_seq=seq, seq=self._resolve_seq):
                 return
             self._resolving = False
             if isinstance(result, Exception):
@@ -411,7 +418,21 @@ class SpottyBunnyController(NSObject):
                 self._hide_completions()
                 self._set_status(str(result))
                 return
-            logger.info("opened %s", result)
+            url = result if isinstance(result, str) else ""
+            if not url:
+                logger.warning("resolve failed: missing url")
+                self._hide_completions()
+                self._set_status("resolve response missing url")
+                return
+            try:
+                open_url(url)
+                append_history_line(query)
+            except ClientError as exc:
+                logger.warning("open failed: %s", exc)
+                self._hide_completions()
+                self._set_status(str(exc))
+                return
+            logger.info("opened %s", url)
             self.hide()
 
         _run_on_main(apply)
@@ -476,12 +497,17 @@ class SpottyBunnyController(NSObject):
         seq = self._resolve_seq
         self._resolving = True
         self._set_status("")
-        base_url = self._base_url or resolve_base_url(persist=False, allow_prompt=False)
+        cached_base = self._base_url
 
         def work() -> str:
-            return resolve_query(query, base_url=base_url)
+            base_url = cached_base or resolve_base_url(
+                persist=False, allow_prompt=False
+            )
+            return lookup_resolved_url(query, base_url=base_url)
 
-        self._io.submit(work, lambda result: self._resolve_ready(result, seq=seq))
+        self._io.submit(
+            work, lambda result: self._resolve_ready(result, query=query, seq=seq)
+        )
 
 
 def run_spotty_bunny_app() -> int:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -141,6 +141,8 @@ class SpottyBunnyController(NSObject):
 
     def hide(self) -> None:
         logger.info("hide panel (was visible=%s)", self.visible)
+        self._resolve_seq += 1
+        self._resolving = False
         self._hide_completions()
         self._set_status("")
         panel = getattr(self, "panel", None)
@@ -162,6 +164,7 @@ class SpottyBunnyController(NSObject):
         self._completion_seq = 0
         self._history = HistoryNavigator()
         self._io = ThreadIo()
+        self._resolve_seq = 0
         self._resolving = False
         self.callback = None
         self.chord = ChordTracker()
@@ -396,11 +399,11 @@ class SpottyBunnyController(NSObject):
             lambda result: self._completions_ready(result, seq=seq),
         )
 
-    def _resolve_ready(self, result: object) -> None:
+    def _resolve_ready(self, result: object, *, seq: int) -> None:
         def apply() -> None:
-            self._resolving = False
-            if not self.visible:
+            if seq != self._resolve_seq:
                 return
+            self._resolving = False
             if isinstance(result, Exception):
                 logger.warning("resolve failed: %s", result)
                 self._hide_completions()
@@ -467,6 +470,8 @@ class SpottyBunnyController(NSObject):
         if not query:
             self.hide()
             return
+        self._resolve_seq += 1
+        seq = self._resolve_seq
         self._resolving = True
         self._set_status("")
         base_url = self._base_url or resolve_base_url(persist=False, allow_prompt=False)
@@ -474,7 +479,7 @@ class SpottyBunnyController(NSObject):
         def work() -> str:
             return resolve_query(query, base_url=base_url)
 
-        self._io.submit(work, self._resolve_ready)
+        self._io.submit(work, lambda result: self._resolve_ready(result, seq=seq))
 
 
 def run_spotty_bunny_app() -> int:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -162,6 +162,7 @@ class SpottyBunnyController(NSObject):
         self._completion_seq = 0
         self._history = HistoryNavigator()
         self._io = ThreadIo()
+        self._resolving = False
         self.callback = None
         self.chord = ChordTracker()
         self.field = None
@@ -181,6 +182,7 @@ class SpottyBunnyController(NSObject):
     def show(self) -> None:
         self._history = HistoryNavigator(load_history_lines())
         self._hide_completions()
+        self._set_status("")
         if self.field is not None:
             self.field.setStringValue_("")
         self._center_panel()
@@ -396,6 +398,9 @@ class SpottyBunnyController(NSObject):
 
     def _resolve_ready(self, result: object) -> None:
         def apply() -> None:
+            self._resolving = False
+            if not self.visible:
+                return
             if isinstance(result, Exception):
                 logger.warning("resolve failed: %s", result)
                 self._hide_completions()
@@ -456,14 +461,15 @@ class SpottyBunnyController(NSObject):
         self._set_table_visible(len(rows) > 1)
 
     def _submit_query(self) -> None:
-        if self.field is None:
+        if self.field is None or self._resolving:
             return
         query = str(self.field.stringValue()).strip()
         if not query:
             self.hide()
             return
+        self._resolving = True
         self._set_status("")
-        base_url = self._base_url or resolve_base_url(persist=False)
+        base_url = self._base_url or resolve_base_url(persist=False, allow_prompt=False)
 
         def work() -> str:
             return resolve_query(query, base_url=base_url)

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -93,6 +93,7 @@ from app.spotty_bunny_quit import (
     post_application_wake_event,
     quit_ns_app,
 )
+from app.spotty_bunny_resolve import resolve_query
 
 PANEL_HEIGHT = 80.0
 PANEL_WIDTH = 640.0
@@ -128,9 +129,12 @@ class SpottyBunnyController(NSObject):
             if self.field is not None:
                 self.field.setStringValue_(history_text)
             return True
-        if name in {"cancelOperation:", "insertNewline:"}:
+        if name in {"cancelOperation:"}:
             logger.info("field-editor command %s → hide", name)
             self.hide()
+            return True
+        if name == "insertNewline:":
+            self._submit_query()
             return True
         logger.debug("field-editor command ignored: %s", name)
         return False
@@ -138,6 +142,7 @@ class SpottyBunnyController(NSObject):
     def hide(self) -> None:
         logger.info("hide panel (was visible=%s)", self.visible)
         self._hide_completions()
+        self._set_status("")
         panel = getattr(self, "panel", None)
         if panel is not None:
             panel.orderOut_(None)
@@ -150,6 +155,7 @@ class SpottyBunnyController(NSObject):
             return None
         self._applying_completion = False
         self._became_key = False
+        self._base_url = ""
         self._completer = None
         self._completion_prefix = ""
         self._completion_rows: list[CompletionRow] = []
@@ -162,6 +168,7 @@ class SpottyBunnyController(NSObject):
         self.panel = None
         self.scroll = None
         self.source = None
+        self.status = None
         self.table = None
         self.tap = None
         self.visible = False
@@ -255,6 +262,17 @@ class SpottyBunnyController(NSObject):
         field.setDelegate_(self)
         panel.contentView().addSubview_(field)
 
+        status = NSTextField.alloc().initWithFrame_(
+            NSMakeRect(16.0, 4.0, PANEL_WIDTH - 32.0, 14.0)
+        )
+        status.setEditable_(False)
+        status.setSelectable_(False)
+        status.setBezeled_(False)
+        status.setDrawsBackground_(False)
+        status.setFont_(NSFont.systemFontOfSize_(11.0))
+        status.setStringValue_("")
+        panel.contentView().addSubview_(status)
+
         scroll = NSScrollView.alloc().initWithFrame_(
             NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, TABLE_HEIGHT - 8.0)
         )
@@ -278,6 +296,7 @@ class SpottyBunnyController(NSObject):
         self.field = field
         self.panel = panel
         self.scroll = scroll
+        self.status = status
         self.table = table
 
     def _center_panel(self) -> None:
@@ -297,7 +316,9 @@ class SpottyBunnyController(NSObject):
             if isinstance(result, Exception):
                 logger.warning("could not load shortcuts: %s", result)
                 return
-            self._completer = result
+            completer, base_url = result  # type: ignore[misc]
+            self._completer = completer
+            self._base_url = base_url
             logger.info("shortcut completer ready")
 
         _run_on_main(apply)
@@ -332,10 +353,11 @@ class SpottyBunnyController(NSObject):
     def _load_completer(self) -> object:
         base_url = resolve_base_url(persist=False, allow_prompt=False)
         entries = fetch_key_entries(base_url=base_url)
-        return make_spotty_completer(
+        completer = make_spotty_completer(
             entries=entries,
             suggestions_fn=lambda query: fetch_suggestions(query, base_url=base_url),
         )
+        return completer, base_url
 
     def _move_completion(self, selector: str) -> None:
         if not self._completion_rows or self.table is None or self.field is None:
@@ -372,6 +394,18 @@ class SpottyBunnyController(NSObject):
             lambda result: self._completions_ready(result, seq=seq),
         )
 
+    def _resolve_ready(self, result: object) -> None:
+        def apply() -> None:
+            if isinstance(result, Exception):
+                logger.warning("resolve failed: %s", result)
+                self._hide_completions()
+                self._set_status(str(result))
+                return
+            logger.info("opened %s", result)
+            self.hide()
+
+        _run_on_main(apply)
+
     def _set_field_text(self, text: str) -> None:
         if self.field is None:
             return
@@ -380,6 +414,13 @@ class SpottyBunnyController(NSObject):
             self.field.setStringValue_(text)
         finally:
             self._applying_completion = False
+
+    def _set_status(self, message: str) -> None:
+        if self.status is None:
+            return
+        self.status.setStringValue_(message)
+        color = NSColor.systemRedColor() if message else NSColor.secondaryLabelColor()
+        self.status.setTextColor_(color)
 
     def _set_table_visible(self, visible: bool) -> None:
         if self.scroll is None or self.panel is None or self.field is None:
@@ -413,6 +454,21 @@ class SpottyBunnyController(NSObject):
                 False,
             )
         self._set_table_visible(len(rows) > 1)
+
+    def _submit_query(self) -> None:
+        if self.field is None:
+            return
+        query = str(self.field.stringValue()).strip()
+        if not query:
+            self.hide()
+            return
+        self._set_status("")
+        base_url = self._base_url or resolve_base_url(persist=False)
+
+        def work() -> str:
+            return resolve_query(query, base_url=base_url)
+
+        self._io.submit(work, self._resolve_ready)
 
 
 def run_spotty_bunny_app() -> int:

--- a/app/spotty_bunny_resolve.py
+++ b/app/spotty_bunny_resolve.py
@@ -1,0 +1,37 @@
+"""Resolve a Spotty Bunny query the same way as the CLI (strict)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from app.cli import open_url
+from app.client import resolve_shortcut
+from app.spotty_bunny_history import append_history_line
+
+
+def resolve_query(
+    query: str,
+    *,
+    base_url: str,
+    append_fn: Callable[[str], None] | None = None,
+    open_fn: Callable[..., None] | None = None,
+    resolve_fn: Callable[..., object] | None = None,
+) -> str:
+    """Resolve *query* strictly, open the URL, then append REPL history.
+
+    Returns the opened URL. Raises ``ClientError`` (or the resolver's error)
+    on failure; history is not written then.
+    """
+    text = query.strip()
+    if not text:
+        raise ValueError("empty query")
+    resolve = resolve_fn or resolve_shortcut
+    opener = open_fn or open_url
+    append = append_fn or append_history_line
+    resolved = resolve(text, base_url=base_url, strict=True)
+    url = getattr(resolved, "url", None)
+    if not isinstance(url, str) or not url:
+        raise ValueError("resolve response missing url")
+    opener(url)
+    append(text)
+    return url

--- a/app/spotty_bunny_resolve.py
+++ b/app/spotty_bunny_resolve.py
@@ -9,6 +9,24 @@ from app.client import resolve_shortcut
 from app.spotty_bunny_history import append_history_line
 
 
+def lookup_resolved_url(
+    query: str,
+    *,
+    base_url: str,
+    resolve_fn: Callable[..., object] | None = None,
+) -> str:
+    """Strict-resolve *query* and return the URL without opening or history."""
+    text = query.strip()
+    if not text:
+        raise ValueError("empty query")
+    resolve = resolve_fn or resolve_shortcut
+    resolved = resolve(text, base_url=base_url, strict=True)
+    url = getattr(resolved, "url", None)
+    if not isinstance(url, str) or not url:
+        raise ValueError("resolve response missing url")
+    return url
+
+
 def resolve_query(
     query: str,
     *,
@@ -23,15 +41,14 @@ def resolve_query(
     on failure; history is not written then.
     """
     text = query.strip()
-    if not text:
-        raise ValueError("empty query")
-    resolve = resolve_fn or resolve_shortcut
     opener = open_fn or open_url
     append = append_fn or append_history_line
-    resolved = resolve(text, base_url=base_url, strict=True)
-    url = getattr(resolved, "url", None)
-    if not isinstance(url, str) or not url:
-        raise ValueError("resolve response missing url")
+    url = lookup_resolved_url(query, base_url=base_url, resolve_fn=resolve_fn)
     opener(url)
     append(text)
     return url
+
+
+def resolve_still_current(*, expected_seq: int, seq: int) -> bool:
+    """True when an async Enter result still matches the submit that requested it."""
+    return seq == expected_seq

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -802,6 +802,57 @@ class SpottyBunnyQuitTests(SimpleTestCase):
         )
 
 
+class SpottyBunnyResolveTests(SimpleTestCase):
+    def test_failure_does_not_append_history(self) -> None:
+        from app.client import ClientError
+        from app.spotty_bunny_resolve import resolve_query
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "repl_history"
+
+            def append(line: str) -> None:
+                append_history_line(line, path=path)
+
+            def boom(*_args: object, **_kwargs: object) -> object:
+                raise ClientError("unknown shortcut")
+
+            with self.assertRaises(ClientError):
+                resolve_query(
+                    "nope",
+                    base_url="http://127.0.0.1:9",
+                    append_fn=append,
+                    open_fn=lambda _url: None,
+                    resolve_fn=boom,
+                )
+            self.assertEqual(load_history_lines(path=path), [])
+
+    def test_success_appends_shared_history_and_opens(self) -> None:
+        from app.client import ResolvedShortcut
+        from app.spotty_bunny_resolve import resolve_query
+
+        opened: list[str] = []
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "repl_history"
+
+            def append(line: str) -> None:
+                append_history_line(line, path=path)
+
+            url = resolve_query(
+                "  gh  ",
+                base_url="http://127.0.0.1:8000",
+                append_fn=append,
+                open_fn=opened.append,
+                resolve_fn=lambda query, **_kwargs: ResolvedShortcut(
+                    url="https://github.com",
+                    kind="shortcut",
+                    key=query,
+                ),
+            )
+            self.assertEqual(url, "https://github.com")
+            self.assertEqual(opened, ["https://github.com"])
+            self.assertEqual(load_history_lines(path=path), ["gh"])
+
+
 class _FakeClock:
     def __init__(self) -> None:
         self.t = 0.0

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -826,6 +826,28 @@ class SpottyBunnyResolveTests(SimpleTestCase):
                 )
             self.assertEqual(load_history_lines(path=path), [])
 
+    def test_lookup_does_not_open_or_append(self) -> None:
+        from app.client import ResolvedShortcut
+        from app.spotty_bunny_resolve import lookup_resolved_url
+
+        seen: dict[str, object] = {}
+
+        def resolve_fn(query: str, **kwargs: object) -> ResolvedShortcut:
+            seen.update(kwargs)
+            return ResolvedShortcut(
+                url="https://github.com",
+                kind="shortcut",
+                key=query,
+            )
+
+        url = lookup_resolved_url(
+            "  gh  ",
+            base_url="http://127.0.0.1:8000",
+            resolve_fn=resolve_fn,
+        )
+        self.assertEqual(url, "https://github.com")
+        self.assertIs(seen.get("strict"), True)
+
     def test_open_failure_does_not_append_history(self) -> None:
         from app.client import ClientError, ResolvedShortcut
         from app.spotty_bunny_resolve import resolve_query
@@ -852,6 +874,12 @@ class SpottyBunnyResolveTests(SimpleTestCase):
                     ),
                 )
             self.assertEqual(load_history_lines(path=path), [])
+
+    def test_resolve_still_current_requires_matching_seq(self) -> None:
+        from app.spotty_bunny_resolve import resolve_still_current
+
+        self.assertTrue(resolve_still_current(expected_seq=4, seq=4))
+        self.assertFalse(resolve_still_current(expected_seq=4, seq=5))
 
     def test_success_appends_shared_history_and_opens(self) -> None:
         from app.client import ResolvedShortcut

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -826,31 +826,64 @@ class SpottyBunnyResolveTests(SimpleTestCase):
                 )
             self.assertEqual(load_history_lines(path=path), [])
 
-    def test_success_appends_shared_history_and_opens(self) -> None:
-        from app.client import ResolvedShortcut
+    def test_open_failure_does_not_append_history(self) -> None:
+        from app.client import ClientError, ResolvedShortcut
         from app.spotty_bunny_resolve import resolve_query
 
-        opened: list[str] = []
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / "repl_history"
 
             def append(line: str) -> None:
                 append_history_line(line, path=path)
 
+            def boom_open(_url: str) -> None:
+                raise ClientError("no browser")
+
+            with self.assertRaises(ClientError):
+                resolve_query(
+                    "gh",
+                    base_url="http://127.0.0.1:8000",
+                    append_fn=append,
+                    open_fn=boom_open,
+                    resolve_fn=lambda query, **_kwargs: ResolvedShortcut(
+                        url="https://github.com",
+                        kind="shortcut",
+                        key=query,
+                    ),
+                )
+            self.assertEqual(load_history_lines(path=path), [])
+
+    def test_success_appends_shared_history_and_opens(self) -> None:
+        from app.client import ResolvedShortcut
+        from app.spotty_bunny_resolve import resolve_query
+
+        opened: list[str] = []
+        seen: dict[str, object] = {}
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "repl_history"
+
+            def append(line: str) -> None:
+                append_history_line(line, path=path)
+
+            def resolve_fn(query: str, **kwargs: object) -> ResolvedShortcut:
+                seen.update(kwargs)
+                return ResolvedShortcut(
+                    url="https://github.com",
+                    kind="shortcut",
+                    key=query,
+                )
+
             url = resolve_query(
                 "  gh  ",
                 base_url="http://127.0.0.1:8000",
                 append_fn=append,
                 open_fn=opened.append,
-                resolve_fn=lambda query, **_kwargs: ResolvedShortcut(
-                    url="https://github.com",
-                    kind="shortcut",
-                    key=query,
-                ),
+                resolve_fn=resolve_fn,
             )
             self.assertEqual(url, "https://github.com")
             self.assertEqual(opened, ["https://github.com"])
             self.assertEqual(load_history_lines(path=path), ["gh"])
+            self.assertIs(seen.get("strict"), True)
 
 
 class _FakeClock:

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -106,8 +106,10 @@ Hold **one** Control, then press the **other** to show the search box. Esc
 (or the same chord again) hides it. Up/down walks the CLI REPL history file
 (`platformdirs` cache `bunnify/repl_history`). Tab uses the same completers as
 the CLI (`FirstTokenFuzzyCompleter` / `ShortcutCompleter`) and lists matches
-under the field. Ctrl-C in that terminal quits. Startup prints the log file
-path on stderr (`spotty-bunny: logging to …`).
+under the field. Enter resolves via `/api/resolve/?strict=1` and opens the URL
+in the default browser (unknown keys stay in the panel with an error). Ctrl-C
+in that terminal quits. Startup prints the log file path on stderr
+(`spotty-bunny: logging to …`).
 
 If the chord does nothing, run with `--verbose` and watch stderr. Lines
 named `tap …` show whether key events arrive. If none appear while you press
@@ -117,8 +119,6 @@ Settings → Privacy & Security, then re-run. If events arrive but `fired=True`
 never appears, HID may still miss right Control (`hid R=False`); Spotty Bunny
 also uses device flag bits and the event keycode. Re-run `--verbose` after
 this fix.
-
-Opening shortcuts with Enter is not wired yet.
 
 ## macOS LaunchAgent
 


### PR DESCRIPTION
Closes #306.

Successor to #313 (GitHub would not reopen that stacked PR after #311/#312 merged).

## Summary
- Enter runs `resolve_shortcut(..., strict=True)` then `open_url`.
- Success dismisses the panel, opens the browser, and appends the query to the shared REPL history.
- Failure keeps the panel open and shows the error.
- Guards against double-submit, stale callbacks after hide, and missing Tab completers.

## Test plan
- [x] Mocked resolve/open/history tests
- [ ] Enter `gh` with the server up; unknown key stays in the panel