### PR TITLE
feat: polish Spotty Bunny UI and REPL auto-start

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -947,6 +947,15 @@ def _run_repl(
 ) -> None:
     entries = fetch_key_entries(base_url=base_url)
     keys = [entry.key for entry in entries]
+    if sys.platform == "darwin" and input_fn is None:
+        from app.spotty_bunny_launch import ensure_spotty_bunny_running
+
+        if ensure_spotty_bunny_running():
+            click.echo(
+                theme.dim(
+                    "Spotty Bunny overlay ready (hold one Control, tap the other)"
+                )
+            )
     click.echo(
         f"{theme.brand('bunnify')} {theme.dim(build_version())} "
         f"{theme.dim('interactive — Tab fuzzy-completes; quit to exit')}"

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -18,6 +18,8 @@ from Cocoa import (
     NSEventTypeApplicationDefined,
     NSFloatingWindowLevel,
     NSFont,
+    NSImageScaleProportionallyUpOrDown,
+    NSImageView,
     NSMakeRect,
     NSObject,
     NSPanel,
@@ -70,6 +72,7 @@ from app.spotty_bunny_cli import SpottyBunnyEventTapError
 from app.spotty_bunny_complete import (
     CompletionRow,
     apply_completion,
+    completion_row_after_selector,
     completion_still_current,
     completions_for,
     make_spotty_completer,
@@ -89,6 +92,7 @@ from app.spotty_bunny_hotkey import (
     apply_control_event,
     describe_key,
 )
+from app.spotty_bunny_icon import make_spotty_bunny_icon
 from app.spotty_bunny_io import ThreadIo
 from app.spotty_bunny_quit import (
     WAKE_EVENT_SELECTOR,
@@ -97,9 +101,15 @@ from app.spotty_bunny_quit import (
 )
 from app.spotty_bunny_resolve import lookup_resolved_url, resolve_still_current
 
+FIELD_PLACEHOLDER = "Type a shortcut (e.g., gh, c, search hello)"
+LOGO_LEFT = 16.0
+LOGO_SIZE = 40.0
+LOGO_TOP = 24.0
 PANEL_HEIGHT = 80.0
 PANEL_WIDTH = 640.0
 TABLE_HEIGHT = 140.0
+FIELD_LEFT = LOGO_LEFT + LOGO_SIZE + 12.0
+FIELD_WIDTH = PANEL_WIDTH - FIELD_LEFT - 16.0
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +129,12 @@ class SpottyBunnyController(NSObject):
         if name == "insertTab:":
             self._request_completions()
             return True
-        if self._completion_rows and name in {"moveDown:", "moveUp:"}:
+        if self._completion_rows and name in {
+            "moveDown:",
+            "moveUp:",
+            "pageDown:",
+            "pageUp:",
+        }:
             self._move_completion(name)
             return True
         current = ""
@@ -172,6 +187,7 @@ class SpottyBunnyController(NSObject):
         self.callback = None
         self.chord = ChordTracker()
         self.field = None
+        self.logo = None
         self.panel = None
         self.scroll = None
         self.source = None
@@ -259,14 +275,21 @@ class SpottyBunnyController(NSObject):
         panel.setReleasedWhenClosed_(False)
         panel.setDelegate_(self)
 
+        logo = NSImageView.alloc().initWithFrame_(
+            NSMakeRect(LOGO_LEFT, LOGO_TOP, LOGO_SIZE, LOGO_SIZE)
+        )
+        logo.setImage_(make_spotty_bunny_icon(LOGO_SIZE))
+        logo.setImageScaling_(NSImageScaleProportionallyUpOrDown)
+        panel.contentView().addSubview_(logo)
+
         field = NSTextField.alloc().initWithFrame_(
-            NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, 40.0)
+            NSMakeRect(FIELD_LEFT, 16.0, FIELD_WIDTH, 40.0)
         )
         field.setEditable_(True)
         field.setSelectable_(True)
         field.setBezeled_(True)
         field.setFont_(NSFont.systemFontOfSize_(20.0))
-        field.setPlaceholderString_("Type a shortcut…")
+        field.setPlaceholderString_(FIELD_PLACEHOLDER)
         field.setBackgroundColor_(NSColor.textBackgroundColor())
         field.setDelegate_(self)
         panel.contentView().addSubview_(field)
@@ -303,6 +326,7 @@ class SpottyBunnyController(NSObject):
         panel.contentView().addSubview_(scroll)
 
         self.field = field
+        self.logo = logo
         self.panel = panel
         self.scroll = scroll
         self.status = status
@@ -311,7 +335,7 @@ class SpottyBunnyController(NSObject):
     def _center_panel(self) -> None:
         if self.panel is None:
             return
-        screen = NSScreen.mainScreen()
+        screen = _primary_screen()
         if screen is None:
             return
         visible = screen.visibleFrame()
@@ -374,17 +398,16 @@ class SpottyBunnyController(NSObject):
     def _move_completion(self, selector: str) -> None:
         if not self._completion_rows or self.table is None or self.field is None:
             return
-        idx = int(self.table.selectedRow())
-        if idx < 0:
-            idx = 0
-        if selector == "moveUp:":
-            idx = max(0, idx - 1)
-        else:
-            idx = min(len(self._completion_rows) - 1, idx + 1)
+        idx = completion_row_after_selector(
+            int(self.table.selectedRow()),
+            row_count=len(self._completion_rows),
+            selector=selector,
+        )
         self.table.selectRowIndexes_byExtendingSelection_(
             NSIndexSet.indexSetWithIndex_(idx),
             False,
         )
+        self.table.scrollRowToVisible_(idx)
         row = self._completion_rows[idx]
         self._set_field_text(apply_completion(self._completion_prefix, row))
 
@@ -448,13 +471,13 @@ class SpottyBunnyController(NSObject):
         self.panel.setFrame_display_(frame, True)
         if visible:
             self.field.setFrame_(
-                NSMakeRect(16.0, 16.0 + TABLE_HEIGHT, PANEL_WIDTH - 32.0, 40.0)
+                NSMakeRect(FIELD_LEFT, 16.0 + TABLE_HEIGHT, FIELD_WIDTH, 40.0)
             )
             self.scroll.setFrame_(
                 NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, TABLE_HEIGHT - 8.0)
             )
         else:
-            self.field.setFrame_(NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, 40.0))
+            self.field.setFrame_(NSMakeRect(FIELD_LEFT, 16.0, FIELD_WIDTH, 40.0))
         self._center_panel()
 
     def _show_completions(self, rows: list[CompletionRow]) -> None:
@@ -470,6 +493,7 @@ class SpottyBunnyController(NSObject):
                 NSIndexSet.indexSetWithIndex_(0),
                 False,
             )
