### PR TITLE
feat: install Spotty Bunny as a login LaunchAgent

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -34,6 +34,10 @@ bunnify --print-url gh          # print resolved URL instead of opening browser
 bunnify --list-keys             # list keys from the running server
 bunnify spotty-bunny            # macOS search box (requires extra macos)
 bunnify spotty-bunny --verbose  # DEBUG logs on stderr and log file
+bunnify spotty-bunny install    # login LaunchAgent (TCC + KeepAlive)
+bunnify spotty-bunny status     # process, launchd, logs, TCC
+bunnify spotty-bunny upgrade    # refresh agent after `bunnify upgrade`
+bunnify spotty-bunny uninstall
 ```
 
 ## Server

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Unknown keys exit non-zero in direct mode (no search-engine fallback).
 ## Features
 
 - **CLI / REPL** — fuzzy Tab completion, fzf mode, Vim/Emacs edit keys
-- **Spotty Bunny** — dual-Control search box (`spotty-bunny`; extra `macos`)
+- **Spotty Bunny** — dual-Control search box (`spotty-bunny`; extra `macos`; `install` LaunchAgent)
 - **Web** — `/cmd/` command palette, `/list/` browser, smart `/search/`
 - **Chrome / Edge** — OpenSearch at `/opensearch.xml`
   ([setup guide](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md))

--- a/app/cli.py
+++ b/app/cli.py
@@ -1371,6 +1371,8 @@ def main(
     \b
     macOS Spotty Bunny (`spotty-bunny` is a reserved shortcut name):
       bunnify spotty-bunny
+      bunnify spotty-bunny install
+      bunnify spotty-bunny status
       ./scripts/spotty-bunny
       ./scripts/spotty-bunny --verbose
 

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -1,0 +1,518 @@
+"""Spotty Bunny macOS LaunchAgent (install, uninstall, status, upgrade)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from app.spotty_bunny_cli import (
+    COMMAND_NAME,
+    MACOS_EXTRA_HINT,
+    NOT_MACOS_MESSAGE,
+    _spotty_bunny_log_file,
+)
+from app.spotty_bunny_launch import (
+    clear_spotty_bunny_pid,
+    spotty_bunny_command,
+    spotty_bunny_is_running,
+    stop_spotty_bunny,
+)
+from app.version import build_version
+
+AGENT_COMMANDS = frozenset({"install", "status", "uninstall", "upgrade"})
+AGENT_LABEL = "com.thehcma.bunnify.spotty-bunny"
+AGENT_PLIST_NAME = f"{AGENT_LABEL}.plist"
+LAUNCHCTL_TIMEOUT_S = 10
+TCC_INSTRUCTIONS = f"""\
+{COMMAND_NAME}: Accessibility and Input Monitoring must be granted to the
+Python interpreter launchd will exec (the pipx/venv interpreter behind
+spotty-bunny), not only Terminal.app.
+
+System Settings → Privacy & Security → Accessibility
+System Settings → Privacy & Security → Input Monitoring
+
+Then re-run: {COMMAND_NAME} install
+"""
+TCC_PROBE_TIMEOUT_S = 15
+UNKNOWN_COMMAND_MESSAGE = (
+    f"{COMMAND_NAME}: unknown command '{{command}}'. "
+    "Use install, uninstall, status, or upgrade; "
+    "or run with no subcommand for the foreground overlay."
+)
+
+LaunchctlFn = Callable[..., subprocess.CompletedProcess[str]]
+TccFn = Callable[[Path], "TccStatus"]
+
+
+@dataclass(frozen=True)
+class TccStatus:
+    """Current Accessibility and Input Monitoring grants for one interpreter."""
+
+    accessibility: bool
+    input_monitoring: bool
+
+    @property
+    def ok(self) -> bool:
+        return self.accessibility and self.input_monitoring
+
+
+def agent_plist_path(*, home: Path | None = None) -> Path:
+    """Installed LaunchAgent path under *home*."""
+    root = home if home is not None else Path.home()
+    return root / "Library" / "LaunchAgents" / AGENT_PLIST_NAME
+
+
+def format_agent_plist(*, program: Path, home: Path) -> str:
+    """Return the LaunchAgent plist for *program* and *home*."""
+    return _PLIST_TEMPLATE.replace("__SPOTTY_BUNNY__", escape(str(program))).replace(
+        "__HOME__", escape(str(home))
+    )
+
+
+def install_agent(
+    *,
+    home: Path | None = None,
+    launchctl: LaunchctlFn | None = None,
+    platform: str | None = None,
+    print_err: Callable[[str], None] | None = None,
+    probe_tcc: TccFn | None = None,
+    program: Path | None = None,
+    request_tcc: TccFn | None = None,
+) -> int:
+    """Write the LaunchAgent, verify TCC, and bootstrap it."""
+    err = print_err or _print_err
+    if not _is_darwin(platform):
+        err(NOT_MACOS_MESSAGE)
+        return 1
+    binary = program if program is not None else spotty_bunny_program()
+    if binary is None:
+        err(f"{COMMAND_NAME}: could not find the spotty-bunny binary on PATH.")
+        return 1
+    interpreter = interpreter_for_program(binary)
+    status = _require_current_tcc(
+        interpreter,
+        err=err,
+        probe_tcc=probe_tcc,
+        request_tcc=request_tcc,
+    )
+    if status is None:
+        return 1
+    root = home if home is not None else Path.home()
+    plist = agent_plist_path(home=root)
+    _write_plist(plist, program=binary, home=root)
+    _bootout_agent(launchctl=launchctl)
+    if not _bootstrap_agent(plist, launchctl=launchctl):
+        err(f"{COMMAND_NAME}: launchctl bootstrap failed for {plist}.")
+        return 1
+    err(f"{COMMAND_NAME}: installed LaunchAgent {AGENT_LABEL}")
+    err(f"{COMMAND_NAME}: plist {plist}")
+    return 0
+
+
+def interpreter_for_program(program: Path) -> Path:
+    """Return the interpreter launchd will exec for a console-script *program*."""
+    try:
+        first = program.read_bytes().splitlines()[:1]
+    except OSError:
+        return program
+    if not first or not first[0].startswith(b"#!"):
+        return program
+    line = first[0][2:].decode("utf-8", errors="replace").strip()
+    parts = line.split()
+    if not parts:
+        return program
+    executable = Path(parts[0])
+    if executable.name == "env" and len(parts) >= 2:
+        resolved = shutil.which(parts[1])
+        return Path(resolved) if resolved else Path(parts[1])
+    return executable
+
+
+def is_agent_loaded(
+    *,
+    launchctl: LaunchctlFn | None = None,
+    uid: int | None = None,
+) -> bool:
+    """True when launchd has the Spotty Bunny agent in the gui domain."""
+    completed = _launchctl(
+        ["print", f"{_gui_domain(uid)}/{AGENT_LABEL}"],
+        launchctl=launchctl,
+    )
+    return completed.returncode == 0
+
+
+def run_agent_command(
+    command: str,
+    rest: Sequence[str] = (),
+    **kwargs: object,
+) -> int:
+    """Dispatch a LaunchAgent subcommand. Extra argv is an error."""
+    if rest:
+        print(
+            f"{COMMAND_NAME} {command}: unexpected arguments.",
+            file=sys.stderr,
+        )
+        return 2
+    if command == "install":
+        return install_agent(**kwargs)
+    if command == "status":
+        return status_agent(**kwargs)
+    if command == "uninstall":
+        return uninstall_agent(**kwargs)
+    if command == "upgrade":
+        return upgrade_agent(**kwargs)
+    print(UNKNOWN_COMMAND_MESSAGE.format(command=command), file=sys.stderr)
+    return 2
+
+
+def spotty_bunny_program() -> Path | None:
+    """Absolute path launchd should exec (`command -v spotty-bunny`)."""
+    command = spotty_bunny_command()
+    if not command:
+        return None
+    path = Path(command[0]).expanduser()
+    if path.is_absolute():
+        return path
+    resolved = shutil.which(command[0])
+    return Path(resolved) if resolved else path.resolve()
+
+
+def status_agent(
+    *,
+    home: Path | None = None,
+    launchctl: LaunchctlFn | None = None,
+    pid_dir: Path | None = None,
+    platform: str | None = None,
+    print_err: Callable[[str], None] | None = None,
+    print_fn: Callable[[str], None] | None = None,
+    probe_tcc: TccFn | None = None,
+    program: Path | None = None,
+) -> int:
+    """Print agent, process, log, version, and TCC state. Exit 0 if healthy."""
+    err = print_err or _print_err
+    out = print_fn or print
+    if not _is_darwin(platform):
+        err(NOT_MACOS_MESSAGE)
+        return 1
+    root = home if home is not None else Path.home()
+    plist = agent_plist_path(home=root)
+    binary = program if program is not None else spotty_bunny_program()
+    loaded = is_agent_loaded(launchctl=launchctl) if plist.is_file() else False
+    running = spotty_bunny_is_running(pid_dir=pid_dir)
+    pid_text = "none"
+    if running:
+        pid_text = _pid_text(pid_dir=pid_dir)
+    installed = plist.is_file()
+    interpreter = interpreter_for_program(binary) if binary is not None else None
+    tcc = (
+        (probe_tcc or _probe_tcc)(interpreter)
+        if interpreter is not None
+        else TccStatus(False, False)
+    )
+    stdout_path, stderr_path = _launchd_log_paths(plist)
+    out(f"running: {'yes' if running else 'no'}")
+    out(f"pid: {pid_text}")
+    if not installed:
+        out("launchd: not installed")
+    else:
+        out(f"launchd: {'loaded' if loaded else 'not loaded'}")
+    out(f"binary: {binary if binary is not None else 'none'}")
+    out(f"application_log: {_spotty_bunny_log_file(None)}")
+    out(f"launchd_stdout: {stdout_path or 'none'}")
+    out(f"launchd_stderr: {stderr_path or 'none'}")
+    out(f"version: {build_version()}")
+    out(f"accessibility: {'yes' if tcc.accessibility else 'no'}")
+    out(f"input_monitoring: {'yes' if tcc.input_monitoring else 'no'}")
+    return 0 if installed and loaded and running else 1
+
+
+def uninstall_agent(
+    *,
+    home: Path | None = None,
+    launchctl: LaunchctlFn | None = None,
+    pid_dir: Path | None = None,
+    platform: str | None = None,
+    print_err: Callable[[str], None] | None = None,
+) -> int:
+    """Boot out the agent, remove the plist, stop the process, clear the pid."""
+    err = print_err or _print_err
+    if not _is_darwin(platform):
+        err(NOT_MACOS_MESSAGE)
+        return 1
+    root = home if home is not None else Path.home()
+    plist = agent_plist_path(home=root)
+    if plist.is_file() or is_agent_loaded(launchctl=launchctl):
+        _bootout_agent(launchctl=launchctl)
+    plist.unlink(missing_ok=True)
+    stop_spotty_bunny(pid_dir=pid_dir)
+    clear_spotty_bunny_pid(pid_dir=pid_dir)
+    err(f"{COMMAND_NAME}: uninstalled LaunchAgent {AGENT_LABEL}")
+    return 0
+
+
+def upgrade_agent(
+    *,
+    home: Path | None = None,
+    launchctl: LaunchctlFn | None = None,
+    platform: str | None = None,
+    print_err: Callable[[str], None] | None = None,
+    probe_tcc: TccFn | None = None,
+    program: Path | None = None,
+    request_tcc: TccFn | None = None,
+) -> int:
+    """Rewrite the plist for the current binary, re-check TCC, and bounce."""
+    err = print_err or _print_err
+    if not _is_darwin(platform):
+        err(NOT_MACOS_MESSAGE)
+        return 1
+    root = home if home is not None else Path.home()
+    plist = agent_plist_path(home=root)
+    if not plist.is_file():
+        err(
+            f"{COMMAND_NAME}: LaunchAgent is not installed. Run: {COMMAND_NAME} install"
+        )
+        return 1
+    binary = program if program is not None else spotty_bunny_program()
+    if binary is None:
+        err(f"{COMMAND_NAME}: could not find the spotty-bunny binary on PATH.")
+        return 1
+    interpreter = interpreter_for_program(binary)
+    status = _require_current_tcc(
+        interpreter,
+        err=err,
+        probe_tcc=probe_tcc,
+        request_tcc=request_tcc,
+    )
+    if status is None:
+        return 1
+    _write_plist(plist, program=binary, home=root)
+    if is_agent_loaded(launchctl=launchctl):
+        _kickstart_agent(launchctl=launchctl)
+    elif not _bootstrap_agent(plist, launchctl=launchctl):
+        err(f"{COMMAND_NAME}: launchctl bootstrap failed for {plist}.")
+        return 1
+    err(f"{COMMAND_NAME}: refreshed LaunchAgent {AGENT_LABEL}")
+    err(f"{COMMAND_NAME}: binary {binary}")
+    return 0
+
+
+def _bootstrap_agent(
+    plist: Path, *, launchctl: LaunchctlFn | None = None, uid: int | None = None
+) -> bool:
+    completed = _launchctl(
+        ["bootstrap", _gui_domain(uid), str(plist)],
+        launchctl=launchctl,
+    )
+    return completed.returncode == 0
+
+
+def _bootout_agent(
+    *, launchctl: LaunchctlFn | None = None, uid: int | None = None
+) -> None:
+    _launchctl(
+        ["bootout", f"{_gui_domain(uid)}/{AGENT_LABEL}"],
+        launchctl=launchctl,
+    )
+
+
+def _gui_domain(uid: int | None = None) -> str:
+    return f"gui/{os.getuid() if uid is None else uid}"
+
+
+def _is_darwin(platform: str | None) -> bool:
+    return (sys.platform if platform is None else platform) == "darwin"
+
+
+def _kickstart_agent(
+    *, launchctl: LaunchctlFn | None = None, uid: int | None = None
+) -> None:
+    _launchctl(
+        ["kickstart", "-k", f"{_gui_domain(uid)}/{AGENT_LABEL}"],
+        launchctl=launchctl,
+    )
+
+
+def _launchctl(
+    args: Sequence[str],
+    *,
+    launchctl: LaunchctlFn | None = None,
+) -> subprocess.CompletedProcess[str]:
+    argv = ["launchctl", *args]
+    runner = launchctl or subprocess.run
+    try:
+        return runner(
+            argv,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=LAUNCHCTL_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(argv, 1, "", str(exc))
+
+
+def _launchd_log_paths(plist: Path) -> tuple[str | None, str | None]:
+    if not plist.is_file():
+        return None, None
+    try:
+        text = plist.read_text(encoding="utf-8")
+    except OSError:
+        return None, None
+    return (
+        _plist_string(text, "StandardOutPath"),
+        _plist_string(text, "StandardErrorPath"),
+    )
+
+
+def _pid_text(*, pid_dir: Path | None) -> str:
+    from app.spotty_bunny_launch import spotty_bunny_pid_path
+
+    path = spotty_bunny_pid_path(pid_dir=pid_dir)
+    try:
+        return path.read_text(encoding="utf-8").strip() or "none"
+    except OSError:
+        return "none"
+
+
+def _plist_string(text: str, key: str) -> str | None:
+    marker = f"<key>{key}</key>"
+    start = text.find(marker)
+    if start < 0:
+        return None
+    chunk = text[start:]
+    open_tag = chunk.find("<string>")
+    close_tag = chunk.find("</string>")
+    if open_tag < 0 or close_tag < 0 or close_tag <= open_tag:
+        return None
+    return chunk[open_tag + len("<string>") : close_tag]
+
+
+def _print_err(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def _probe_tcc(interpreter: Path) -> TccStatus:
+    return _run_tcc_probe(interpreter, prompt=False)
+
+
+def _request_tcc(interpreter: Path) -> TccStatus:
+    return _run_tcc_probe(interpreter, prompt=True)
+
+
+def _require_current_tcc(
+    interpreter: Path,
+    *,
+    err: Callable[[str], None],
+    probe_tcc: TccFn | None,
+    request_tcc: TccFn | None,
+) -> TccStatus | None:
+    probe = probe_tcc or _probe_tcc
+    request = request_tcc or _request_tcc
+    try:
+        status = probe(interpreter)
+        if not status.ok:
+            request(interpreter)
+            status = probe(interpreter)
+    except ImportError:
+        err(MACOS_EXTRA_HINT)
+        return None
+    except (OSError, subprocess.SubprocessError) as exc:
+        err(f"{COMMAND_NAME}: could not verify TCC for {interpreter}: {exc}")
+        return None
+    if not status.ok:
+        err(TCC_INSTRUCTIONS)
+        err(f"{COMMAND_NAME}: interpreter {interpreter}")
+        err(
+            f"{COMMAND_NAME}: accessibility="
+            f"{'yes' if status.accessibility else 'no'} "
+            f"input_monitoring={'yes' if status.input_monitoring else 'no'}"
+        )
+        return None
+    return status
+
+
+def _run_tcc_probe(interpreter: Path, *, prompt: bool) -> TccStatus:
+    completed = subprocess.run(
+        [str(interpreter), "-c", _TCC_PROBE, "1" if prompt else "0"],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=TCC_PROBE_TIMEOUT_S,
+    )
+    if completed.returncode == 2:
+        raise ImportError("PyObjC is required to probe TCC")
+    if completed.returncode != 0:
+        raise OSError(
+            completed.stderr.strip() or completed.stdout.strip() or "tcc probe failed"
+        )
+    payload = json.loads(completed.stdout)
+    return TccStatus(
+        accessibility=bool(payload["accessibility"]),
+        input_monitoring=bool(payload["input_monitoring"]),
+    )
+
+
+def _write_plist(plist: Path, *, program: Path, home: Path) -> None:
+    plist.parent.mkdir(parents=True, exist_ok=True)
+    plist.write_text(format_agent_plist(program=program, home=home), encoding="utf-8")
+
+
+_PLIST_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.thehcma.bunnify.spotty-bunny</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__SPOTTY_BUNNY__</string>
+  </array>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/bunnify.spotty-bunny.err.log</string>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/bunnify.spotty-bunny.out.log</string>
+</dict>
+</plist>
+"""
+
+_TCC_PROBE = r"""
+import json
+import sys
+
+try:
+    from ApplicationServices import AXIsProcessTrusted, AXIsProcessTrustedWithOptions
+    from Foundation import NSDictionary
+    from Quartz import CGPreflightListenEventAccess, CGRequestListenEventAccess
+except ImportError:
+    raise SystemExit(2)
+
+if sys.argv[1] == "1":
+    AXIsProcessTrustedWithOptions(
+        NSDictionary.dictionaryWithObject_forKey_(True, "AXTrustedCheckOptionPrompt")
+    )
+    CGRequestListenEventAccess()
+print(
+    json.dumps(
+        {
+            "accessibility": bool(AXIsProcessTrusted()),
+            "input_monitoring": bool(CGPreflightListenEventAccess()),
+        }
+    )
+)
+"""

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -30,6 +30,7 @@ AGENT_COMMANDS = frozenset({"install", "status", "uninstall", "upgrade"})
 AGENT_LABEL = "com.thehcma.bunnify.spotty-bunny"
 AGENT_PLIST_NAME = f"{AGENT_LABEL}.plist"
 LAUNCHCTL_TIMEOUT_S = 10
+LAUNCHD_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
 TCC_INSTRUCTIONS = f"""\
 {COMMAND_NAME}: Accessibility and Input Monitoring must be granted to the
 Python interpreter launchd will exec (the pipx/venv interpreter behind
@@ -69,9 +70,12 @@ def agent_plist_path(*, home: Path | None = None) -> Path:
     return root / "Library" / "LaunchAgents" / AGENT_PLIST_NAME
 
 
-def format_agent_plist(*, program: Path, home: Path) -> str:
-    """Return the LaunchAgent plist for *program* and *home*."""
-    return _PLIST_TEMPLATE.replace("__SPOTTY_BUNNY__", escape(str(program))).replace(
+def format_agent_plist(*, home: Path, program_arguments: Sequence[str]) -> str:
+    """Return the LaunchAgent plist for *program_arguments* and *home*."""
+    args_xml = "\n".join(
+        f"    <string>{escape(arg)}</string>" for arg in program_arguments
+    )
+    return _PLIST_TEMPLATE.replace("__PROGRAM_ARGUMENTS__", args_xml).replace(
         "__HOME__", escape(str(home))
     )
 
@@ -92,10 +96,15 @@ def install_agent(
         err(NOT_MACOS_MESSAGE)
         return 1
     binary = program if program is not None else spotty_bunny_program()
-    if binary is None:
+    program_argv = (
+        [str(program.resolve())]
+        if program is not None
+        else spotty_bunny_program_arguments()
+    )
+    if program_argv is None or binary is None:
         err(f"{COMMAND_NAME}: could not find the spotty-bunny binary on PATH.")
         return 1
-    interpreter = interpreter_for_program(binary)
+    interpreter = interpreter_for_program(Path(program_argv[0]))
     status = _require_current_tcc(
         interpreter,
         err=err,
@@ -106,7 +115,7 @@ def install_agent(
         return 1
     root = home if home is not None else Path.home()
     plist = agent_plist_path(home=root)
-    _write_plist(plist, program=binary, home=root)
+    _write_plist(plist, home=root, program_arguments=program_argv)
     _bootout_agent(launchctl=launchctl)
     if not _bootstrap_agent(plist, launchctl=launchctl):
         err(f"{COMMAND_NAME}: launchctl bootstrap failed for {plist}.")
@@ -130,8 +139,10 @@ def interpreter_for_program(program: Path) -> Path:
         return program
     executable = Path(parts[0])
     if executable.name == "env" and len(parts) >= 2:
-        resolved = shutil.which(parts[1])
-        return Path(resolved) if resolved else Path(parts[1])
+        resolved = shutil.which(parts[1], path=LAUNCHD_PATH)
+        if resolved is None:
+            return Path(parts[1])
+        return Path(resolved)
     return executable
 
 
@@ -173,15 +184,30 @@ def run_agent_command(
 
 
 def spotty_bunny_program() -> Path | None:
-    """Absolute path launchd should exec (`command -v spotty-bunny`)."""
+    """Primary executable path for status display (first ProgramArguments entry)."""
+    argv = spotty_bunny_program_arguments()
+    if not argv:
+        return None
+    return Path(argv[0])
+
+
+def spotty_bunny_program_arguments() -> list[str] | None:
+    """Absolute argv launchd should use in ProgramArguments."""
     command = spotty_bunny_command()
     if not command:
         return None
-    path = Path(command[0]).expanduser()
-    if path.is_absolute():
-        return path
-    resolved = shutil.which(command[0])
-    return Path(resolved) if resolved else path.resolve()
+    resolved: list[str] = []
+    for index, part in enumerate(command):
+        if index == 0:
+            path = Path(part).expanduser()
+            if path.is_absolute():
+                resolved.append(str(path))
+                continue
+            found = shutil.which(part)
+            resolved.append(found if found else str(path.resolve()))
+            continue
+        resolved.append(part)
+    return resolved
 
 
 def status_agent(
@@ -211,10 +237,10 @@ def status_agent(
         pid_text = _pid_text(pid_dir=pid_dir)
     installed = plist.is_file()
     interpreter = interpreter_for_program(binary) if binary is not None else None
-    tcc = (
-        (probe_tcc or _probe_tcc)(interpreter)
-        if interpreter is not None
-        else TccStatus(False, False)
+    tcc = _probe_tcc_for_status(
+        interpreter,
+        err=err,
+        probe_tcc=probe_tcc,
     )
     stdout_path, stderr_path = _launchd_log_paths(plist)
     out(f"running: {'yes' if running else 'no'}")
@@ -280,10 +306,15 @@ def upgrade_agent(
         )
         return 1
     binary = program if program is not None else spotty_bunny_program()
-    if binary is None:
+    program_argv = (
+        [str(program.resolve())]
+        if program is not None
+        else spotty_bunny_program_arguments()
+    )
+    if program_argv is None or binary is None:
         err(f"{COMMAND_NAME}: could not find the spotty-bunny binary on PATH.")
         return 1
-    interpreter = interpreter_for_program(binary)
+    interpreter = interpreter_for_program(Path(program_argv[0]))
     status = _require_current_tcc(
         interpreter,
         err=err,
@@ -292,12 +323,14 @@ def upgrade_agent(
     )
     if status is None:
         return 1
-    _write_plist(plist, program=binary, home=root)
-    if is_agent_loaded(launchctl=launchctl):
-        _kickstart_agent(launchctl=launchctl)
-    elif not _bootstrap_agent(plist, launchctl=launchctl):
-        err(f"{COMMAND_NAME}: launchctl bootstrap failed for {plist}.")
-        return 1
+    was_loaded = is_agent_loaded(launchctl=launchctl)
+    _write_plist(plist, home=root, program_arguments=program_argv)
+    if was_loaded:
+        _bootout_agent(launchctl=launchctl)
+    if was_loaded or not is_agent_loaded(launchctl=launchctl):
+        if not _bootstrap_agent(plist, launchctl=launchctl):
+            err(f"{COMMAND_NAME}: launchctl bootstrap failed for {plist}.")
+            return 1
     err(f"{COMMAND_NAME}: refreshed LaunchAgent {AGENT_LABEL}")
     err(f"{COMMAND_NAME}: binary {binary}")
     return 0
@@ -328,15 +361,6 @@ def _gui_domain(uid: int | None = None) -> str:
 
 def _is_darwin(platform: str | None) -> bool:
     return (sys.platform if platform is None else platform) == "darwin"
-
-
-def _kickstart_agent(
-    *, launchctl: LaunchctlFn | None = None, uid: int | None = None
-) -> None:
-    _launchctl(
-        ["kickstart", "-k", f"{_gui_domain(uid)}/{AGENT_LABEL}"],
-        launchctl=launchctl,
-    )
 
 
 def _launchctl(
@@ -423,7 +447,7 @@ def _require_current_tcc(
     except ImportError:
         err(MACOS_EXTRA_HINT)
         return None
-    except (OSError, subprocess.SubprocessError) as exc:
+    except (OSError, subprocess.SubprocessError, ValueError) as exc:
         err(f"{COMMAND_NAME}: could not verify TCC for {interpreter}: {exc}")
         return None
     if not status.ok:
@@ -452,16 +476,42 @@ def _run_tcc_probe(interpreter: Path, *, prompt: bool) -> TccStatus:
         raise OSError(
             completed.stderr.strip() or completed.stdout.strip() or "tcc probe failed"
         )
-    payload = json.loads(completed.stdout)
-    return TccStatus(
-        accessibility=bool(payload["accessibility"]),
-        input_monitoring=bool(payload["input_monitoring"]),
-    )
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise OSError(f"tcc probe returned invalid JSON: {exc}") from exc
+    try:
+        return TccStatus(
+            accessibility=bool(payload["accessibility"]),
+            input_monitoring=bool(payload["input_monitoring"]),
+        )
+    except (KeyError, TypeError) as exc:
+        raise OSError(f"tcc probe returned invalid JSON: {exc}") from exc
 
 
-def _write_plist(plist: Path, *, program: Path, home: Path) -> None:
+def _probe_tcc_for_status(
+    interpreter: Path | None,
+    *,
+    err: Callable[[str], None],
+    probe_tcc: TccFn | None,
+) -> TccStatus:
+    if interpreter is None:
+        return TccStatus(False, False)
+    try:
+        return (probe_tcc or _probe_tcc)(interpreter)
+    except ImportError:
+        err(MACOS_EXTRA_HINT)
+        return TccStatus(False, False)
+    except OSError, subprocess.SubprocessError, ValueError:
+        return TccStatus(False, False)
+
+
+def _write_plist(plist: Path, *, home: Path, program_arguments: Sequence[str]) -> None:
     plist.parent.mkdir(parents=True, exist_ok=True)
-    plist.write_text(format_agent_plist(program=program, home=home), encoding="utf-8")
+    plist.write_text(
+        format_agent_plist(home=home, program_arguments=program_arguments),
+        encoding="utf-8",
+    )
 
 
 _PLIST_TEMPLATE = """\
@@ -475,7 +525,7 @@ _PLIST_TEMPLATE = """\
 
   <key>ProgramArguments</key>
   <array>
-    <string>__SPOTTY_BUNNY__</string>
+__PROGRAM_ARGUMENTS__
   </array>
 
   <key>KeepAlive</key>

--- a/app/spotty_bunny_cli.py
+++ b/app/spotty_bunny_cli.py
@@ -54,7 +54,8 @@ def build_parser() -> argparse.ArgumentParser:
         prog=COMMAND_NAME,
         description=(
             "Spotty Bunny: macOS Spotlight-style search box. Hold one Control, "
-            "press the other to show it. Shortcut completion is not wired yet."
+            "press the other to show it. Subcommands: install, uninstall, "
+            "status, upgrade (login LaunchAgent). Bare invocation is foreground."
         ),
     )
     parser.add_argument(
@@ -89,7 +90,20 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the installed Spotty Bunny command."""
-    args = list(argv) if argv is not None else None
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if args:
+        from app.spotty_bunny_agent import (
+            AGENT_COMMANDS,
+            UNKNOWN_COMMAND_MESSAGE,
+            run_agent_command,
+        )
+
+        token = args[0]
+        if token in AGENT_COMMANDS:
+            return run_agent_command(token, args[1:])
+        if not token.startswith("-"):
+            print(UNKNOWN_COMMAND_MESSAGE.format(command=token), file=sys.stderr)
+            return 2
     parsed = build_parser().parse_args(args)
     log_level = "DEBUG" if parsed.verbose else parsed.log_level
     log_file = _spotty_bunny_log_file(parsed.log_file)

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -86,6 +87,21 @@ def spotty_bunny_pid_path(*, pid_dir: Path | None = None) -> Path:
     return directory / SPOTTY_BUNNY_PID_FILE
 
 
+def stop_spotty_bunny(*, pid_dir: Path | None = None) -> bool:
+    """SIGTERM (then SIGKILL) a leftover overlay. Returns True if signaled."""
+    path = spotty_bunny_pid_path(pid_dir=pid_dir)
+    try:
+        pid = int(path.read_text(encoding="utf-8").strip())
+    except OSError, ValueError:
+        return False
+    if not _spotty_bunny_process_alive(pid):
+        path.unlink(missing_ok=True)
+        return False
+    _terminate_pid(pid)
+    path.unlink(missing_ok=True)
+    return True
+
+
 def write_spotty_bunny_pid(pid: int, *, pid_dir: Path | None = None) -> None:
     """Record *pid* for later ``spotty_bunny_is_running`` checks."""
     path = spotty_bunny_pid_path(pid_dir=pid_dir)
@@ -132,3 +148,28 @@ def _spawn_detached(command: Sequence[str]) -> int:
         start_new_session=True,
     )
     return int(proc.pid)
+
+
+def _terminate_pid(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    if _wait_for_exit(pid, timeout_s=10):
+        return
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    _wait_for_exit(pid, timeout_s=2)
+
+
+def _wait_for_exit(pid: int, *, timeout_s: float) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return True
+        time.sleep(0.05)
+    return False

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -275,19 +275,73 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         example = (
             root / "etc" / "launchd" / "com.thehcma.bunnify.spotty-bunny.plist.example"
         ).read_text(encoding="utf-8")
-        expected = example.replace("__SPOTTY_BUNNY__", "/opt/spotty-bunny").replace(
-            "__HOME__", "/Users/test"
-        )
+        expected = example.replace(
+            "    <string>__SPOTTY_BUNNY__</string>",
+            "    <string>/opt/spotty-bunny</string>",
+        ).replace("__HOME__", "/Users/test")
         self.assertEqual(
             format_agent_plist(
-                program=Path("/opt/spotty-bunny"),
                 home=Path("/Users/test"),
+                program_arguments=["/opt/spotty-bunny"],
             ),
             expected,
         )
         self.assertIn(AGENT_LABEL, expected)
         self.assertIn("<key>KeepAlive</key>", expected)
         self.assertIn("<key>RunAtLoad</key>", expected)
+
+    def test_format_agent_plist_supports_module_argv(self) -> None:
+        from app.spotty_bunny_agent import format_agent_plist
+
+        text = format_agent_plist(
+            home=Path("/Users/test"),
+            program_arguments=[
+                "/usr/bin/python3",
+                "-m",
+                "app.spotty_bunny_cli",
+            ],
+        )
+        self.assertIn("<string>/usr/bin/python3</string>", text)
+        self.assertIn("<string>-m</string>", text)
+        self.assertIn("<string>app.spotty_bunny_cli</string>", text)
+
+    def test_status_handles_missing_macos_extra(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
+
+        def _raise_import(_program: Path) -> TccStatus:
+            raise ImportError("PyObjC")
+
+        ctl = _FakeLaunchctl()
+        stderr = StringIO()
+        stdout = StringIO()
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            program = Path("/opt/spotty-bunny")
+            plist.write_text(
+                format_agent_plist(
+                    home=home,
+                    program_arguments=[str(program)],
+                ),
+                encoding="utf-8",
+            )
+            with patch(
+                "app.spotty_bunny_agent.spotty_bunny_is_running",
+                return_value=False,
+            ):
+                code = status_agent(
+                    home=home,
+                    launchctl=ctl,
+                    platform="darwin",
+                    print_err=stderr.write,
+                    print_fn=lambda line: stdout.write(line + "\n"),
+                    probe_tcc=_raise_import,
+                    program=program,
+                )
+            self.assertEqual(code, 1)
+            self.assertIn("macos", stderr.getvalue().lower())
+            self.assertIn("accessibility: no", stdout.getvalue())
 
     def test_install_bootstraps_when_tcc_is_current(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, install_agent
@@ -405,7 +459,10 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             plist.parent.mkdir(parents=True)
             program = Path("/opt/spotty-bunny")
             plist.write_text(
-                format_agent_plist(program=program, home=home),
+                format_agent_plist(
+                    home=home,
+                    program_arguments=[str(program)],
+                ),
                 encoding="utf-8",
             )
             pid_dir = home / "run"
@@ -492,7 +549,10 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
             plist.parent.mkdir(parents=True)
             plist.write_text(
-                format_agent_plist(program=Path("/old/spotty-bunny"), home=home),
+                format_agent_plist(
+                    home=home,
+                    program_arguments=["/old/spotty-bunny"],
+                ),
                 encoding="utf-8",
             )
             new_program = Path("/new/spotty-bunny")
@@ -508,7 +568,9 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertEqual(code, 0)
             self.assertIn(str(new_program), plist.read_text(encoding="utf-8"))
             self.assertNotIn("/old/spotty-bunny", plist.read_text(encoding="utf-8"))
-            self.assertTrue(any(call[1] == "kickstart" for call in ctl.calls))
+            self.assertTrue(any(call[1] == "bootout" for call in ctl.calls))
+            self.assertTrue(any(call[1] == "bootstrap" for call in ctl.calls))
+            self.assertFalse(any(call[1] == "kickstart" for call in ctl.calls))
 
     def test_upgrade_rechecks_tcc(self) -> None:
         from app.spotty_bunny_agent import (
@@ -524,7 +586,10 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
             plist.parent.mkdir(parents=True)
             plist.write_text(
-                format_agent_plist(program=Path("/opt/spotty-bunny"), home=home),
+                format_agent_plist(
+                    home=home,
+                    program_arguments=["/opt/spotty-bunny"],
+                ),
                 encoding="utf-8",
             )
             code = upgrade_agent(

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -10,6 +11,7 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 from django.test import SimpleTestCase
 
+from app.spotty_bunny_agent import TccStatus
 from app.spotty_bunny_cli import (
     LOG_ENV_VAR,
     SpottyBunnyEventTapError,
@@ -123,6 +125,9 @@ class SpottyBunnyCliTests(SimpleTestCase):
         self.assertIn("--log-file", help_text)
         self.assertIn("--log-level", help_text)
         self.assertIn("--verbose", help_text)
+        self.assertIn("install", help_text)
+        self.assertIn("uninstall", help_text)
+        self.assertIn("LaunchAgent", help_text)
 
     def test_log_level_sets_logger(self) -> None:
         stderr = StringIO()
@@ -180,6 +185,27 @@ class SpottyBunnyCliTests(SimpleTestCase):
 
         self.assertEqual(result.exit_code, 1, result.output)
         spotty.assert_called_once_with([])
+
+    def test_install_subcommand_does_not_start_overlay(self) -> None:
+        with patch("app.spotty_bunny_agent.install_agent", return_value=0) as inst:
+            self.assertEqual(main(["install"]), 0)
+        inst.assert_called_once_with()
+
+    def test_bunnify_spotty_bunny_install_forwards(self) -> None:
+        from app.cli import main as cli_main
+
+        with patch("app.spotty_bunny_cli.main", return_value=0) as spotty:
+            result = CliRunner().invoke(cli_main, ["spotty-bunny", "install"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        spotty.assert_called_once_with(["install"])
+
+    def test_unknown_subcommand_prints_usage(self) -> None:
+        stderr = StringIO()
+        with patch("app.spotty_bunny_cli.sys.stderr", stderr):
+            self.assertEqual(main(["not-a-command"]), 2)
+        self.assertIn("unknown command", stderr.getvalue())
+        self.assertIn("install", stderr.getvalue())
 
     def test_tap_failure_prints_permission_hint(self) -> None:
         def fail_tap() -> int:
@@ -239,6 +265,316 @@ class SpottyBunnyCliTests(SimpleTestCase):
         logged = self.log_file.read_text(encoding="utf-8")
         self.assertIn("spotty-bunny starting", logged)
         self.assertIn("log_level=DEBUG", logged)
+
+
+class SpottyBunnyAgentTests(SimpleTestCase):
+    def test_format_agent_plist_matches_example_placeholders(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist
+
+        root = Path(__file__).resolve().parents[1]
+        example = (
+            root / "etc" / "launchd" / "com.thehcma.bunnify.spotty-bunny.plist.example"
+        ).read_text(encoding="utf-8")
+        expected = example.replace("__SPOTTY_BUNNY__", "/opt/spotty-bunny").replace(
+            "__HOME__", "/Users/test"
+        )
+        self.assertEqual(
+            format_agent_plist(
+                program=Path("/opt/spotty-bunny"),
+                home=Path("/Users/test"),
+            ),
+            expected,
+        )
+        self.assertIn(AGENT_LABEL, expected)
+        self.assertIn("<key>KeepAlive</key>", expected)
+        self.assertIn("<key>RunAtLoad</key>", expected)
+
+    def test_install_bootstraps_when_tcc_is_current(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, install_agent
+
+        ctl = _FakeLaunchctl()
+        tcc = _FakeTcc(TccStatus(True, True))
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            program = home / "bin" / "spotty-bunny"
+            program.parent.mkdir(parents=True)
+            program.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+            stderr = StringIO()
+            code = install_agent(
+                home=home,
+                launchctl=ctl,
+                platform="darwin",
+                print_err=stderr.write,
+                probe_tcc=tcc.probe,
+                program=program,
+                request_tcc=tcc.request,
+            )
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            self.assertEqual(code, 0)
+            self.assertTrue(plist.is_file())
+            text = plist.read_text(encoding="utf-8")
+            self.assertIn(str(program), text)
+            self.assertIn("<key>KeepAlive</key>", text)
+            self.assertEqual(tcc.probes, 1)
+            self.assertEqual(tcc.requests, 0)
+            self.assertTrue(any(call[1] == "bootstrap" for call in ctl.calls))
+
+    def test_install_does_not_bootstrap_when_tcc_missing(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, install_agent
+
+        ctl = _FakeLaunchctl()
+        tcc = _FakeTcc(TccStatus(False, False), TccStatus(False, False))
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            program = home / "spotty-bunny"
+            program.write_text("#!/opt/venv/bin/python\n", encoding="utf-8")
+            stderr = StringIO()
+            code = install_agent(
+                home=home,
+                launchctl=ctl,
+                platform="darwin",
+                print_err=stderr.write,
+                probe_tcc=tcc.probe,
+                program=program,
+                request_tcc=tcc.request,
+            )
+            self.assertEqual(code, 1)
+            self.assertFalse(
+                (home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist").exists()
+            )
+            self.assertGreaterEqual(tcc.probes, 2)
+            self.assertEqual(tcc.requests, 1)
+            self.assertFalse(any(call[1] == "bootstrap" for call in ctl.calls))
+            self.assertIn("Privacy & Security", stderr.getvalue())
+
+    def test_install_rechecks_tcc_after_prompt(self) -> None:
+        from app.spotty_bunny_agent import install_agent
+
+        ctl = _FakeLaunchctl()
+        tcc = _FakeTcc(TccStatus(False, False), TccStatus(True, True))
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            program = home / "spotty-bunny"
+            program.write_text("#!/opt/venv/bin/python\n", encoding="utf-8")
+            code = install_agent(
+                home=home,
+                launchctl=ctl,
+                platform="darwin",
+                print_err=lambda _m: None,
+                probe_tcc=tcc.probe,
+                program=program,
+                request_tcc=tcc.request,
+            )
+            self.assertEqual(code, 0)
+            self.assertEqual(tcc.requests, 1)
+            self.assertEqual(tcc.probes, 2)
+
+    def test_install_not_macos(self) -> None:
+        from app.spotty_bunny_agent import install_agent
+
+        stderr = StringIO()
+        self.assertEqual(
+            install_agent(platform="linux", print_err=stderr.write),
+            1,
+        )
+        self.assertIn("only available on macOS", stderr.getvalue())
+
+    def test_interpreter_for_program_reads_shebang(self) -> None:
+        from app.spotty_bunny_agent import interpreter_for_program
+
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "spotty-bunny"
+            script.write_text(
+                "#!/opt/pipx/venvs/bunnify/bin/python\n", encoding="utf-8"
+            )
+            self.assertEqual(
+                interpreter_for_program(script),
+                Path("/opt/pipx/venvs/bunnify/bin/python"),
+            )
+
+    def test_status_reports_log_version_and_tcc(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
+        from app.version import build_version
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = True
+        stdout = StringIO()
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            program = Path("/opt/spotty-bunny")
+            plist.write_text(
+                format_agent_plist(program=program, home=home),
+                encoding="utf-8",
+            )
+            pid_dir = home / "run"
+            pid_dir.mkdir()
+            (pid_dir / ".spotty-bunny.pid").write_text("99\n", encoding="utf-8")
+            with patch(
+                "app.spotty_bunny_agent.spotty_bunny_is_running",
+                return_value=True,
+            ):
+                code = status_agent(
+                    home=home,
+                    launchctl=ctl,
+                    pid_dir=pid_dir,
+                    platform="darwin",
+                    print_fn=lambda line: stdout.write(line + "\n"),
+                    probe_tcc=lambda _p: TccStatus(True, False),
+                    program=program,
+                )
+            text = stdout.getvalue()
+            self.assertEqual(code, 0)
+            self.assertIn("running: yes", text)
+            self.assertIn("pid: 99", text)
+            self.assertIn("launchd: loaded", text)
+            self.assertIn("binary: /opt/spotty-bunny", text)
+            self.assertIn("application_log:", text)
+            self.assertIn("launchd_stdout:", text)
+            self.assertIn("version: " + build_version(), text)
+            self.assertIn("accessibility: yes", text)
+            self.assertIn("input_monitoring: no", text)
+
+    def test_uninstall_bootout_removes_plist_and_pid(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, uninstall_agent
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = True
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            plist.write_text("plist", encoding="utf-8")
+            pid_dir = home / "run"
+            pid_dir.mkdir()
+            pid_path = pid_dir / ".spotty-bunny.pid"
+            pid_path.write_text("7\n", encoding="utf-8")
+            with patch("app.spotty_bunny_agent.stop_spotty_bunny") as stop:
+                code = uninstall_agent(
+                    home=home,
+                    launchctl=ctl,
+                    pid_dir=pid_dir,
+                    platform="darwin",
+                    print_err=lambda _m: None,
+                )
+            self.assertEqual(code, 0)
+            self.assertFalse(plist.exists())
+            self.assertFalse(pid_path.exists())
+            stop.assert_called_once()
+            self.assertTrue(any(call[1] == "bootout" for call in ctl.calls))
+
+    def test_uninstall_succeeds_when_never_installed(self) -> None:
+        from app.spotty_bunny_agent import uninstall_agent
+
+        ctl = _FakeLaunchctl()
+        with TemporaryDirectory() as tmp:
+            code = uninstall_agent(
+                home=Path(tmp),
+                launchctl=ctl,
+                platform="darwin",
+                print_err=lambda _m: None,
+            )
+        self.assertEqual(code, 0)
+
+    def test_upgrade_rewrites_plist_when_binary_changes(self) -> None:
+        from app.spotty_bunny_agent import (
+            AGENT_LABEL,
+            format_agent_plist,
+            upgrade_agent,
+        )
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = True
+        tcc = _FakeTcc(TccStatus(True, True))
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            plist.write_text(
+                format_agent_plist(program=Path("/old/spotty-bunny"), home=home),
+                encoding="utf-8",
+            )
+            new_program = Path("/new/spotty-bunny")
+            code = upgrade_agent(
+                home=home,
+                launchctl=ctl,
+                platform="darwin",
+                print_err=lambda _m: None,
+                probe_tcc=tcc.probe,
+                program=new_program,
+                request_tcc=tcc.request,
+            )
+            self.assertEqual(code, 0)
+            self.assertIn(str(new_program), plist.read_text(encoding="utf-8"))
+            self.assertNotIn("/old/spotty-bunny", plist.read_text(encoding="utf-8"))
+            self.assertTrue(any(call[1] == "kickstart" for call in ctl.calls))
+
+    def test_upgrade_rechecks_tcc(self) -> None:
+        from app.spotty_bunny_agent import (
+            AGENT_LABEL,
+            format_agent_plist,
+            upgrade_agent,
+        )
+
+        ctl = _FakeLaunchctl()
+        tcc = _FakeTcc(TccStatus(False, True), TccStatus(False, True))
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            plist.write_text(
+                format_agent_plist(program=Path("/opt/spotty-bunny"), home=home),
+                encoding="utf-8",
+            )
+            code = upgrade_agent(
+                home=home,
+                launchctl=ctl,
+                platform="darwin",
+                print_err=lambda _m: None,
+                probe_tcc=tcc.probe,
+                program=Path("/opt/spotty-bunny"),
+                request_tcc=tcc.request,
+            )
+            self.assertEqual(code, 1)
+            self.assertEqual(tcc.requests, 1)
+            self.assertGreaterEqual(tcc.probes, 2)
+            self.assertFalse(any(call[1] == "kickstart" for call in ctl.calls))
+
+
+class _FakeLaunchctl:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.loaded = False
+
+    def __call__(
+        self, argv: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(argv))
+        if len(argv) >= 2 and argv[1] == "print":
+            return subprocess.CompletedProcess(argv, 0 if self.loaded else 1, "", "")
+        if len(argv) >= 2 and argv[1] == "bootstrap":
+            self.loaded = True
+        if len(argv) >= 2 and argv[1] == "bootout":
+            self.loaded = False
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+
+class _FakeTcc:
+    def __init__(self, *results: TccStatus) -> None:
+        self._results = list(results)
+        self.probes = 0
+        self.requests = 0
+
+    def probe(self, _interpreter: Path) -> TccStatus:
+        self.probes += 1
+        if not self._results:
+            raise AssertionError("unexpected TCC probe")
+        return self._results.pop(0)
+
+    def request(self, _interpreter: Path) -> TccStatus:
+        self.requests += 1
+        return TccStatus(False, False)
 
 
 class SpottyBunnyCompleteTests(SimpleTestCase):
@@ -928,6 +1264,27 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 )
             self.assertEqual(len(spawned), 1)
             self.assertEqual(pid_path.read_text(encoding="utf-8"), "4242\n")
+
+    def test_stop_spotty_bunny_clears_pid_file(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            stop_spotty_bunny,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            pid_path = pid_dir / SPOTTY_BUNNY_PID_FILE
+            pid_path.write_text("4242\n", encoding="utf-8")
+            with (
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+                patch("app.spotty_bunny_launch._terminate_pid") as terminate,
+            ):
+                self.assertTrue(stop_spotty_bunny(pid_dir=pid_dir))
+            terminate.assert_called_once_with(4242)
+            self.assertFalse(pid_path.exists())
 
     def test_placeholder_documents_examples(self) -> None:
         source = (

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -83,13 +83,19 @@ files together.
 
 ## Spotty Bunny (macOS)
 
-Foreground process (no login agent yet). Needs the optional `macos` extra
-(PyObjC):
+Needs the optional `macos` extra (PyObjC). Bare `spotty-bunny` still runs the
+overlay **in the foreground**. The login LaunchAgent is a distinct label from
+the server agent (`com.thehcma.bunnify`).
 
 ```bash
 # pipx
 pipx install 'bunnify[macos]'
