### PR TITLE
fix: Spotty Bunny primary display, logo, and about panel

### DIFF
--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -114,9 +114,11 @@ def build_about_panel() -> NSPanel:
 
 
 def position_about_panel(panel: NSPanel, *, anchor_frame) -> None:
-    """Place *panel* just below the logo area on the anchor window."""
+    """Place *panel* just below the logo (right side of the search window)."""
     frame = panel.frame()
-    frame.origin.x = anchor_frame.origin.x + 8.0
+    frame.origin.x = (
+        anchor_frame.origin.x + anchor_frame.size.width - frame.size.width - 8.0
+    )
     frame.origin.y = anchor_frame.origin.y - frame.size.height - 8.0
     panel.setFrame_display_(frame, True)
 

--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -1,0 +1,134 @@
+"""Spotty Bunny about panel (AppKit; imported only on macOS)."""
+
+from __future__ import annotations
+
+# pyright: reportMissingImports=false
+from Cocoa import (
+    NSBackingStoreBuffered,
+    NSColor,
+    NSFloatingWindowLevel,
+    NSFont,
+    NSMakeRect,
+    NSPanel,
+    NSTextField,
+    NSWindowCollectionBehaviorCanJoinAllSpaces,
+    NSWindowStyleMaskBorderless,
+    NSWindowStyleMaskNonactivatingPanel,
+)
+from Foundation import NSMakeRange, NSMutableAttributedString
+
+from app.version import get_build_info
+
+ABOUT_COPYRIGHT = "Copyright © 2026 thehcma"
+ABOUT_LICENSE = "MIT License"
+ABOUT_PANEL_HEIGHT = 188.0
+ABOUT_PANEL_WIDTH = 320.0
+ABOUT_TAGLINE = "Quick shortcut overlay for Bunnify"
+SPOTTY_BUNNY_REPO_URL = "https://github.com/the-hcma/bunnify"
+
+
+def build_about_panel() -> NSPanel:
+    """Return a small floating panel with version and project links."""
+    panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
+        NSMakeRect(0.0, 0.0, ABOUT_PANEL_WIDTH, ABOUT_PANEL_HEIGHT),
+        NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel,
+        NSBackingStoreBuffered,
+        False,
+    )
+    panel.setLevel_(NSFloatingWindowLevel + 1)
+    panel.setCollectionBehavior_(NSWindowCollectionBehaviorCanJoinAllSpaces)
+    panel.setFloatingPanel_(True)
+    panel.setHidesOnDeactivate_(False)
+    panel.setBecomesKeyOnlyIfNeeded_(True)
+    panel.setReleasedWhenClosed_(False)
+    panel.setBackgroundColor_(NSColor.windowBackgroundColor())
+
+    package_version, commit = get_build_info()
+    y = ABOUT_PANEL_HEIGHT - 24.0
+
+    title = _label(
+        NSMakeRect(16.0, y - 22.0, ABOUT_PANEL_WIDTH - 32.0, 22.0),
+        "Spotty Bunny",
+        font=NSFont.boldSystemFontOfSize_(16.0),
+    )
+    panel.contentView().addSubview_(title)
+    y -= 30.0
+
+    tagline = _label(
+        NSMakeRect(16.0, y - 18.0, ABOUT_PANEL_WIDTH - 32.0, 18.0),
+        ABOUT_TAGLINE,
+        color=NSColor.secondaryLabelColor(),
+    )
+    panel.contentView().addSubview_(tagline)
+    y -= 24.0
+
+    version_line = _label(
+        NSMakeRect(16.0, y - 18.0, ABOUT_PANEL_WIDTH - 32.0, 18.0),
+        f"Version {package_version} · commit {commit}",
+        color=NSColor.secondaryLabelColor(),
+    )
+    panel.contentView().addSubview_(version_line)
+    y -= 24.0
+
+    copyright_line = _label(
+        NSMakeRect(16.0, y - 18.0, ABOUT_PANEL_WIDTH - 32.0, 18.0),
+        ABOUT_COPYRIGHT,
+    )
+    panel.contentView().addSubview_(copyright_line)
+    y -= 20.0
+
+    license_line = _label(
+        NSMakeRect(16.0, y - 18.0, ABOUT_PANEL_WIDTH - 32.0, 18.0),
+        ABOUT_LICENSE,
+        color=NSColor.secondaryLabelColor(),
+    )
+    panel.contentView().addSubview_(license_line)
+    y -= 28.0
+
+    link = NSTextField.alloc().initWithFrame_(
+        NSMakeRect(16.0, y - 18.0, ABOUT_PANEL_WIDTH - 32.0, 18.0)
+    )
+    link.setEditable_(False)
+    link.setSelectable_(True)
+    link.setBezeled_(False)
+    link.setDrawsBackground_(False)
+    link.setAllowsEditingTextAttributes_(True)
+    link.setFont_(NSFont.systemFontOfSize_(13.0))
+    repo_text = "github.com/the-hcma/bunnify"
+    attributed = NSMutableAttributedString.alloc().initWithString_(repo_text)
+    from AppKit import NSLinkAttributeName
+
+    attributed.addAttribute_value_range_(
+        NSLinkAttributeName,
+        SPOTTY_BUNNY_REPO_URL,
+        NSMakeRange(0, len(repo_text)),
+    )
+    attributed.addAttribute_value_range_(
+        "NSColor",
+        NSColor.linkColor(),
+        NSMakeRange(0, len(repo_text)),
+    )
+    link.setAttributedStringValue_(attributed)
+    panel.contentView().addSubview_(link)
+    return panel
+
+
+def position_about_panel(panel: NSPanel, *, anchor_frame) -> None:
+    """Place *panel* just below the logo area on the anchor window."""
+    frame = panel.frame()
+    frame.origin.x = anchor_frame.origin.x + 8.0
+    frame.origin.y = anchor_frame.origin.y - frame.size.height - 8.0
+    panel.setFrame_display_(frame, True)
+
+
+def _label(frame, text: str, *, font=None, color=None) -> NSTextField:
+    field = NSTextField.alloc().initWithFrame_(frame)
+    field.setEditable_(False)
+    field.setSelectable_(False)
+    field.setBezeled_(False)
+    field.setDrawsBackground_(False)
+    field.setStringValue_(text)
+    field.setFont_(font or NSFont.systemFontOfSize_(13.0))
+    if color is not None:
+        field.setTextColor_(color)
+    return field

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -101,6 +101,7 @@ from app.spotty_bunny_quit import (
     quit_ns_app,
 )
 from app.spotty_bunny_resolve import lookup_resolved_url, resolve_still_current