+            self.table.scrollRowToVisible_(0)
         self._set_table_visible(len(rows) > 1)
 
     def _submit_query(self) -> None:
@@ -497,6 +521,15 @@ class SpottyBunnyController(NSObject):
             return url
 
         self._io.submit(work, lambda result: self._resolve_ready(result, seq=seq))
+
+
+def _primary_screen():
+    """Return the menu-bar (main) display, not a secondary monitor."""
+    main = NSScreen.mainScreen()
+    if main is not None:
+        return main
+    screens = NSScreen.screens()
+    return screens[0] if screens else None
 
 
 def run_spotty_bunny_app() -> int:

--- a/app/spotty_bunny_cli.py
+++ b/app/spotty_bunny_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import atexit
 import logging
 import logging.handlers
 import os
@@ -11,6 +12,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from app.config import data_dir
+from app.spotty_bunny_launch import clear_spotty_bunny_pid, write_spotty_bunny_pid
 from app.version import build_version
 
 COMMAND_NAME = "spotty-bunny"
@@ -65,8 +67,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--log-level",
         type=str.upper,
         choices=LOG_LEVELS,
-        default="WARNING",
-        help="Application log level (default: WARNING). Same values as bunnify-server.",
+        default="INFO",
+        help="Application log level (default: INFO). Same values as bunnify-server.",
     )
     parser.add_argument(
         "-v",
@@ -101,6 +103,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"{COMMAND_NAME}: logging to {active_log}", file=sys.stderr)
     else:
         print(f"{COMMAND_NAME}: logging to stderr only", file=sys.stderr)
