### PR TITLE
fix(deps): batch updates including CVE fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "platformdirs>=4.11.1",
     "prompt-toolkit>=3.0.53",
     "rpds-py>=2026.6.3",
+    "sqlparse>=0.6.0",
     "typing-extensions==4.16.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "prompt-toolkit" },
     { name = "rpds-py" },
+    { name = "sqlparse" },
     { name = "typing-extensions" },
 ]
 
@@ -64,6 +65,7 @@ requires-dist = [
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin' and extra == 'macos'", specifier = "==12.2.1" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin' and extra == 'macos'", specifier = "==12.2.1" },
     { name = "rpds-py", specifier = ">=2026.6.3" },
+    { name = "sqlparse", specifier = ">=0.6.0" },
     { name = "typing-extensions", specifier = "==4.16.0" },
 ]
 provides-extras = ["macos"]
@@ -346,11 +348,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Batch dependency updates

Automated dependency updates via `dep-updater --batch`.

All outdated packages and CVE fixes combined into a single PR.

## Python CVEs addressed

| Package | Current | Fixed | CVEs |
|---|---|---|---|
| `sqlparse` | `0.5.5` | `0.6.0` | CVE-2026-71491,  CVE-2026-59894, CVE-2026-59893, CVE-2026-54284 |

## Dependency update summary

| Ecosystem | Package | From | To | CVE? | CVEs |
|---|---|---|---|---|---|
| python/uv | `sqlparse` | `0.5.5` | `0.6.0` | no | - |
| python/uv | `sqlparse` | `0.5.5` | `0.6.0` | yes | CVE-2026-71491,  CVE-2026-59894, CVE-2026-59893, CVE-2026-54284 |

## Python updates

| Package | From | To |
|---|---|---|
| `sqlparse` | `0.5.5` | `0.6.0` |