-spotty-bunny
+spotty-bunny                     # foreground overlay
+bunnify spotty-bunny             # same (reserved CLI token)
+bunnify spotty-bunny install     # LaunchAgent (KeepAlive + RunAtLoad)
+bunnify spotty-bunny status
+bunnify spotty-bunny upgrade     # after `bunnify upgrade` (pipx)
+bunnify spotty-bunny uninstall
 
 # development checkout (wrapper syncs extra macos)
 ./scripts/spotty-bunny
@@ -102,33 +108,66 @@ spotty-bunny
 ./scripts/spotty-bunny --log-file /tmp/spotty-bunny.log --verbose
 ```
 
+`install` writes
+`~/Library/LaunchAgents/com.thehcma.bunnify.spotty-bunny.plist` from
+[`etc/launchd/com.thehcma.bunnify.spotty-bunny.plist.example`](https://github.com/the-hcma/bunnify/blob/main/etc/launchd/com.thehcma.bunnify.spotty-bunny.plist.example)
+with **ProgramArguments** set to the absolute path from `command -v spotty-bunny`,
+then `launchctl bootstrap "gui/$(id -u)"` that plist. It does **not** succeed
+until **Accessibility** and **Input Monitoring** are currently granted to the
+**interpreter launchd will exec** (typically the pipx venv Python in the
+`spotty-bunny` shebang), not only Terminal.app. Missing grants trigger the
+system prompts where the APIs allow it, then the checks run again. If either
+is still missing, the command prints System Settings → Privacy & Security
+instructions and exits non-zero without treating bootstrap as success.
+
+`status` prints running/pid, whether launchd has loaded the agent, the binary
+path, the application log
+(`~/.local/share/bunnify/spotty-bunny.log` or `BUNNIFY_SPOTTY_BUNNY_LOG_FILE` /
+`$BUNNIFY_DATA_DIR`), launchd stdout/stderr paths from the plist, version, and
+Accessibility / Input Monitoring yes/no. Exit `0` only when the plist exists,
+the agent is loaded, and the process is running.
+
+`upgrade` rewrites the plist if `command -v spotty-bunny` moved (pipx venv
+path / shebang), re-verifies TCC for that interpreter, and
+`launchctl kickstart -k "gui/$(id -u)/com.thehcma.bunnify.spotty-bunny"`.
+Package updates stay on `bunnify upgrade` (`pipx upgrade bunnify`); run that
+first, then `bunnify spotty-bunny upgrade` so launchd does not keep a stale
+binary path.
+
+`uninstall` boots the agent out, removes the plist, stops a leftover overlay
+process, and clears the pid file. It does not delete the application log.
+If the agent was never installed, it still succeeds.
+
 Hold **one** Control, then press the **other** to show the search box. Esc
 (or the same chord again) hides it. Up/down walks the CLI REPL history file
 (`platformdirs` cache `bunnify/repl_history`). Tab uses the same completers as
 the CLI (`FirstTokenFuzzyCompleter` / `ShortcutCompleter`) and lists matches
 under the field. Enter resolves via `/api/resolve/?strict=1` and opens the URL
 in the default browser (unknown keys stay in the panel with an error). Ctrl-C
-in that terminal quits. Startup prints the log file path on stderr
+in a foreground terminal quits. Startup prints the log file path on stderr
 (`spotty-bunny: logging to …`). Default log level is **INFO** (use `--verbose`
-for per-key tap debug).
+for per-key tap debug). Launchd stdout/stderr under `~/Library/Logs/` are
+separate from that application log.
 
 The search box is centered on the **main display** (menu-bar monitor), with a
 small bunny icon to the right of the field. Click the icon for version, commit, and
 project links (domesti-bot-style about panel).
 
-If the chord does nothing, run with `--verbose` and watch stderr. Lines
-named `tap …` show whether key events arrive. If none appear while you press
-keys, grant **Accessibility** and **Input Monitoring** to the Python that
-`uv run` uses (often `.venv/bin/python`), not only Terminal.app, in System
-Settings → Privacy & Security, then re-run. If events arrive but `fired=True`
-never appears, HID may still miss right Control (`hid R=False`); Spotty Bunny
-also uses device flag bits and the event keycode. Re-run `--verbose` after
-this fix.
+If the chord does nothing, run with `--verbose` and watch stderr (or the
+application log). Lines named `tap …` show whether key events arrive. If none
+appear while you press keys, grant **Accessibility** and **Input Monitoring**
+to the Python that `uv run` / pipx uses (often `.venv/bin/python` or the pipx
+venv interpreter), not only Terminal.app, in System Settings → Privacy &
+Security, then re-run. If events arrive but `fired=True` never appears, HID may
+still miss right Control (`hid R=False`); Spotty Bunny also uses device flag
+bits and the event keycode. Re-run `--verbose` after this fix.
 
 On macOS, starting the **`bunnify` interactive REPL** (no query args) also
 starts `spotty-bunny` in the background when it is not already running.
 
 ## macOS LaunchAgent
+
+The **server** agent is separate from Spotty Bunny.
 
 Copy `etc/launchd/com.thehcma.bunnify.plist.example` to
 `~/Library/LaunchAgents/com.thehcma.bunnify.plist`. Replace
@@ -147,6 +186,15 @@ launchctl bootout "gui/$(id -u)/com.thehcma.bunnify"
 The template runs the server in the foreground with `KeepAlive` enabled. Ensure
 `~/.config/bunnify/bookmarks.json` exists before loading the agent. Confirm that
 port 8000 is free unless you override `--port`.
+
+Prefer `bunnify spotty-bunny install` for the overlay agent instead of copying
+its example plist by hand. Manual `launchctl` for Spotty Bunny:
+
+```bash
+launchctl bootstrap "gui/$(id -u)" \
+  ~/Library/LaunchAgents/com.thehcma.bunnify.spotty-bunny.plist
+launchctl bootout "gui/$(id -u)/com.thehcma.bunnify.spotty-bunny"
+```
 
 ## Troubleshooting
 

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -128,8 +128,9 @@ Accessibility / Input Monitoring yes/no. Exit `0` only when the plist exists,
 the agent is loaded, and the process is running.
 
 `upgrade` rewrites the plist if `command -v spotty-bunny` moved (pipx venv
-path / shebang), re-verifies TCC for that interpreter, and
-`launchctl kickstart -k "gui/$(id -u)/com.thehcma.bunnify.spotty-bunny"`.
+path / shebang), re-verifies TCC for that interpreter, then reloads the agent
+with `launchctl bootout` and `launchctl bootstrap` so launchd picks up the new
+ProgramArguments.
 Package updates stay on `bunnify upgrade` (`pipx upgrade bunnify`); run that
 first, then `bunnify spotty-bunny upgrade` so launchd does not keep a stale
 binary path.

--- a/etc/launchd/com.thehcma.bunnify.spotty-bunny.plist.example
+++ b/etc/launchd/com.thehcma.bunnify.spotty-bunny.plist.example
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.thehcma.bunnify.spotty-bunny</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__SPOTTY_BUNNY__</string>
+  </array>
+
+  <key>KeepAlive</key>
+  <true/>
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/bunnify.spotty-bunny.err.log</string>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/bunnify.spotty-bunny.out.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- `bunnify spotty-bunny {install,uninstall,status,upgrade}` (same on the `spotty-bunny` entry point)
- LaunchAgent `com.thehcma.bunnify.spotty-bunny` with KeepAlive + RunAtLoad and absolute ProgramArguments
- install/upgrade require current Accessibility + Input Monitoring on the launchd interpreter
- Bare `spotty-bunny` remains the foreground overlay

Closes #307

## Test plan
- [ ] `spotty-bunny install` writes the plist and refuses without TCC
- [ ] `status` shows pid, launchd, log path, version, TCC
- [ ] `upgrade` rewrites ProgramArguments after a binary path change
- [ ] `uninstall` bootout + plist + pid clear
- [ ] Bare `spotty-bunny` still runs in the foreground
- [x] Local tests / pre-pr-checks

Co-authored-by: Cursor <cursoragent@cursor.com>