+    if sys.platform == "darwin":
+        write_spotty_bunny_pid(os.getpid())
+        atexit.register(clear_spotty_bunny_pid)
     return run_spotty_bunny()
 
 

--- a/app/spotty_bunny_complete.py
+++ b/app/spotty_bunny_complete.py
@@ -23,6 +23,31 @@ class CompletionRow:
     start_position: int
 
 
+COMPLETION_PAGE_STEP = 5
+
+
+def completion_row_after_selector(
+    current: int,
+    *,
+    row_count: int,
+    selector: str,
+    page_step: int = COMPLETION_PAGE_STEP,
+) -> int:
+    """Return the completion table row index after a navigation selector."""
+    if row_count <= 0:
+        return 0
+    idx = current if current >= 0 else 0
+    if selector == "moveUp:":
+        return max(0, idx - 1)
+    if selector == "moveDown:":
+        return min(row_count - 1, idx + 1)
+    if selector == "pageUp:":
+        return max(0, idx - page_step)
+    if selector == "pageDown:":
+        return min(row_count - 1, idx + page_step)
+    return idx
+
+
 def apply_completion(current: str, row: CompletionRow) -> str:
     """Apply *row* like prompt_toolkit (start_position is relative to the cursor)."""
     begin = len(current) + row.start_position