+from app.version import get_build_info
 
 FIELD_PLACEHOLDER = "Type a shortcut (e.g., gh, c, yt, docs)"
 LOGO_LEFT = 16.0
@@ -199,6 +200,7 @@ class SpottyBunnyController(NSObject):
         self.tap = None
         self.visible = False
         self._build_panel()
+        self._io.submit(get_build_info, lambda _result: None)
         return self
 
     def numberOfRowsInTableView_(self, _table) -> int:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -13,13 +13,14 @@ from Cocoa import (
     NSApplication,
     NSApplicationActivationPolicyAccessory,
     NSBackingStoreBuffered,
+    NSBezelStyleShadowlessSquare,
+    NSButton,
     NSColor,
     NSEvent,
     NSEventTypeApplicationDefined,
     NSFloatingWindowLevel,
     NSFont,
     NSImageScaleProportionallyUpOrDown,
-    NSImageView,
     NSMakeRect,
     NSObject,
     NSPanel,
@@ -30,9 +31,8 @@ from Cocoa import (
     NSTextField,
     NSWindowCollectionBehaviorCanJoinAllSpaces,
     NSWindowCollectionBehaviorFullScreenAuxiliary,
-    NSWindowStyleMaskFullSizeContentView,
+    NSWindowStyleMaskBorderless,
     NSWindowStyleMaskNonactivatingPanel,
-    NSWindowStyleMaskTitled,
 )
 from Foundation import NSIndexSet, NSOperationQueue, NSThread
 from PyObjCTools import MachSignals
@@ -68,6 +68,7 @@ from Quartz import (
 from app.cli import open_url
 from app.client import fetch_key_entries, fetch_suggestions
 from app.config import resolve_base_url
+from app.spotty_bunny_about import build_about_panel, position_about_panel
 from app.spotty_bunny_cli import SpottyBunnyEventTapError
 from app.spotty_bunny_complete import (
     CompletionRow,
@@ -101,10 +102,10 @@ from app.spotty_bunny_quit import (
 )
 from app.spotty_bunny_resolve import lookup_resolved_url, resolve_still_current
 
-FIELD_PLACEHOLDER = "Type a shortcut (e.g., gh, c, search hello)"
+FIELD_PLACEHOLDER = "Type a shortcut (e.g., gh, c, yt, docs)"
 LOGO_LEFT = 16.0
 LOGO_SIZE = 40.0
-LOGO_TOP = 24.0
+LOGO_TOP = 16.0
 PANEL_HEIGHT = 80.0
 PANEL_WIDTH = 640.0
 TABLE_HEIGHT = 140.0
@@ -160,6 +161,7 @@ class SpottyBunnyController(NSObject):
         logger.info("hide panel (was visible=%s)", self.visible)
         self._resolve_seq += 1
         self._resolving = False
+        self._hide_about_panel()
         self._hide_completions()
         self._set_status("")
         panel = getattr(self, "panel", None)
@@ -172,6 +174,7 @@ class SpottyBunnyController(NSObject):
         self = objc.super(SpottyBunnyController, self).init()
         if self is None:
             return None
+        self._about_panel = None
         self._applying_completion = False
         self._became_key = False
         self._base_url = ""
@@ -201,8 +204,12 @@ class SpottyBunnyController(NSObject):
     def numberOfRowsInTableView_(self, _table) -> int:
         return len(self._completion_rows)
 
+    def showAbout_(self, _sender) -> None:
+        self._toggle_about_panel()
+
     def show(self) -> None:
         self._history = HistoryNavigator(load_history_lines())
+        self._hide_about_panel()
         self._hide_completions()
         self._set_status("")
         self._shortcuts_load_failed = False
@@ -251,19 +258,14 @@ class SpottyBunnyController(NSObject):
             self.hide()
 
     def _build_panel(self) -> None:
-        style = (
-            NSWindowStyleMaskTitled
-            | NSWindowStyleMaskFullSizeContentView
-            | NSWindowStyleMaskNonactivatingPanel
-        )
+        style = NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
         panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
             NSMakeRect(0.0, 0.0, PANEL_WIDTH, PANEL_HEIGHT),
             style,
             NSBackingStoreBuffered,
             False,
         )
-        panel.setTitle_("spotty-bunny")
-        panel.setTitlebarAppearsTransparent_(True)
+        panel.setBackgroundColor_(NSColor.windowBackgroundColor())
         panel.setLevel_(NSFloatingWindowLevel)
         panel.setCollectionBehavior_(
             NSWindowCollectionBehaviorCanJoinAllSpaces
@@ -275,11 +277,15 @@ class SpottyBunnyController(NSObject):
         panel.setReleasedWhenClosed_(False)
         panel.setDelegate_(self)
 
-        logo = NSImageView.alloc().initWithFrame_(
+        logo = NSButton.alloc().initWithFrame_(
             NSMakeRect(LOGO_LEFT, LOGO_TOP, LOGO_SIZE, LOGO_SIZE)
         )
+        logo.setBezelStyle_(NSBezelStyleShadowlessSquare)
+        logo.setBordered_(False)
         logo.setImage_(make_spotty_bunny_icon(LOGO_SIZE))
         logo.setImageScaling_(NSImageScaleProportionallyUpOrDown)
+        logo.setTarget_(self)
+        logo.setAction_("showAbout:")
         panel.contentView().addSubview_(logo)
 
         field = NSTextField.alloc().initWithFrame_(
@@ -340,9 +346,15 @@ class SpottyBunnyController(NSObject):
             return
         visible = screen.visibleFrame()
         frame = self.panel.frame()
-        origin_x = visible.origin.x + (visible.size.width - frame.size.width) / 2.0
-        origin_y = visible.origin.y + (visible.size.height - frame.size.height) * 0.55
-        self.panel.setFrameOrigin_((origin_x, origin_y))
+        frame.origin.x = (
+            visible.origin.x + (visible.size.width - frame.size.width) / 2.0
+        )
+        frame.origin.y = (
+            visible.origin.y + (visible.size.height - frame.size.height) * 0.55
+        )
+        self.panel.setFrame_display_(frame, True)
+        if self._about_panel is not None and self._about_panel.isVisible():
+            position_about_panel(self._about_panel, anchor_frame=frame)
 
     def _completer_loaded(self, result: object) -> None:
         def apply() -> None:
@@ -377,6 +389,20 @@ class SpottyBunnyController(NSObject):
             self._show_completions(result)  # type: ignore[arg-type]
 
         _run_on_main(apply)
+
+    def _hide_about_panel(self) -> None:
+        if self._about_panel is not None:
+            self._about_panel.orderOut_(None)
+
+    def _toggle_about_panel(self) -> None:
+        if self._about_panel is None:
+            self._about_panel = build_about_panel()
+        if self._about_panel.isVisible():
+            self._about_panel.orderOut_(None)
+            return
+        if self.panel is not None:
+            position_about_panel(self._about_panel, anchor_frame=self.panel.frame())
+        self._about_panel.orderFrontRegardless()
 
     def _hide_completions(self) -> None:
         self._completion_seq += 1
@@ -524,10 +550,7 @@ class SpottyBunnyController(NSObject):
 
 
 def _primary_screen():
-    """Return the menu-bar (main) display, not a secondary monitor."""
-    main = NSScreen.mainScreen()
-    if main is not None:
-        return main
+    """Return the menu-bar display (screens[0]), not the keyboard-focus screen."""
     screens = NSScreen.screens()
     return screens[0] if screens else None
 

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -250,11 +250,21 @@ class SpottyBunnyController(NSObject):
         logger.debug("windowDidBecomeKey")
         self._became_key = True
 
-    def windowDidResignKey_(self, _notification) -> None:
+    def windowDidResignKey_(self, notification) -> None:
         # Accessory + Terminal: resign fires before the panel ever becomes key.
         # Only dismiss after a successful key cycle (click-away / app switch).
         logger.debug("windowDidResignKey became_key=%s", self._became_key)
+        resigning = notification.object()
+        if resigning is self._about_panel:
+            key = NSApp.keyWindow()
+            if key is self.panel:
+                self._hide_about_panel()
+            else:
+                self.hide()
+            return
         if self._became_key:
+            if self._about_panel is not None and self._about_panel.isVisible():
+                return
             self.hide()
 
     def _build_panel(self) -> None:
@@ -397,6 +407,7 @@ class SpottyBunnyController(NSObject):
     def _toggle_about_panel(self) -> None:
         if self._about_panel is None:
             self._about_panel = build_about_panel()
+            self._about_panel.setDelegate_(self)
         if self._about_panel.isVisible():
             self._about_panel.orderOut_(None)
             return

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -176,6 +176,7 @@ class SpottyBunnyController(NSObject):
         if self is None:
             return None
         self._about_panel = None
+        self._about_open = False
         self._applying_completion = False
         self._became_key = False
         self._base_url = ""
@@ -260,9 +261,8 @@ class SpottyBunnyController(NSObject):
         if resigning is self._about_panel:
             key = NSApp.keyWindow()
             if key is self.panel:
-                self._hide_about_panel()
-            else:
-                self.hide()
+                return
+            self.hide()
             return
         if self._became_key:
             if (
@@ -409,17 +409,19 @@ class SpottyBunnyController(NSObject):
     def _hide_about_panel(self) -> None:
         if self._about_panel is not None:
             self._about_panel.orderOut_(None)
+        self._about_open = False
 
     def _toggle_about_panel(self) -> None:
         if self._about_panel is None:
             self._about_panel = build_about_panel()
             self._about_panel.setDelegate_(self)
-        if self._about_panel.isVisible():
-            self._about_panel.orderOut_(None)
+        if self._about_open:
+            self._hide_about_panel()
             return
         if self.panel is not None:
             position_about_panel(self._about_panel, anchor_frame=self.panel.frame())
         self._about_panel.orderFrontRegardless()
+        self._about_open = True
 
     def _hide_completions(self) -> None:
         self._completion_seq += 1

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -263,7 +263,11 @@ class SpottyBunnyController(NSObject):
                 self.hide()
             return
         if self._became_key:
-            if self._about_panel is not None and self._about_panel.isVisible():
+            if (
+                self._about_panel is not None
+                and self._about_panel.isVisible()
+                and NSApp.keyWindow() is self._about_panel
+            ):
                 return
             self.hide()
 

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -28,7 +28,9 @@ from Cocoa import (
     NSScrollView,
     NSTableColumn,
     NSTableView,
+    NSTextAlignmentCenter,
     NSTextField,
+    NSTextFieldCell,
     NSWindowCollectionBehaviorCanJoinAllSpaces,
     NSWindowCollectionBehaviorFullScreenAuxiliary,
     NSWindowStyleMaskBorderless,
@@ -103,15 +105,16 @@ from app.spotty_bunny_quit import (
 from app.spotty_bunny_resolve import lookup_resolved_url, resolve_still_current
 from app.version import get_build_info
 
+FIELD_HEIGHT = 40.0
+FIELD_LEFT = 16.0
 FIELD_PLACEHOLDER = "Type a shortcut (e.g., gh, c, yt, docs)"
-LOGO_LEFT = 16.0
+LOGO_GAP = 12.0
 LOGO_SIZE = 40.0
-LOGO_TOP = 16.0
 PANEL_HEIGHT = 80.0
 PANEL_WIDTH = 640.0
 TABLE_HEIGHT = 140.0
-FIELD_LEFT = LOGO_LEFT + LOGO_SIZE + 12.0
-FIELD_WIDTH = PANEL_WIDTH - FIELD_LEFT - 16.0
+LOGO_LEFT = PANEL_WIDTH - FIELD_LEFT - LOGO_SIZE
+FIELD_WIDTH = LOGO_LEFT - FIELD_LEFT - LOGO_GAP
 
 logger = logging.getLogger(__name__)
 
@@ -294,7 +297,7 @@ class SpottyBunnyController(NSObject):
         panel.setDelegate_(self)
 
         logo = NSButton.alloc().initWithFrame_(
-            NSMakeRect(LOGO_LEFT, LOGO_TOP, LOGO_SIZE, LOGO_SIZE)
+            NSMakeRect(LOGO_LEFT, 16.0, LOGO_SIZE, LOGO_SIZE)
         )
         logo.setBezelStyle_(NSBezelStyleShadowlessSquare)
         logo.setBordered_(False)
@@ -305,11 +308,13 @@ class SpottyBunnyController(NSObject):
         panel.contentView().addSubview_(logo)
 
         field = NSTextField.alloc().initWithFrame_(
-            NSMakeRect(FIELD_LEFT, 16.0, FIELD_WIDTH, 40.0)
+            NSMakeRect(FIELD_LEFT, 16.0, FIELD_WIDTH, FIELD_HEIGHT)
         )
+        field.setCell_(_CenteredFieldCell.alloc().initTextCell_(""))
         field.setEditable_(True)
         field.setSelectable_(True)
         field.setBezeled_(True)
+        field.setAlignment_(NSTextAlignmentCenter)
         field.setFont_(NSFont.systemFontOfSize_(20.0))
         field.setPlaceholderString_(FIELD_PLACEHOLDER)
         field.setBackgroundColor_(NSColor.textBackgroundColor())
@@ -431,6 +436,15 @@ class SpottyBunnyController(NSObject):
             self.table.reloadData()
         self._set_table_visible(False)
 
+    def _layout_search_chrome(self, *, table_visible: bool) -> None:
+        origin_y = 16.0 + (TABLE_HEIGHT if table_visible else 0.0)
+        if self.field is not None:
+            self.field.setFrame_(
+                NSMakeRect(FIELD_LEFT, origin_y, FIELD_WIDTH, FIELD_HEIGHT)
+            )
+        if self.logo is not None:
+            self.logo.setFrame_(NSMakeRect(LOGO_LEFT, origin_y, LOGO_SIZE, LOGO_SIZE))
+
     def _load_completer(self) -> object:
         base_url = resolve_base_url(persist=False, allow_prompt=False)
         entries = fetch_key_entries(base_url=base_url)
@@ -514,15 +528,11 @@ class SpottyBunnyController(NSObject):
         frame = self.panel.frame()
         frame.size.height = PANEL_HEIGHT + (TABLE_HEIGHT if visible else 0.0)
         self.panel.setFrame_display_(frame, True)
+        self._layout_search_chrome(table_visible=visible)
         if visible:
-            self.field.setFrame_(
-                NSMakeRect(FIELD_LEFT, 16.0 + TABLE_HEIGHT, FIELD_WIDTH, 40.0)
-            )
             self.scroll.setFrame_(
                 NSMakeRect(16.0, 16.0, PANEL_WIDTH - 32.0, TABLE_HEIGHT - 8.0)
             )
-        else:
-            self.field.setFrame_(NSMakeRect(FIELD_LEFT, 16.0, FIELD_WIDTH, 40.0))
         self._center_panel()
 
     def _show_completions(self, rows: list[CompletionRow]) -> None:
@@ -593,6 +603,23 @@ def run_spotty_bunny_app() -> int:
     NSApp.run()
     logger.info("event loop exited")
     return 0
+
+
+class _CenteredFieldCell(NSTextFieldCell):
+    """Center placeholder and typed text horizontally and vertically."""
+
+    def drawingRectForBounds_(self, rect):
+        drawn = objc.super(_CenteredFieldCell, self).drawingRectForBounds_(rect)
+        font = self.font()
+        if font is None:
+            return drawn
+        text_height = float(font.boundingRectForFont().size.height)
+        if drawn.size.height <= text_height:
+            return drawn
+        inset = (drawn.size.height - text_height) / 2.0
+        drawn.origin.y += inset
+        drawn.size.height = text_height
+        return drawn
 
 
 def _control_key_down(keycode: int) -> bool:

--- a/app/spotty_bunny_icon.py
+++ b/app/spotty_bunny_icon.py
@@ -16,8 +16,16 @@ def _rgba(red: float, green: float, blue: float, alpha: float = 1.0) -> NSColor:
     return NSColor.colorWithCalibratedRed_green_blue_alpha_(red, green, blue, alpha)
 
 
+def _spot(center_x: float, center_y: float, radius: float, color: NSColor) -> None:
+    spot = NSBezierPath.bezierPathWithOvalInRect_(
+        NSMakeRect(center_x - radius, center_y - radius, radius * 2.0, radius * 2.0)
+    )
+    color.setFill()
+    spot.fill()
+
+
 def make_spotty_bunny_icon(size: float) -> NSImage:
-    """Return a simple bunny face icon at *size*×*size* points."""
+    """Return a spotty bunny face icon at *size*×*size* points."""
     side = float(size)
     image = NSImage.alloc().initWithSize_(NSMakeSize(side, side))
     image.lockFocus()
@@ -25,52 +33,80 @@ def make_spotty_bunny_icon(size: float) -> NSImage:
         NSColor.clearColor().set()
         NSBezierPath.fillRect_(NSMakeRect(0.0, 0.0, side, side))
 
-        ear_color = _rgba(0.95, 0.72, 0.78)
-        face_color = _rgba(1.0, 0.92, 0.94)
-        stroke = _rgba(0.45, 0.28, 0.36)
+        fur = _rgba(0.98, 0.94, 0.96)
+        ear_outer = _rgba(0.94, 0.78, 0.84)
+        ear_inner = _rgba(1.0, 0.82, 0.88)
+        stroke = _rgba(0.42, 0.24, 0.34)
+        spot_color = _rgba(0.82, 0.48, 0.58)
 
-        for center_x in (side * 0.32, side * 0.68):
-            ear = NSBezierPath.bezierPathWithOvalInRect_(
+        for center_x in (side * 0.34, side * 0.66):
+            outer = NSBezierPath.bezierPathWithOvalInRect_(
                 NSMakeRect(
-                    center_x - side * 0.12,
-                    side * 0.52,
-                    side * 0.24,
-                    side * 0.34,
+                    center_x - side * 0.09,
+                    side * 0.46,
+                    side * 0.18,
+                    side * 0.44,
                 )
             )
-            ear_color.setFill()
-            ear.fill()
+            ear_outer.setFill()
+            outer.fill()
             stroke.set()
-            ear.setLineWidth_(1.2)
-            ear.stroke()
+            outer.setLineWidth_(1.1)
+            outer.stroke()
+
+            inner = NSBezierPath.bezierPathWithOvalInRect_(
+                NSMakeRect(
+                    center_x - side * 0.05,
+                    side * 0.50,
+                    side * 0.10,
+                    side * 0.28,
+                )
+            )
+            ear_inner.setFill()
+            inner.fill()
 
         face = NSBezierPath.bezierPathWithOvalInRect_(
-            NSMakeRect(side * 0.14, side * 0.08, side * 0.72, side * 0.72)
+            NSMakeRect(side * 0.18, side * 0.10, side * 0.64, side * 0.58)
         )
-        face_color.setFill()
+        fur.setFill()
         face.fill()
         stroke.set()
-        face.setLineWidth_(1.4)
+        face.setLineWidth_(1.3)
         face.stroke()
 
-        eye_color = _rgba(0.25, 0.18, 0.22)
-        for center_x in (side * 0.38, side * 0.62):
+        _spot(side * 0.28, side * 0.52, side * 0.035, spot_color)
+        _spot(side * 0.72, side * 0.48, side * 0.03, spot_color)
+        _spot(side * 0.58, side * 0.22, side * 0.025, spot_color)
+
+        eye_color = _rgba(0.18, 0.12, 0.16)
+        for center_x in (side * 0.40, side * 0.60):
             eye = NSBezierPath.bezierPathWithOvalInRect_(
                 NSMakeRect(
-                    center_x - side * 0.045,
-                    side * 0.38,
-                    side * 0.09,
-                    side * 0.11,
+                    center_x - side * 0.04,
+                    side * 0.34,
+                    side * 0.08,
+                    side * 0.10,
                 )
             )
             eye_color.setFill()
             eye.fill()
 
         nose = NSBezierPath.bezierPathWithOvalInRect_(
-            NSMakeRect(side * 0.44, side * 0.28, side * 0.12, side * 0.09)
+            NSMakeRect(side * 0.46, side * 0.24, side * 0.08, side * 0.06)
         )
-        _rgba(0.92, 0.55, 0.62).setFill()
+        _rgba(0.94, 0.55, 0.64).setFill()
         nose.fill()
+
+        tooth_color = _rgba(0.99, 0.98, 0.97)
+        for left in (side * 0.47, side * 0.53):
+            tooth = NSBezierPath.bezierPathWithRect_(
+                NSMakeRect(left, side * 0.14, side * 0.045, side * 0.07)
+            )
+            tooth_color.setFill()
+            tooth.fill()
+            stroke.set()
+            tooth.setLineWidth_(0.8)
+            tooth.stroke()
     finally:
         image.unlockFocus()
     image.setSize_(NSMakeSize(side, side))

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -965,6 +965,7 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("resigning is self._about_panel", source)
         self.assertIn("NSApp.keyWindow() is self._about_panel", source)
         self.assertIn("self._about_panel.setDelegate_(self)", source)
+        self.assertIn("self._about_open", source)
 
 
 class SpottyBunnyResolveTests(SimpleTestCase):

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -952,6 +952,12 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertNotIn('setTitle_("spotty-bunny")', source)
         self.assertIn("showAbout:", source)
 
+    def test_about_panel_build_info_prewarmed(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("self._io.submit(get_build_info", source)
+
     def test_about_panel_resign_does_not_dismiss_main_while_visible(self) -> None:
         source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -957,7 +957,7 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
         ).read_text(encoding="utf-8")
         self.assertIn("resigning is self._about_panel", source)
-        self.assertIn("self._about_panel.isVisible()", source)
+        self.assertIn("NSApp.keyWindow() is self._about_panel", source)
         self.assertIn("self._about_panel.setDelegate_(self)", source)
 
 

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -945,6 +945,14 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("Quick shortcut overlay for Bunnify", source)
         self.assertIn("https://github.com/the-hcma/bunnify", source)
 
+    def test_search_field_is_centered_with_logo_on_right(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("NSTextAlignmentCenter", source)
+        self.assertIn("_CenteredFieldCell", source)
+        self.assertIn("LOGO_LEFT = PANEL_WIDTH - FIELD_LEFT - LOGO_SIZE", source)
+
     def test_search_panel_has_no_title_bar_label(self) -> None:
         source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -928,7 +928,29 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
         ).read_text(encoding="utf-8")
-        self.assertIn("gh, c, search hello", source)
+        self.assertIn("gh, c, yt, docs", source)
+
+    def test_primary_screen_uses_menu_bar_display(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("screens[0]", source)
+        self.assertNotIn("mainScreen()", source)
+
+    def test_about_panel_constants(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_about.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Copyright © 2026 thehcma", source)
+        self.assertIn("Quick shortcut overlay for Bunnify", source)
+        self.assertIn("https://github.com/the-hcma/bunnify", source)
+
+    def test_search_panel_has_no_title_bar_label(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn('setTitle_("spotty-bunny")', source)
+        self.assertIn("showAbout:", source)
 
 
 class SpottyBunnyResolveTests(SimpleTestCase):

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -952,6 +952,14 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertNotIn('setTitle_("spotty-bunny")', source)
         self.assertIn("showAbout:", source)
 
+    def test_about_panel_resign_does_not_dismiss_main_while_visible(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("resigning is self._about_panel", source)
+        self.assertIn("self._about_panel.isVisible()", source)
+        self.assertIn("self._about_panel.setDelegate_(self)", source)
+
 
 class SpottyBunnyResolveTests(SimpleTestCase):
     def test_failure_does_not_append_history(self) -> None:

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -113,7 +113,8 @@ in that terminal quits. Startup prints the log file path on stderr
 for per-key tap debug).
 
 The search box is centered on the **main display** (menu-bar monitor), with a
-small bunny icon beside the field.
+small bunny icon beside the field. Click the icon for version, commit, and
+project links (domesti-bot-style about panel).
 
 If the chord does nothing, run with `--verbose` and watch stderr. Lines
 named `tap …` show whether key events arrive. If none appear while you press

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -113,7 +113,7 @@ in that terminal quits. Startup prints the log file path on stderr
 for per-key tap debug).
 
 The search box is centered on the **main display** (menu-bar monitor), with a
-small bunny icon beside the field. Click the icon for version, commit, and
+small bunny icon to the right of the field. Click the icon for version, commit, and
 project links (domesti-bot-style about panel).
 
 If the chord does nothing, run with `--verbose` and watch stderr. Lines


### PR DESCRIPTION
## Summary
- Fix overlay placement on the menu-bar display (`NSScreen.screens()[0]`, not `mainScreen()`)
- Borderless search panel (no "spotty-bunny" title bar); logo no longer clipped on secondary monitors
- Redrawn spotty bunny icon (long ears, spots, buck teeth)
- Placeholder examples: `gh, c, yt, docs`
- Click bunny logo for about panel (version, commit, copyright, GitHub link)
- Center search placeholder and typed text; move bunny logo to the right of the field

## Test plan
- [ ] With two monitors, overlay centers on menu-bar display with bunny visible
- [ ] No title-bar "spotty-bunny" label on search panel
- [ ] Click bunny → about panel with version/commit and GitHub link
- [ ] Tab completion list scrolls; placeholder shows new examples
- [ ] Search hint and typed text are centered; bunny logo sits on the right
- [x] `./test_bunnify` and pre-pr-checks pass locally