--- a/app/spotty_bunny_icon.py
+++ b/app/spotty_bunny_icon.py
@@ -1,0 +1,77 @@
+"""Spotty Bunny panel icon (AppKit drawing; imported only on macOS)."""
+
+from __future__ import annotations
+
+# pyright: reportMissingImports=false
+from Cocoa import (
+    NSBezierPath,
+    NSColor,
+    NSImage,
+    NSMakeRect,
+    NSMakeSize,
+)
+
+
+def _rgba(red: float, green: float, blue: float, alpha: float = 1.0) -> NSColor:
+    return NSColor.colorWithCalibratedRed_green_blue_alpha_(red, green, blue, alpha)
+
+
+def make_spotty_bunny_icon(size: float) -> NSImage:
+    """Return a simple bunny face icon at *size*×*size* points."""
+    side = float(size)
+    image = NSImage.alloc().initWithSize_(NSMakeSize(side, side))
+    image.lockFocus()
+    try:
+        NSColor.clearColor().set()
+        NSBezierPath.fillRect_(NSMakeRect(0.0, 0.0, side, side))
+
+        ear_color = _rgba(0.95, 0.72, 0.78)
+        face_color = _rgba(1.0, 0.92, 0.94)
+        stroke = _rgba(0.45, 0.28, 0.36)
+
+        for center_x in (side * 0.32, side * 0.68):
+            ear = NSBezierPath.bezierPathWithOvalInRect_(
+                NSMakeRect(
+                    center_x - side * 0.12,
+                    side * 0.52,
+                    side * 0.24,
+                    side * 0.34,
+                )
+            )
+            ear_color.setFill()
+            ear.fill()
+            stroke.set()
+            ear.setLineWidth_(1.2)
+            ear.stroke()
+
+        face = NSBezierPath.bezierPathWithOvalInRect_(
+            NSMakeRect(side * 0.14, side * 0.08, side * 0.72, side * 0.72)
+        )
+        face_color.setFill()
+        face.fill()
+        stroke.set()
+        face.setLineWidth_(1.4)
+        face.stroke()
+
+        eye_color = _rgba(0.25, 0.18, 0.22)
+        for center_x in (side * 0.38, side * 0.62):
+            eye = NSBezierPath.bezierPathWithOvalInRect_(
+                NSMakeRect(
+                    center_x - side * 0.045,
+                    side * 0.38,
+                    side * 0.09,
+                    side * 0.11,
+                )
+            )
+            eye_color.setFill()
+            eye.fill()
+
+        nose = NSBezierPath.bezierPathWithOvalInRect_(
+            NSMakeRect(side * 0.44, side * 0.28, side * 0.12, side * 0.09)
+        )
+        _rgba(0.92, 0.55, 0.62).setFill()
+        nose.fill()
+    finally:
+        image.unlockFocus()
+    image.setSize_(NSMakeSize(side, side))
+    return image

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -1,0 +1,102 @@
+"""Start and detect the Spotty Bunny overlay process (macOS)."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+from app.config import run_dir
+
+logger = logging.getLogger(__name__)
+
+SPOTTY_BUNNY_PID_FILE = ".spotty-bunny.pid"
+
+
+def clear_spotty_bunny_pid(*, pid_dir: Path | None = None) -> None:
+    """Remove the recorded Spotty Bunny PID file."""
+    spotty_bunny_pid_path(pid_dir=pid_dir).unlink(missing_ok=True)
+
+
+def ensure_spotty_bunny_running(
+    *,
+    pid_dir: Path | None = None,
+    spawn: Callable[[Sequence[str]], int] | None = None,
+) -> bool:
+    """Start Spotty Bunny in the background when it is not already running.
+
+    Returns ``True`` when a process was already running or was started successfully.
+    """
+    if sys.platform != "darwin":
+        return False
+    directory = pid_dir if pid_dir is not None else run_dir()
+    if spotty_bunny_is_running(pid_dir=directory):
+        logger.debug("spotty-bunny already running (pid file %s)", directory)
+        return True
+    command = spotty_bunny_command()
+    spawn_fn = spawn or _spawn_detached
+    try:
+        pid = spawn_fn(command)
+    except OSError as exc:
+        logger.warning("could not start spotty-bunny: %s", exc)
+        return False
+    if pid <= 0:
+        logger.warning("spotty-bunny spawn returned invalid pid %s", pid)
+        return False
+    write_spotty_bunny_pid(pid, pid_dir=directory)
+    logger.info("started spotty-bunny (pid %s)", pid)
+    return True
+
+
+def spotty_bunny_command() -> list[str]:
+    """Return the argv used to launch Spotty Bunny."""
+    binary = shutil.which("spotty-bunny")
+    if binary:
+        return [binary]
+    return [sys.executable, "-m", "app.spotty_bunny_cli"]
+
+
+def spotty_bunny_is_running(*, pid_dir: Path | None = None) -> bool:
+    """True when the pid file points at a live process."""
+    path = spotty_bunny_pid_path(pid_dir=pid_dir)
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+        pid = int(raw)
+    except OSError, ValueError:
+        return False
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        path.unlink(missing_ok=True)
+        return False
+    return True
+
+
+def spotty_bunny_pid_path(*, pid_dir: Path | None = None) -> Path:
+    """Path to the Spotty Bunny PID file under the runtime directory."""
+    directory = pid_dir if pid_dir is not None else run_dir()
+    return directory / SPOTTY_BUNNY_PID_FILE
+
+
+def write_spotty_bunny_pid(pid: int, *, pid_dir: Path | None = None) -> None:
+    """Record *pid* for later ``spotty_bunny_is_running`` checks."""
+    path = spotty_bunny_pid_path(pid_dir=pid_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{pid}\n", encoding="utf-8")
+
+
+def _spawn_detached(command: Sequence[str]) -> int:
+    proc = subprocess.Popen(
+        list(command),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return int(proc.pid)

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from app.config import run_dir
 logger = logging.getLogger(__name__)
 
 SPOTTY_BUNNY_PID_FILE = ".spotty-bunny.pid"
+SPOTTY_BUNNY_STARTUP_WAIT_S = 0.05
 
 
 def clear_spotty_bunny_pid(*, pid_dir: Path | None = None) -> None:
@@ -47,6 +49,10 @@ def ensure_spotty_bunny_running(
     if pid <= 0:
         logger.warning("spotty-bunny spawn returned invalid pid %s", pid)
         return False
+    time.sleep(SPOTTY_BUNNY_STARTUP_WAIT_S)
+    if not _spotty_bunny_process_alive(pid):
+        logger.warning("spotty-bunny exited immediately after spawn (pid %s)", pid)
+        return False
     write_spotty_bunny_pid(pid, pid_dir=directory)
     logger.info("started spotty-bunny (pid %s)", pid)
     return True
@@ -61,18 +67,14 @@ def spotty_bunny_command() -> list[str]:
 
 
 def spotty_bunny_is_running(*, pid_dir: Path | None = None) -> bool:
-    """True when the pid file points at a live process."""
+    """True when the pid file points at a live Spotty Bunny process."""
     path = spotty_bunny_pid_path(pid_dir=pid_dir)
     try:
         raw = path.read_text(encoding="utf-8").strip()
         pid = int(raw)
     except OSError, ValueError:
         return False
-    if pid <= 0:
-        return False
-    try:
-        os.kill(pid, 0)
-    except OSError:
+    if not _spotty_bunny_process_alive(pid):
         path.unlink(missing_ok=True)
         return False
     return True
@@ -89,6 +91,36 @@ def write_spotty_bunny_pid(pid: int, *, pid_dir: Path | None = None) -> None:
     path = spotty_bunny_pid_path(pid_dir=pid_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"{pid}\n", encoding="utf-8")
+
+
+def _is_spotty_bunny_command(command: str) -> bool:
+    return "spotty-bunny" in command or "spotty_bunny_cli" in command
+
+
+def _process_command(pid: int) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return None
+    command = completed.stdout.strip()
+    return command or None
+
+
+def _spotty_bunny_process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    command = _process_command(pid)
+    return command is not None and _is_spotty_bunny_command(command)
 
 
 def _spawn_detached(command: Sequence[str]) -> int:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import sys
 from io import StringIO
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from click.testing import CliRunner
 from django.test import Client, TestCase, override_settings
@@ -290,6 +290,38 @@ class CliUnitTests(TestCase):
         mock_resolve.assert_called_once_with(
             "gh", base_url="http://127.0.0.1:8000", strict=True
         )
+
+    @patch("app.cli.fetch_key_entries")
+    def test_repl_starts_spotty_bunny_on_macos(self, mock_fetch_entries) -> None:
+        mock_fetch_entries.return_value = [KeyEntry(key="gh")]
+        captured = StringIO()
+        mock_session = MagicMock()
+        mock_session.prompt.side_effect = EOFError()
+        with (
+            patch("app.cli.sys.platform", "darwin"),
+            patch(
+                "app.spotty_bunny_launch.ensure_spotty_bunny_running",
+                return_value=True,
+            ) as ensure,
+            patch("sys.stdout", captured),
+            patch("app.cli.ensure_github_authenticated", return_value=None),
+            patch(
+                "app.cli.create_repl_session",
+                return_value=(mock_session, MagicMock()),
+            ),
+        ):
+            _run(
+                shortcut_args=(),
+                base_url="http://127.0.0.1:8000",
+                list_keys=False,
+                use_fzf=False,
+                fzf_query="",
+                print_url=False,
+                open_browser=False,
+                input_fn=None,
+            )
+        ensure.assert_called_once()
+        self.assertIn("Spotty Bunny overlay ready", captured.getvalue())
 
     @patch("app.cli.fetch_key_entries")
     def test_repl_banner_includes_version(self, mock_fetch_entries) -> None:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -828,7 +828,13 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         with TemporaryDirectory() as tmp:
             pid_dir = Path(tmp)
             (pid_dir / SPOTTY_BUNNY_PID_FILE).write_text(f"{os.getpid()}\n")
-            with patch("app.spotty_bunny_launch.sys.platform", "darwin"):
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+            ):
                 self.assertTrue(
                     ensure_spotty_bunny_running(
                         pid_dir=pid_dir,
@@ -844,7 +850,13 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
 
         with TemporaryDirectory() as tmp:
             pid_dir = Path(tmp)
-            with patch("app.spotty_bunny_launch.sys.platform", "darwin"):
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+            ):
                 self.assertTrue(
                     ensure_spotty_bunny_running(
                         pid_dir=pid_dir,
@@ -855,6 +867,62 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 (pid_dir / SPOTTY_BUNNY_PID_FILE).read_text(encoding="utf-8"),
                 "4242\n",
             )
+
+    def test_ensure_spotty_bunny_running_fails_when_child_exits(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=False,
+                ),
+            ):
+                self.assertFalse(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        spawn=lambda _cmd: 4242,
+                    )
+                )
+            self.assertFalse((pid_dir / SPOTTY_BUNNY_PID_FILE).exists())
+
+    def test_spotty_bunny_is_running_clears_stale_pid(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+            spotty_bunny_is_running,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            pid_path = pid_dir / SPOTTY_BUNNY_PID_FILE
+            pid_path.write_text("999999999\n", encoding="utf-8")
+            self.assertFalse(spotty_bunny_is_running(pid_dir=pid_dir))
+            self.assertFalse(pid_path.exists())
+
+            spawned: list[object] = []
+
+            def spawn(_cmd: object) -> int:
+                spawned.append(_cmd)
+                return 4242
+
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(pid_dir=pid_dir, spawn=spawn)
+                )
+            self.assertEqual(len(spawned), 1)
+            self.assertEqual(pid_path.read_text(encoding="utf-8"), "4242\n")
 
     def test_placeholder_documents_examples(self) -> None:
         source = (

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -70,7 +70,7 @@ class SpottyBunnyCliTests(SimpleTestCase):
         self.assertTrue(self.log_file.is_file())
         self.assertIn(str(self.log_file), stderr.getvalue())
 
-    def test_default_log_level_is_warning(self) -> None:
+    def test_default_log_level_is_info(self) -> None:
         stderr = StringIO()
         with (
             patch("app.spotty_bunny_cli.sys.platform", "linux"),
@@ -79,11 +79,11 @@ class SpottyBunnyCliTests(SimpleTestCase):
             self.assertEqual(main([]), 1)
         self.assertEqual(
             logging.getLogger("app.spotty_bunny_app").level,
-            logging.WARNING,
+            logging.INFO,
         )
         self.assertEqual(
             logging.getLogger("app.spotty_bunny_cli").level,
-            logging.WARNING,
+            logging.INFO,
         )
 
     def test_env_log_file(self) -> None:
@@ -264,6 +264,22 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         )
         self.assertFalse(
             completion_still_current(expected_seq=2, field="gh", prefix="gh", seq=3)
+        )
+
+    def test_completion_row_after_selector_supports_page_keys(self) -> None:
+        from app.spotty_bunny_complete import completion_row_after_selector
+
+        self.assertEqual(
+            completion_row_after_selector(7, row_count=20, selector="pageUp:"),
+            2,
+        )
+        self.assertEqual(
+            completion_row_after_selector(7, row_count=20, selector="pageDown:"),
+            12,
+        )
+        self.assertEqual(
+            completion_row_after_selector(0, row_count=3, selector="moveDown:"),
+            1,
         )
 
     def test_first_token_fuzzy_matches_description(self) -> None:
@@ -800,6 +816,51 @@ class SpottyBunnyQuitTests(SimpleTestCase):
             "otherEventWithType_location_modifierFlags_timestamp_windowNumber"
             "_context_subtype_data1_data2_",
         )
+
+
+class SpottyBunnyLaunchTests(SimpleTestCase):
+    def test_ensure_spotty_bunny_running_skips_when_already_running(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            (pid_dir / SPOTTY_BUNNY_PID_FILE).write_text(f"{os.getpid()}\n")
+            with patch("app.spotty_bunny_launch.sys.platform", "darwin"):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        spawn=lambda _cmd: self.fail("should not spawn"),
+                    )
+                )
+
+    def test_ensure_spotty_bunny_running_spawns_on_darwin(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            with patch("app.spotty_bunny_launch.sys.platform", "darwin"):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        spawn=lambda _cmd: 4242,
+                    )
+                )
+            self.assertEqual(
+                (pid_dir / SPOTTY_BUNNY_PID_FILE).read_text(encoding="utf-8"),
+                "4242\n",
+            )
+
+    def test_placeholder_documents_examples(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("gh, c, search hello", source)
 
 
 class SpottyBunnyResolveTests(SimpleTestCase):

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -94,7 +94,7 @@ spotty-bunny
 # development checkout (wrapper syncs extra macos)
 ./scripts/spotty-bunny
 ./scripts/spotty-bunny --verbose          # DEBUG: every tap event, chord, show/hide
-./scripts/spotty-bunny --log-level INFO   # chord complete, show/hide, SIGINT
+./scripts/spotty-bunny --log-level INFO   # default; chord complete, show/hide, SIGINT
 # same values as bunnify-server:
 ./scripts/spotty-bunny --log-level DEBUG
 # rotating file (10 MiB × 5), same verbose format as bunnify-server:
@@ -109,7 +109,11 @@ the CLI (`FirstTokenFuzzyCompleter` / `ShortcutCompleter`) and lists matches
 under the field. Enter resolves via `/api/resolve/?strict=1` and opens the URL
 in the default browser (unknown keys stay in the panel with an error). Ctrl-C
 in that terminal quits. Startup prints the log file path on stderr
-(`spotty-bunny: logging to …`).
+(`spotty-bunny: logging to …`). Default log level is **INFO** (use `--verbose`
+for per-key tap debug).
+
+The search box is centered on the **main display** (menu-bar monitor), with a
+small bunny icon beside the field.
 
 If the chord does nothing, run with `--verbose` and watch stderr. Lines
 named `tap …` show whether key events arrive. If none appear while you press
@@ -119,6 +123,9 @@ Settings → Privacy & Security, then re-run. If events arrive but `fired=True`
 never appears, HID may still miss right Control (`hid R=False`); Spotty Bunny
 also uses device flag bits and the event keycode. Re-run `--verbose` after
 this fix.
+
+On macOS, starting the **`bunnify` interactive REPL** (no query args) also
+starts `spotty-bunny` in the background when it is not already running.
 
 ## macOS LaunchAgent
 


### PR DESCRIPTION
## Summary
- Center Spotty Bunny on the main display (menu-bar monitor) when multiple screens are connected
- Add a bunny logo beside the search field and a clearer placeholder with examples
- Fix Tab-completion list scrolling with arrow keys and PgUp/PgDown
- Default `spotty-bunny` logging to INFO (less noisy than DEBUG tap spam)
- Auto-start `spotty-bunny` from the interactive `bunnify` REPL on macOS when not already running

## Test plan
- [ ] Connect a second monitor; open Spotty Bunny — panel should center on the main display
- [ ] Verify bunny logo appears left of the search field
- [ ] Press Tab on empty field; scroll long shortcut list with ↑/↓ and PgUp/PgDown
- [ ] Run `./scripts/spotty-bunny` without flags — INFO-level logs only (no per-tap DEBUG)
- [ ] Run interactive `bunnify` — spotty-bunny starts in background with ready message
- [x] `./test_bunnify` and pre-pr-checks pass locally