### PR TITLE
feat: Spotty Bunny about links, logo menu, and update check

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -40,6 +40,25 @@ bunnify spotty-bunny upgrade    # refresh agent after `bunnify upgrade`
 bunnify spotty-bunny uninstall
 ```
 
+## Spotty Bunny (macOS)
+
+Requires `pipx install 'bunnify[macos]'`. Hold one Control, tap the other.
+
+```bash
+bunnify spotty-bunny install     # login LaunchAgent (TCC + KeepAlive)
+bunnify spotty-bunny status
+bunnify upgrade && bunnify spotty-bunny upgrade
+bunnify spotty-bunny uninstall
+spotty-bunny                     # foreground (debug)
+```
+
+Left-click the bunny for About (bookmarks file, GitHub repo if that file is in
+a GitHub checkout, local vs remote server + URL, update available). Right-click
+for **Quit**, **Uninstall**, and **Upgrade** (Upgrade only when PyPI is newer).
+An up-arrow badge on the bunny means this install is behind PyPI.
+
+Details: [docs/LOCAL.md](docs/LOCAL.md)
+
 ## Server
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Summary of what it covers:
 3. **Chrome / Edge** — match `BUNNIFY_BASE_URL` from `config.env`  
    [CHROME_SETUP.md](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md)
 4. **Try it:** `bunnify gh` or address-bar keyword (e.g. `b gh`)
+5. **macOS Spotty Bunny** (optional) — `pipx install 'bunnify[macos]'` then
+   `bunnify spotty-bunny install`
+   ([LOCAL.md](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md))
 
 ### Upgrade
 
@@ -136,12 +139,63 @@ Unknown keys exit non-zero in direct mode (no search-engine fallback).
 ## Features
 
 - **CLI / REPL** — fuzzy Tab completion, fzf mode, Vim/Emacs edit keys
-- **Spotty Bunny** — dual-Control search box (`spotty-bunny`; extra `macos`; `install` LaunchAgent)
+- **Spotty Bunny** — dual-Control search box (`spotty-bunny`; extra `macos`;
+  login LaunchAgent via `install` / `upgrade` / `uninstall`)
 - **Web** — `/cmd/` command palette, `/list/` browser, smart `/search/`
 - **Chrome / Edge** — OpenSearch at `/opensearch.xml`
   ([setup guide](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md))
 - **Parameters** — URLs with `#{name}` placeholders and optional defaults
 - **Validation** — JSON Schema on load; reserved keys `h` / `help`
+
+## Spotty Bunny (macOS)
+
+Optional Spotlight-style search box. Hold one Control and tap the other to
+type a shortcut. Needs the `macos` extra (PyObjC).
+
+### Install
+
+```bash
+pipx install 'bunnify[macos]'
+pipx ensurepath
+bunnify spotty-bunny install    # login LaunchAgent (TCC + KeepAlive)
+bunnify spotty-bunny status
+```
+
+`install` grants Accessibility and Input Monitoring to the **interpreter
+launchd will exec** (typically the pipx venv Python), writes
+`~/Library/LaunchAgents/com.thehcma.bunnify.spotty-bunny.plist`, and bootstraps
+it. Bare `spotty-bunny` (or `bunnify spotty-bunny` with no subcommand) still
+runs in the **foreground** for debugging.
+
+### Upgrade
+
+```bash
+bunnify upgrade                 # pipx package
+bunnify spotty-bunny upgrade    # refresh the LaunchAgent binary path
+```
+
+Run `upgrade` after `bunnify upgrade` so launchd does not keep a stale
+`ProgramArguments` path.
+
+### Uninstall
+
+```bash
+bunnify spotty-bunny uninstall
+```
+
+That boots the agent out, removes the plist, and stops a leftover overlay
+process. Bookmarks and `config.env` are unchanged. Right-click the bunny icon
+for **Quit Spotty Bunny**, **Uninstall Spotty Bunny**, and (when a newer
+PyPI version is known) **Upgrade Spotty Bunny**. An up-arrow badge on the
+icon and an About line mark an outdated install (PyPI is checked at most
+once a day).
+
+Left-click the bunny for About: bookmarks file, GitHub repo when that file
+lives in a GitHub checkout, and whether the CLI is talking to a local or
+remote server (with its URL).
+
+Details:
+[Local and remote setup](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md).
 
 ## Server lifecycle
 
@@ -236,7 +290,7 @@ the checkout `.venv` (same entry points systemd uses on service hosts).
 | Doc | Audience |
 |-----|----------|
 | [CONFIG.md](https://github.com/the-hcma/bunnify/blob/main/docs/CONFIG.md) | XDG paths and environment variables |
-| [LOCAL.md](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md) | Local vs remote setup, ports, LaunchAgent |
+| [LOCAL.md](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md) | Local vs remote setup, ports, Spotty Bunny |
 | [SYSTEMD.md](https://github.com/the-hcma/bunnify/blob/main/docs/SYSTEMD.md) | Linux user service |
 | [CHROME_SETUP.md](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md) | Browser search engine |
 | [QUICK_REFERENCE.md](https://github.com/the-hcma/bunnify/blob/main/QUICK_REFERENCE.md) | Cheat sheet |

--- a/app/cli.py
+++ b/app/cli.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import subprocess
 import sys
-import urllib.error
-import urllib.request
 import webbrowser
 from collections.abc import Callable
 from pathlib import Path
@@ -60,6 +57,7 @@ from app.interactive import (
     repl_prompt_message,
 )
 from app.local_server import ensure_local_server, port_is_free, stop_local_server
+from app.pypi import pypi_latest_version as _pypi_latest_version
 from app.theme import Theme, stdout_color_enabled
 from app.usage import format_key_usage_lines
 from app.version import (
@@ -216,6 +214,14 @@ def format_onboarding_text() -> str:
             "   Guide: https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md",
             "",
             "4. Try it:  bunnify gh   (or address-bar keyword, e.g. b gh)",
+            "",
+            "5. macOS Spotty Bunny (optional search box):",
+            "     pipx install 'bunnify[macos]'   # if the extra is not installed",
+            "     bunnify spotty-bunny install    # login LaunchAgent",
+            "     bunnify spotty-bunny status",
+            "     bunnify upgrade && bunnify spotty-bunny upgrade",
+            "     bunnify spotty-bunny uninstall",
+            "   Guide: https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md",
             "",
             "Upgrade later (preferred):",
             "     bunnify upgrade   # shows from/to versions, then pipx upgrade",
@@ -699,26 +705,6 @@ def _pipx_bunnify_path() -> Path | None:
             except OSError:
                 return candidate
     return None
-
-
-def _pypi_latest_version() -> str | None:
-    """Return the latest bunnify version on PyPI, or None on failure."""
-    try:
-        with urllib.request.urlopen(
-            "https://pypi.org/pypi/bunnify/json",
-            timeout=8,
-        ) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except (
-        OSError,
-        TimeoutError,
-        ValueError,
-        json.JSONDecodeError,
-        urllib.error.URLError,
-    ):
-        return None
-    version = payload.get("info", {}).get("version")
-    return version if isinstance(version, str) and version else None
 
 
 def _prompt_local_port(
@@ -1373,6 +1359,8 @@ def main(
       bunnify spotty-bunny
       bunnify spotty-bunny install
       bunnify spotty-bunny status
+      bunnify spotty-bunny upgrade
+      bunnify spotty-bunny uninstall
       ./scripts/spotty-bunny
       ./scripts/spotty-bunny --verbose
 

--- a/app/pypi.py
+++ b/app/pypi.py
@@ -1,0 +1,32 @@
+"""Latest bunnify version on PyPI."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+PYPI_JSON_URL = "https://pypi.org/pypi/bunnify/json"
+PYPI_TIMEOUT_S = 8
+
+UrlOpen = Callable[..., Any]
+
+
+def pypi_latest_version(*, urlopen: UrlOpen | None = None) -> str | None:
+    """Return the latest bunnify version on PyPI, or None on failure."""
+    opener = urllib.request.urlopen if urlopen is None else urlopen
+    try:
+        with opener(PYPI_JSON_URL, timeout=PYPI_TIMEOUT_S) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (
+        OSError,
+        TimeoutError,
+        ValueError,
+        json.JSONDecodeError,
+        urllib.error.URLError,
+    ):
+        return None
+    version = payload.get("info", {}).get("version")
+    return version if isinstance(version, str) and version else None

--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -37,7 +37,9 @@ from Cocoa import (
 )
 from Foundation import NSAttributedString, NSMakeRange, NSMutableAttributedString
 
+from app.spotty_bunny_about_info import load_about_runtime_info
 from app.spotty_bunny_hotkey import ESCAPE_KEYCODE
+from app.spotty_bunny_update import UpdateStatus, read_cached_update_status
 from app.version import get_build_info
 
 ABOUT_BORDER_WIDTH = 2.0
@@ -62,6 +64,7 @@ ABOUT_SUMMARY = (
     "(Tab completes, like the CLI), and press Return to open it in your browser. "
     "Esc hides the box."
 )
+ABOUT_WARN_RGB = (0.62, 0.28, 0.08)
 SPOTTY_BUNNY_REPO_URL = "https://github.com/the-hcma/bunnify"
 
 
@@ -116,19 +119,38 @@ def apply_spotty_chrome(
     layer.setBorderWidth_(ABOUT_BORDER_WIDTH)
 
 
-def build_about_panel() -> NSPanel:
+def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
     """Return a small floating panel with version and project links."""
     title_font = NSFont.boldSystemFontOfSize_(16.0)
     body_font = NSFont.systemFontOfSize_(13.0)
     package_version, commit = get_build_info()
+    runtime = load_about_runtime_info()
+    status = update if update is not None else read_cached_update_status()
     version_text = f"Version {package_version} · commit {commit}"
+    update_text = (
+        None
+        if not status.outdated or not status.latest
+        else f"Update available: {status.latest}"
+    )
     repo_text = "github.com/the-hcma/bunnify"
+    bookmarks_text = f"Bookmarks: {runtime.bookmarks_display}"
+    github_text = (
+        None if runtime.github_display is None else f"GitHub: {runtime.github_display}"
+    )
     inner_cap = ABOUT_PANEL_MAX_WIDTH - 2.0 * ABOUT_INSET
     needed_width = max(
-        _measure_text(ABOUT_COPYRIGHT, body_font, max_width=inner_cap)[0],
-        _measure_text(version_text, body_font, max_width=inner_cap)[0],
-        _measure_text(repo_text, body_font, max_width=inner_cap)[0],
         _measure_text("Spotty Bunny", title_font, max_width=inner_cap)[0],
+        _measure_text(ABOUT_COPYRIGHT, body_font, max_width=inner_cap)[0],
+        _measure_text(bookmarks_text, body_font, max_width=inner_cap)[0],
+        _measure_text(repo_text, body_font, max_width=inner_cap)[0],
+        _measure_text(runtime.server_display, body_font, max_width=inner_cap)[0],
+        _measure_text(version_text, body_font, max_width=inner_cap)[0],
+        0.0
+        if github_text is None
+        else _measure_text(github_text, body_font, max_width=inner_cap)[0],
+        0.0
+        if update_text is None
+        else _measure_text(update_text, body_font, max_width=inner_cap)[0],
     )
     width = min(
         ABOUT_PANEL_MAX_WIDTH,
@@ -142,6 +164,23 @@ def build_about_panel() -> NSPanel:
     summary_height = max(
         36.0,
         _measure_text(ABOUT_SUMMARY, body_font, max_width=inner)[1] + ABOUT_CELL_PAD,
+    )
+    bookmarks_height = max(
+        18.0,
+        _measure_text(bookmarks_text, body_font, max_width=inner)[1] + ABOUT_CELL_PAD,
+    )
+    github_height = (
+        0.0
+        if github_text is None
+        else max(
+            18.0,
+            _measure_text(github_text, body_font, max_width=inner)[1] + ABOUT_CELL_PAD,
+        )
+    )
+    server_height = max(
+        18.0,
+        _measure_text(runtime.server_display, body_font, max_width=inner)[1]
+        + ABOUT_CELL_PAD,
     )
     rows: list[tuple[float, Callable[[float, float], NSTextField]]] = [
         (
@@ -168,34 +207,89 @@ def build_about_panel() -> NSPanel:
                 color=_srgb_color(ABOUT_MUTED_RGB),
             ),
         ),
-        (
-            copy_height,
-            lambda y, h: _link_field(
-                NSMakeRect(ABOUT_INSET, y, inner, h),
-                ABOUT_COPYRIGHT,
-                ABOUT_GITHUB_HANDLE,
-                ABOUT_GITHUB_PROFILE_URL,
-            ),
-        ),
-        (
-            18.0,
-            lambda y, h: _link_field(
-                NSMakeRect(ABOUT_INSET, y, inner, h),
-                ABOUT_LICENSE,
-                ABOUT_LICENSE,
-                ABOUT_LICENSE_URL,
-            ),
-        ),
-        (
-            18.0,
-            lambda y, h: _link_field(
-                NSMakeRect(ABOUT_INSET, y, inner, h),
-                repo_text,
-                repo_text,
-                SPOTTY_BUNNY_REPO_URL,
-            ),
-        ),
     ]
+    if update_text is not None:
+        notice = update_text
+        rows.append(
+            (
+                18.0,
+                lambda y, h: _label(
+                    NSMakeRect(ABOUT_INSET, y, inner, h),
+                    notice,
+                    color=_srgb_color(ABOUT_WARN_RGB),
+                ),
+            )
+        )
+    rows.extend(
+        [
+            (
+                copy_height,
+                lambda y, h: _link_field(
+                    NSMakeRect(ABOUT_INSET, y, inner, h),
+                    ABOUT_COPYRIGHT,
+                    ABOUT_GITHUB_HANDLE,
+                    ABOUT_GITHUB_PROFILE_URL,
+                ),
+            ),
+            (
+                18.0,
+                lambda y, h: _link_field(
+                    NSMakeRect(ABOUT_INSET, y, inner, h),
+                    ABOUT_LICENSE,
+                    ABOUT_LICENSE,
+                    ABOUT_LICENSE_URL,
+                ),
+            ),
+            (
+                18.0,
+                lambda y, h: _link_field(
+                    NSMakeRect(ABOUT_INSET, y, inner, h),
+                    repo_text,
+                    repo_text,
+                    SPOTTY_BUNNY_REPO_URL,
+                ),
+            ),
+            (
+                bookmarks_height,
+                lambda y, h: _link_field(
+                    NSMakeRect(ABOUT_INSET, y, inner, h),
+                    bookmarks_text,
+                    runtime.bookmarks_display,
+                    runtime.bookmarks_uri,
+                ),
+            ),
+        ]
+    )
+    if (
+        github_text is not None
+        and runtime.github_display is not None
+        and runtime.github_url is not None
+    ):
+        github_label = github_text
+        github_link = runtime.github_display
+        github_href = runtime.github_url
+        rows.append(
+            (
+                github_height,
+                lambda y, h: _link_field(
+                    NSMakeRect(ABOUT_INSET, y, inner, h),
+                    github_label,
+                    github_link,
+                    github_href,
+                ),
+            )
+        )
+    rows.append(
+        (
+            server_height,
+            lambda y, h: _link_field(
+                NSMakeRect(ABOUT_INSET, y, inner, h),
+                runtime.server_display,
+                runtime.server_url,
+                runtime.server_url,
+            ),
+        )
+    )
     gap = 8.0
     height = ABOUT_INSET * 2.0 + sum(row_h for row_h, _ in rows) + gap * (len(rows) - 1)
 

--- a/app/spotty_bunny_about_info.py
+++ b/app/spotty_bunny_about_info.py
@@ -1,0 +1,166 @@
+"""Cocoa-free About panel facts: bookmarks path, GitHub remote, server mode."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from urllib.parse import urlparse
+
+from app.config import (
+    default_bookmarks_path,
+    load_preferences,
+    resolve_base_url,
+)
+
+
+@dataclass(frozen=True)
+class AboutRuntimeInfo:
+    """Bookmarks, optional GitHub remote, and local/remote server for About."""
+
+    bookmarks_display: str
+    bookmarks_uri: str
+    github_display: str | None
+    github_url: str | None
+    server_display: str
+    server_url: str
+
+
+OriginUrlFor = Callable[[Path], str | None]
+
+
+def display_user_path(path: Path) -> str:
+    """Return *path* with the home directory replaced by ``~`` when possible."""
+    expanded = path.expanduser()
+    home = Path.home()
+    if expanded == home:
+        return "~"
+    try:
+        return f"~/{expanded.relative_to(home)}"
+    except ValueError:
+        return str(expanded)
+
+
+def github_https_url(remote: str) -> str | None:
+    """Return ``https://github.com/owner/repo`` when *remote* points at GitHub."""
+    raw = remote.strip()
+    if raw.endswith(".git"):
+        raw = raw[: -len(".git")]
+    raw = raw.rstrip("/")
+    patterns = (
+        re.compile(r"^git@github\.com:([^/]+)/(.+)$"),
+        re.compile(r"^git://github\.com/([^/]+)/(.+)$"),
+        re.compile(r"^https?://(?:www\.)?github\.com/([^/]+)/(.+)$"),
+        re.compile(r"^ssh://(?:git@)?github\.com/([^/]+)/(.+)$"),
+    )
+    for pattern in patterns:
+        match = pattern.match(raw)
+        if match is None:
+            continue
+        owner, rest = match.group(1), match.group(2)
+        repo = rest.split("/", maxsplit=1)[0]
+        if not owner or not repo:
+            return None
+        return f"https://github.com/{owner}/{repo}"
+    return None
+
+
+def github_repo_url_for_path(
+    path: Path,
+    *,
+    origin_url_for: OriginUrlFor | None = None,
+) -> str | None:
+    """Return the GitHub HTTPS URL for the git checkout that contains *path*."""
+    workdir = _workdir_containing_git(path)
+    if workdir is None:
+        return None
+    reader = origin_url_for if origin_url_for is not None else _git_origin_url
+    remote = reader(workdir)
+    if not remote:
+        return None
+    return github_https_url(remote)
+
+
+def load_about_runtime_info(
+    *,
+    bookmarks_path: Path | None = None,
+    environ: dict[str, str] | None = None,
+    origin_url_for: OriginUrlFor | None = None,
+) -> AboutRuntimeInfo:
+    """Resolve bookmarks, GitHub, and server rows from config (no Cocoa)."""
+    path = (
+        bookmarks_path
+        if bookmarks_path is not None
+        else default_bookmarks_path(environ=environ)
+    )
+    expanded = path.expanduser()
+    bookmarks_uri = expanded.resolve(strict=False).as_uri()
+    github_url = github_repo_url_for_path(expanded, origin_url_for=origin_url_for)
+    github_display = None
+    if github_url is not None:
+        github_display = github_url.removeprefix("https://")
+    prefs = load_preferences(environ=environ)
+    mode: Literal["local", "remote"] | None = None
+    base_url = ""
+    if prefs is not None:
+        mode = prefs.mode
+        base_url = prefs.base_url
+    if not base_url:
+        base_url = resolve_base_url(
+            environ=environ,
+            persist=False,
+            allow_prompt=False,
+        )
+    if mode is None:
+        mode = "local" if _is_loopback_url(base_url) else "remote"
+    label = "Local server" if mode == "local" else "Remote server"
+    return AboutRuntimeInfo(
+        bookmarks_display=display_user_path(path),
+        bookmarks_uri=bookmarks_uri,
+        github_display=github_display,
+        github_url=github_url,
+        server_display=f"{label} · {base_url}",
+        server_url=base_url,
+    )
+
+
+_GIT_REMOTE_TIMEOUT_S = 2
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def _git_origin_url(workdir: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(workdir), "remote", "get-url", "origin"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=_GIT_REMOTE_TIMEOUT_S,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip() or None
+
+
+def _is_loopback_url(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    return host in _LOOPBACK_HOSTS
+
+
+def _workdir_containing_git(path: Path) -> Path | None:
+    current = path.expanduser()
+    try:
+        current = current.resolve(strict=False)
+    except OSError, RuntimeError:
+        pass
+    if not current.is_dir():
+        current = current.parent
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -70,6 +70,21 @@ def agent_plist_path(*, home: Path | None = None) -> Path:
     return root / "Library" / "LaunchAgents" / AGENT_PLIST_NAME
 
 
+def bootout_loaded_agent(
+    *,
+    launchctl: LaunchctlFn | None = None,
+    uid: int | None = None,
+) -> bool:
+    """Unload the LaunchAgent when loaded so KeepAlive cannot respawn.
+
+    Returns True when a bootout was issued.
+    """
+    if not is_agent_loaded(launchctl=launchctl, uid=uid):
+        return False
+    _bootout_agent(launchctl=launchctl, uid=uid)
+    return True
+
+
 def format_agent_plist(*, home: Path, program_arguments: Sequence[str]) -> str:
     """Return the LaunchAgent plist for *program_arguments* and *home*."""
     args_xml = "\n".join(

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -174,6 +174,40 @@ def is_agent_loaded(
     return completed.returncode == 0
 
 
+def refresh_agent_plist(
+    *,
+    home: Path | None = None,
+    platform: str | None = None,
+    print_err: Callable[[str], None] | None = None,
+    program: Path | None = None,
+) -> int:
+    """Rewrite the LaunchAgent plist for this binary without bouncing launchd."""
+    err = print_err or _print_err
+    if not _is_darwin(platform):
+        err(NOT_MACOS_MESSAGE)
+        return 1
+    root = home if home is not None else Path.home()
+    plist = agent_plist_path(home=root)
+    if not plist.is_file():
+        err(
+            f"{COMMAND_NAME}: LaunchAgent is not installed. Run: {COMMAND_NAME} install"
+        )
+        return 1
+    binary = program if program is not None else spotty_bunny_program()
+    program_argv = (
+        [str(program.resolve())]
+        if program is not None
+        else spotty_bunny_program_arguments()
+    )
+    if program_argv is None or binary is None:
+        err(f"{COMMAND_NAME}: could not find the spotty-bunny binary on PATH.")
+        return 1
+    _write_plist(plist, home=root, program_arguments=program_argv)
+    err(f"{COMMAND_NAME}: refreshed LaunchAgent plist {plist}")
+    err(f"{COMMAND_NAME}: binary {binary}")
+    return 0
+
+
 def run_agent_command(
     command: str,
     rest: Sequence[str] = (),
@@ -282,16 +316,18 @@ def uninstall_agent(
     platform: str | None = None,
     print_err: Callable[[str], None] | None = None,
 ) -> int:
-    """Boot out the agent, remove the plist, stop the process, clear the pid."""
+    """Remove the plist, then boot out, stop leftovers, and clear the pid."""
     err = print_err or _print_err
     if not _is_darwin(platform):
         err(NOT_MACOS_MESSAGE)
         return 1
     root = home if home is not None else Path.home()
     plist = agent_plist_path(home=root)
-    if plist.is_file() or is_agent_loaded(launchctl=launchctl):
-        _bootout_agent(launchctl=launchctl)
+    loaded = is_agent_loaded(launchctl=launchctl)
+    # Unlink first so an in-process bootout cannot leave the plist behind.
     plist.unlink(missing_ok=True)
+    if loaded:
+        _bootout_agent(launchctl=launchctl)
     stop_spotty_bunny(pid_dir=pid_dir)
     clear_spotty_bunny_pid(pid_dir=pid_dir)
     err(f"{COMMAND_NAME}: uninstalled LaunchAgent {AGENT_LABEL}")

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -105,8 +105,8 @@ from app.spotty_bunny_about import (
 )
 from app.spotty_bunny_agent import (
     bootout_loaded_agent,
+    refresh_agent_plist,
     uninstall_agent,
-    upgrade_agent,
 )
 from app.spotty_bunny_cli import SpottyBunnyEventTapError
 from app.spotty_bunny_complete import (
@@ -378,7 +378,7 @@ class SpottyBunnyController(NSObject):
         quit_ns_app(ns_app=NSApp, post_wake=_post_wake_event)
 
     def upgradeSpottyBunny_(self, _sender) -> None:
-        """Upgrade the pipx install, refresh the agent, then quit to relaunch."""
+        """Upgrade via pipx, rewrite the plist, then quit so KeepAlive relaunches."""
         logger.info("upgrade from logo menu")
         self._set_status(UPGRADE_STATUS)
         self._io.submit(self._perform_upgrade, self._upgrade_ready)
@@ -719,7 +719,8 @@ class SpottyBunnyController(NSObject):
         from app.cli import run_upgrade
 
         run_upgrade(print_fn=lambda message: logger.info("%s", message))
-        upgrade_agent()
+        if refresh_agent_plist() != 0:
+            raise RuntimeError("LaunchAgent plist refresh failed")
 
     def _present_about_panel(self) -> None:
         if self._about_panel is not None:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -10,6 +10,9 @@ import sys
 
 import objc
 from Cocoa import (
+    NSAlert,
+    NSAlertFirstButtonReturn,
+    NSAlertStyleWarning,
     NSApp,
     NSApplication,
     NSApplicationActivationPolicyAccessory,
@@ -30,6 +33,8 @@ from Cocoa import (
     NSLineBreakByWordWrapping,
     NSMakeRect,
     NSMakeSize,
+    NSMenu,
+    NSMenuItem,
     NSMutableParagraphStyle,
     NSObject,
     NSPanel,
@@ -98,6 +103,11 @@ from app.spotty_bunny_about import (
     build_about_panel,
     position_about_panel,
 )
+from app.spotty_bunny_agent import (
+    bootout_loaded_agent,
+    uninstall_agent,
+    upgrade_agent,
+)
 from app.spotty_bunny_cli import SpottyBunnyEventTapError
 from app.spotty_bunny_complete import (
     CompletionRow,
@@ -125,6 +135,12 @@ from app.spotty_bunny_hotkey import (
 )
 from app.spotty_bunny_icon import make_spotty_bunny_icon
 from app.spotty_bunny_io import ThreadIo
+from app.spotty_bunny_menu import (
+    UNINSTALL_INFORMATIVE,
+    UNINSTALL_MENU_TITLE,
+    UPGRADE_STATUS,
+    logo_menu_specs,
+)
 from app.spotty_bunny_quit import (
     WAKE_EVENT_SELECTOR,
     post_application_wake_event,
@@ -137,6 +153,12 @@ from app.spotty_bunny_status import (
     format_spotty_bunny_status,
     status_text_runs,
     wrap_status_preferring_punctuation,
+)
+from app.spotty_bunny_update import (
+    UpdateStatus,
+    cache_is_stale,
+    read_cached_update_status,
+    refresh_update_status,
 )
 from app.version import get_build_info
 
@@ -262,9 +284,12 @@ class SpottyBunnyController(NSObject):
         self._escape_held = False
         self._history = HistoryNavigator()
         self._io = ThreadIo()
+        self._logo_menu = None
         self._resolve_seq = 0
         self._resolving = False
         self._shortcuts_load_failed = False
+        self._update_check_pending = False
+        self._update_status = read_cached_update_status()
         self.callback = None
         self.chord = ChordTracker()
         self.field = None
@@ -277,11 +302,22 @@ class SpottyBunnyController(NSObject):
         self.tap = None
         self.visible = False
         self._build_panel()
+        self._apply_update_status()
         self._io.submit(get_build_info, lambda _result: None)
+        self._schedule_update_check()
         return self
+
+    def menuNeedsUpdate_(self, menu) -> None:
+        self._rebuild_logo_menu(menu)
 
     def numberOfRowsInTableView_(self, _table) -> int:
         return len(self._completion_rows)
+
+    def quitSpottyBunny_(self, _sender) -> None:
+        """Stop this process; boot out the LaunchAgent so KeepAlive cannot respawn."""
+        logger.info("quit from logo menu")
+        bootout_loaded_agent()
+        quit_ns_app(ns_app=NSApp, post_wake=_post_wake_event)
 
     def releaseEscape_(self, _sender) -> None:
         """Arm the next Esc after the key-up of a tap or field-editor dismiss."""
@@ -312,6 +348,8 @@ class SpottyBunnyController(NSObject):
             self.panel.makeFirstResponder_(self.field)
             self._paint_search_editor()
         self._io.submit(self._load_completer, self._completer_loaded)
+        if cache_is_stale(self._update_status.checked_at):
+            self._schedule_update_check()
 
     def tableView_objectValueForTableColumn_row_(self, _table, column, row: int):
         if row < 0 or row >= len(self._completion_rows):
@@ -331,6 +369,20 @@ class SpottyBunnyController(NSObject):
         else:
             self.show()
 
+    def uninstallSpottyBunny_(self, _sender) -> None:
+        """Confirm, remove the LaunchAgent, and quit this process."""
+        if not _confirm_uninstall():
+            return
+        logger.info("uninstall from logo menu")
+        uninstall_agent()
+        quit_ns_app(ns_app=NSApp, post_wake=_post_wake_event)
+
+    def upgradeSpottyBunny_(self, _sender) -> None:
+        """Upgrade the pipx install, refresh the agent, then quit to relaunch."""
+        logger.info("upgrade from logo menu")
+        self._set_status(UPGRADE_STATUS)
+        self._io.submit(self._perform_upgrade, self._upgrade_ready)
+
     def windowDidBecomeKey_(self, _notification) -> None:
         logger.debug("windowDidBecomeKey")
         self._became_key = True
@@ -349,6 +401,15 @@ class SpottyBunnyController(NSObject):
         resigning = notification.object()
         if resigning is self.panel and self._became_key:
             self.hide()
+
+    def _apply_update_status(self) -> None:
+        outdated = self._update_status.outdated
+        if self.logo is not None:
+            self.logo.setImage_(make_spotty_bunny_icon(LOGO_SIZE, outdated=outdated))
+        if self._logo_menu is not None:
+            self._rebuild_logo_menu(self._logo_menu)
+        if self._about_open:
+            self._present_about_panel()
 
     def _build_panel(self) -> None:
         style = NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
@@ -382,7 +443,7 @@ class SpottyBunnyController(NSObject):
         )
         panel.setContentView_(chrome)
 
-        logo = NSButton.alloc().initWithFrame_(
+        logo = SpottyBunnyLogoButton.alloc().initWithFrame_(
             NSMakeRect(
                 LOGO_LEFT,
                 PANEL_INSET + (FIELD_HEIGHT - LOGO_SIZE) / 2.0,
@@ -392,10 +453,17 @@ class SpottyBunnyController(NSObject):
         )
         logo.setBezelStyle_(NSBezelStyleShadowlessSquare)
         logo.setBordered_(False)
-        logo.setImage_(make_spotty_bunny_icon(LOGO_SIZE))
+        logo.setImage_(
+            make_spotty_bunny_icon(LOGO_SIZE, outdated=self._update_status.outdated)
+        )
         logo.setImageScaling_(NSImageScaleProportionallyUpOrDown)
         logo.setTarget_(self)
         logo.setAction_("showAbout:")
+        menu = NSMenu.alloc().initWithTitle_("")
+        menu.setDelegate_(self)
+        self._logo_menu = menu
+        self._rebuild_logo_menu(menu)
+        logo.setMenu_(menu)
         panel.contentView().addSubview_(logo)
 
         field = NSTextField.alloc().initWithFrame_(
@@ -555,17 +623,10 @@ class SpottyBunnyController(NSObject):
         self._about_open = False
 
     def _toggle_about_panel(self) -> None:
-        if self._about_panel is None:
-            self._about_panel = build_about_panel()
-            self._about_panel.setDelegate_(self)
         if self._about_open:
             self.hideAbout_(None)
             return
-        if self.panel is not None:
-            position_about_panel(self._about_panel, anchor_frame=self.panel.frame())
-        self._about_open = True
-        self._about_panel.orderFrontRegardless()
-        self._about_panel.makeKeyAndOrderFront_(None)
+        self._present_about_panel()
 
     def _hide_completions(self) -> None:
         self._completion_seq += 1
@@ -654,6 +715,37 @@ class SpottyBunnyController(NSObject):
         if container is not None:
             container.setLineFragmentPadding_(0.0)
 
+    def _perform_upgrade(self) -> None:
+        from app.cli import run_upgrade
+
+        run_upgrade(print_fn=lambda message: logger.info("%s", message))
+        upgrade_agent()
+
+    def _present_about_panel(self) -> None:
+        if self._about_panel is not None:
+            self._about_panel.setDelegate_(None)
+            self._about_panel.orderOut_(None)
+            self._about_panel.close()
+            self._about_panel = None
+        self._about_panel = build_about_panel(update=self._update_status)
+        self._about_panel.setDelegate_(self)
+        if self.panel is not None:
+            position_about_panel(self._about_panel, anchor_frame=self.panel.frame())
+        self._about_open = True
+        self._about_panel.orderFrontRegardless()
+        self._about_panel.makeKeyAndOrderFront_(None)
+
+    def _rebuild_logo_menu(self, menu) -> None:
+        menu.removeAllItems()
+        for title, action in logo_menu_specs(outdated=self._update_status.outdated):
+            item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+                title,
+                action,
+                "",
+            )
+            item.setTarget_(self)
+            menu.addItem_(item)
+
     def _request_completions(self) -> None:
         if self._completer is None or self.field is None:
             logger.warning("tab ignored (completer not ready)")
@@ -741,6 +833,12 @@ class SpottyBunnyController(NSObject):
                 )
             )
         self._center_panel()
+
+    def _schedule_update_check(self) -> None:
+        if self._update_check_pending:
+            return
+        self._update_check_pending = True
+        self._io.submit(refresh_update_status, self._update_check_ready)
 
     def _show_completions(self, rows: list[CompletionRow]) -> None:
         self._completion_rows = rows
@@ -862,6 +960,40 @@ class SpottyBunnyController(NSObject):
             return url
 
         self._io.submit(work, lambda result: self._resolve_ready(result, seq=seq))
+
+    def _update_check_ready(self, result: object) -> None:
+        def apply() -> None:
+            self._update_check_pending = False
+            if isinstance(result, Exception):
+                logger.warning("PyPI version check failed: %s", result)
+                return
+            if isinstance(result, UpdateStatus):
+                self._update_status = result
+                self._apply_update_status()
+
+        _run_on_main(apply)
+
+    def _upgrade_ready(self, result: object) -> None:
+        def apply() -> None:
+            if isinstance(result, Exception):
+                logger.warning("upgrade failed: %s", result)
+                self._set_status(format_spotty_bunny_status(result))
+                return
+            logger.info("upgrade finished; quitting for relaunch")
+            quit_ns_app(ns_app=NSApp, post_wake=_post_wake_event)
+
+        _run_on_main(apply)
+
+
+class SpottyBunnyLogoButton(NSButton):
+    """Bunny icon: left-click About; right-click Quit / Uninstall / Upgrade."""
+
+    def rightMouseDown_(self, event) -> None:
+        menu = self.menu()
+        if menu is None:
+            objc.super(SpottyBunnyLogoButton, self).rightMouseDown_(event)
+            return
+        NSMenu.popUpContextMenu_withEvent_forView_(menu, event, self)
 
 
 class SpottyBunnyPanel(NSPanel):
@@ -1039,6 +1171,17 @@ class _CenteredWrappingFieldCell(NSTextFieldCell):
             rect.size.width,
             text_height,
         )
+
+
+def _confirm_uninstall() -> bool:
+    """Ask before removing the LaunchAgent. Uninstall is the first button."""
+    alert = NSAlert.alloc().init()
+    alert.setAlertStyle_(NSAlertStyleWarning)
+    alert.setMessageText_(UNINSTALL_MENU_TITLE)
+    alert.setInformativeText_(UNINSTALL_INFORMATIVE)
+    alert.addButtonWithTitle_(UNINSTALL_MENU_TITLE)
+    alert.addButtonWithTitle_("Cancel")
+    return int(alert.runModal()) == int(NSAlertFirstButtonReturn)
 
 
 def _control_key_down(keycode: int) -> bool:

--- a/app/spotty_bunny_icon.py
+++ b/app/spotty_bunny_icon.py
@@ -24,7 +24,7 @@ def _spot(center_x: float, center_y: float, radius: float, color: NSColor) -> No
     spot.fill()
 
 
-def make_spotty_bunny_icon(size: float) -> NSImage:
+def make_spotty_bunny_icon(size: float, *, outdated: bool = False) -> NSImage:
     """Return a spotty bunny face icon at *size*×*size* points."""
     side = float(size)
     image = NSImage.alloc().initWithSize_(NSMakeSize(side, side))
@@ -107,7 +107,29 @@ def make_spotty_bunny_icon(size: float) -> NSImage:
             stroke.set()
             tooth.setLineWidth_(0.8)
             tooth.stroke()
+
+        if outdated:
+            _outdated_badge(side)
     finally:
         image.unlockFocus()
     image.setSize_(NSMakeSize(side, side))
     return image
+
+
+def _outdated_badge(side: float) -> None:
+    """Draw a small up-arrow badge in the top-right (update available)."""
+    radius = side * 0.14
+    center_x = side - radius - 1.0
+    center_y = side - radius - 1.0
+    badge = NSBezierPath.bezierPathWithOvalInRect_(
+        NSMakeRect(center_x - radius, center_y - radius, radius * 2.0, radius * 2.0)
+    )
+    _rgba(0.92, 0.45, 0.12).setFill()
+    badge.fill()
+    _rgba(1.0, 1.0, 1.0).setFill()
+    arrow = NSBezierPath.bezierPath()
+    arrow.moveToPoint_((center_x, center_y + radius * 0.45))
+    arrow.lineToPoint_((center_x - radius * 0.42, center_y - radius * 0.22))
+    arrow.lineToPoint_((center_x + radius * 0.42, center_y - radius * 0.22))
+    arrow.closePath()
+    arrow.fill()

--- a/app/spotty_bunny_menu.py
+++ b/app/spotty_bunny_menu.py
@@ -1,0 +1,27 @@
+"""Right-click menu titles for the Spotty Bunny logo."""
+
+from __future__ import annotations
+
+QUIT_MENU_TITLE = "Quit Spotty Bunny"
+UNINSTALL_INFORMATIVE = (
+    "Removes the login LaunchAgent and stops Spotty Bunny. "
+    "Bookmarks and config.env are kept."
+)
+UNINSTALL_MENU_TITLE = "Uninstall Spotty Bunny"
+UPGRADE_MENU_TITLE = "Upgrade Spotty Bunny"
+UPGRADE_STATUS = "Upgrading Bunnify from PyPI…"
+
+
+def logo_menu_specs(*, outdated: bool) -> tuple[tuple[str, str], ...]:
+    """Return logo menu (title, action) pairs in lexicographic title order.
+
+    Upgrade is included only when a newer PyPI version is known.
+    """
+    items = (
+        (QUIT_MENU_TITLE, "quitSpottyBunny:"),
+        (UNINSTALL_MENU_TITLE, "uninstallSpottyBunny:"),
+        (UPGRADE_MENU_TITLE, "upgradeSpottyBunny:"),
+    )
+    if outdated:
+        return items
+    return tuple(item for item in items if item[0] != UPGRADE_MENU_TITLE)

--- a/app/spotty_bunny_update.py
+++ b/app/spotty_bunny_update.py
@@ -1,0 +1,159 @@
+"""Daily PyPI update check and cache for Spotty Bunny."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+from app.config import data_dir
+from app.pypi import pypi_latest_version
+from app.version import package_version
+
+CACHE_FILE_NAME = "pypi-latest.json"
+CHECK_INTERVAL_S = 24 * 60 * 60
+FetchLatest = Callable[[], str | None]
+
+
+@dataclass(frozen=True)
+class UpdateStatus:
+    """Installed version compared to the last successful PyPI lookup."""
+
+    checked_at: float | None
+    current: str
+    latest: str | None
+    outdated: bool
+
+
+def cache_is_stale(checked_at: float | None, *, now: float | None = None) -> bool:
+    """True when there is no check yet, or the last check is older than a day."""
+    if checked_at is None:
+        return True
+    moment = time.time() if now is None else now
+    return moment - checked_at >= CHECK_INTERVAL_S
+
+
+def is_version_outdated(current: str, latest: str | None) -> bool:
+    """True when *latest* is a newer package version than *current*."""
+    if not latest:
+        return False
+    try:
+        return Version(current) < Version(latest)
+    except InvalidVersion:
+        return current != latest
+
+
+def read_cached_update_status(
+    *,
+    cache_path: Path | None = None,
+    current: str | None = None,
+) -> UpdateStatus:
+    """Compare this install to the on-disk cache without hitting the network."""
+    version = current if current is not None else package_version()
+    path = cache_path if cache_path is not None else update_cache_path()
+    cached = _read_cache(path)
+    if cached is None:
+        return UpdateStatus(
+            checked_at=None,
+            current=version,
+            latest=None,
+            outdated=False,
+        )
+    return UpdateStatus(
+        checked_at=cached.checked_at,
+        current=version,
+        latest=cached.latest,
+        outdated=is_version_outdated(version, cached.latest),
+    )
+
+
+def refresh_update_status(
+    *,
+    cache_path: Path | None = None,
+    current: str | None = None,
+    fetch: FetchLatest | None = None,
+    force: bool = False,
+    now: float | None = None,
+) -> UpdateStatus:
+    """Return update status, fetching PyPI when the daily cache is stale."""
+    moment = time.time() if now is None else now
+    version = current if current is not None else package_version()
+    path = cache_path if cache_path is not None else update_cache_path()
+    cached = _read_cache(path)
+    if (
+        not force
+        and cached is not None
+        and not cache_is_stale(cached.checked_at, now=moment)
+    ):
+        return UpdateStatus(
+            checked_at=cached.checked_at,
+            current=version,
+            latest=cached.latest,
+            outdated=is_version_outdated(version, cached.latest),
+        )
+    getter = fetch if fetch is not None else pypi_latest_version
+    latest = getter()
+    if latest is None:
+        if cached is None:
+            return UpdateStatus(
+                checked_at=None,
+                current=version,
+                latest=None,
+                outdated=False,
+            )
+        return UpdateStatus(
+            checked_at=cached.checked_at,
+            current=version,
+            latest=cached.latest,
+            outdated=is_version_outdated(version, cached.latest),
+        )
+    _write_cache(path, checked_at=moment, latest=latest)
+    return UpdateStatus(
+        checked_at=moment,
+        current=version,
+        latest=latest,
+        outdated=is_version_outdated(version, latest),
+    )
+
+
+def update_cache_path(*, environ: dict[str, str] | None = None) -> Path:
+    """JSON cache under Bunnify's data directory."""
+    return data_dir(environ=environ) / CACHE_FILE_NAME
+
+
+@dataclass(frozen=True)
+class _CacheRecord:
+    checked_at: float
+    latest: str
+
+
+def _read_cache(path: Path) -> _CacheRecord | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError, ValueError, json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    latest = payload.get("latest")
+    checked_at = payload.get("checked_at")
+    if not isinstance(latest, str) or not latest:
+        return None
+    if not isinstance(checked_at, int | float):
+        return None
+    return _CacheRecord(checked_at=float(checked_at), latest=latest)
+
+
+def _write_cache(path: Path, *, checked_at: float, latest: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        {"checked_at": checked_at, "latest": latest},
+        indent=2,
+        sort_keys=True,
+    )
+    tmp = path.with_name(f"{path.name}.tmp")
+    tmp.write_text(payload + "\n", encoding="utf-8")
+    tmp.replace(path)

--- a/app/spotty_bunny_update.py
+++ b/app/spotty_bunny_update.py
@@ -44,7 +44,7 @@ def is_version_outdated(current: str, latest: str | None) -> bool:
     try:
         return Version(current) < Version(latest)
     except InvalidVersion:
-        return current != latest
+        return False
 
 
 def read_cached_update_status(
@@ -97,19 +97,14 @@ def refresh_update_status(
         )
     getter = fetch if fetch is not None else pypi_latest_version
     latest = getter()
+    previous_latest = cached.latest if cached is not None else None
     if latest is None:
-        if cached is None:
-            return UpdateStatus(
-                checked_at=None,
-                current=version,
-                latest=None,
-                outdated=False,
-            )
+        _write_cache(path, checked_at=moment, latest=previous_latest)
         return UpdateStatus(
-            checked_at=cached.checked_at,
+            checked_at=moment,
             current=version,
-            latest=cached.latest,
-            outdated=is_version_outdated(version, cached.latest),
+            latest=previous_latest,
+            outdated=is_version_outdated(version, previous_latest),
         )
     _write_cache(path, checked_at=moment, latest=latest)
     return UpdateStatus(
@@ -128,7 +123,7 @@ def update_cache_path(*, environ: dict[str, str] | None = None) -> Path:
 @dataclass(frozen=True)
 class _CacheRecord:
     checked_at: float
-    latest: str
+    latest: str | None
 
 
 def _read_cache(path: Path) -> _CacheRecord | None:
@@ -138,16 +133,20 @@ def _read_cache(path: Path) -> _CacheRecord | None:
         return None
     if not isinstance(payload, dict):
         return None
-    latest = payload.get("latest")
     checked_at = payload.get("checked_at")
-    if not isinstance(latest, str) or not latest:
-        return None
     if not isinstance(checked_at, int | float):
+        return None
+    latest_raw = payload.get("latest")
+    if latest_raw is None:
+        latest: str | None = None
+    elif isinstance(latest_raw, str) and latest_raw:
+        latest = latest_raw
+    else:
         return None
     return _CacheRecord(checked_at=float(checked_at), latest=latest)
 
 
-def _write_cache(path: Path, *, checked_at: float, latest: str) -> None:
+def _write_cache(path: Path, *, checked_at: float, latest: str | None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(
         {"checked_at": checked_at, "latest": latest},

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1941,6 +1941,7 @@ class ConfigUnitTests(TestCase):
         self.assertIn("CHROME_SETUP.md", result.output)
         self.assertIn("bunnify upgrade", result.output)
         self.assertIn("preferred", result.output.lower())
+        self.assertIn("spotty-bunny install", result.output)
 
         flagged = CliRunner().invoke(main, ["--onboard"])
         self.assertEqual(flagged.exit_code, 0)

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -267,7 +267,131 @@ class SpottyBunnyCliTests(SimpleTestCase):
         self.assertIn("log_level=DEBUG", logged)
 
 
+class SpottyBunnyAboutInfoTests(SimpleTestCase):
+    def test_display_user_path_uses_tilde_for_home(self) -> None:
+        from app.spotty_bunny_about_info import display_user_path
+
+        home = Path.home()
+        nested = home / ".config" / "bunnify" / "bookmarks.json"
+        self.assertEqual(
+            display_user_path(nested),
+            "~/.config/bunnify/bookmarks.json",
+        )
+
+    def test_github_https_url_normalizes_remotes(self) -> None:
+        from app.spotty_bunny_about_info import github_https_url
+
+        expected = "https://github.com/acme/dots"
+        self.assertEqual(github_https_url("git@github.com:acme/dots.git"), expected)
+        self.assertEqual(
+            github_https_url("https://github.com/acme/dots.git"),
+            expected,
+        )
+        self.assertEqual(
+            github_https_url("ssh://git@github.com/acme/dots.git"),
+            expected,
+        )
+        self.assertEqual(
+            github_https_url("git://github.com/acme/dots"),
+            expected,
+        )
+        self.assertIsNone(github_https_url("https://gitlab.com/acme/dots.git"))
+
+    def test_github_repo_url_for_path_reads_origin(self) -> None:
+        from app.spotty_bunny_about_info import github_repo_url_for_path
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bookmarks = root / "bookmarks.json"
+            bookmarks.write_text("{}", encoding="utf-8")
+            (root / ".git").mkdir()
+            self.assertEqual(
+                github_repo_url_for_path(
+                    bookmarks,
+                    origin_url_for=lambda _workdir: "git@github.com:acme/dots.git",
+                ),
+                "https://github.com/acme/dots",
+            )
+
+    def test_github_repo_url_for_path_skips_non_git_dirs(self) -> None:
+        from app.spotty_bunny_about_info import github_repo_url_for_path
+
+        with TemporaryDirectory() as tmp:
+            bookmarks = Path(tmp) / "bookmarks.json"
+            bookmarks.write_text("{}", encoding="utf-8")
+            self.assertIsNone(github_repo_url_for_path(bookmarks))
+
+    def test_load_about_runtime_info_local_server_and_file_link(self) -> None:
+        from app.spotty_bunny_about_info import load_about_runtime_info
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bookmarks = root / "bookmarks.json"
+            bookmarks.write_text("{}", encoding="utf-8")
+            env = {
+                "BUNNIFY_BASE_URL": "http://127.0.0.1:9000",
+                "BUNNIFY_BOOKMARKS": str(bookmarks),
+                "BUNNIFY_MODE": "local",
+                "XDG_CONFIG_HOME": str(root / "cfg"),
+            }
+            info = load_about_runtime_info(
+                environ=env,
+                origin_url_for=lambda _workdir: None,
+            )
+            self.assertTrue(info.bookmarks_uri.startswith("file:"))
+            self.assertIn("bookmarks.json", info.bookmarks_display)
+            self.assertIsNone(info.github_url)
+            self.assertEqual(
+                info.server_display,
+                "Local server · http://127.0.0.1:9000",
+            )
+            self.assertEqual(info.server_url, "http://127.0.0.1:9000")
+
+    def test_load_about_runtime_info_remote_server_and_github(self) -> None:
+        from app.spotty_bunny_about_info import load_about_runtime_info
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".git").mkdir()
+            bookmarks = root / "bookmarks.json"
+            bookmarks.write_text("{}", encoding="utf-8")
+            env = {
+                "BUNNIFY_BASE_URL": "https://bun.example.com",
+                "BUNNIFY_BOOKMARKS": str(bookmarks),
+                "BUNNIFY_MODE": "remote",
+                "XDG_CONFIG_HOME": str(root / "cfg"),
+            }
+            info = load_about_runtime_info(
+                environ=env,
+                origin_url_for=lambda _workdir: "https://github.com/acme/dots.git",
+            )
+            self.assertEqual(info.github_url, "https://github.com/acme/dots")
+            self.assertEqual(info.github_display, "github.com/acme/dots")
+            self.assertEqual(
+                info.server_display,
+                "Remote server · https://bun.example.com",
+            )
+            self.assertEqual(info.server_url, "https://bun.example.com")
+
+
 class SpottyBunnyAgentTests(SimpleTestCase):
+    def test_bootout_loaded_agent_issues_bootout_when_loaded(self) -> None:
+        from app.spotty_bunny_agent import bootout_loaded_agent
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = True
+        self.assertTrue(bootout_loaded_agent(launchctl=ctl))
+        self.assertTrue(any(call[1] == "bootout" for call in ctl.calls))
+        self.assertFalse(ctl.loaded)
+
+    def test_bootout_loaded_agent_skips_when_not_loaded(self) -> None:
+        from app.spotty_bunny_agent import bootout_loaded_agent
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = False
+        self.assertFalse(bootout_loaded_agent(launchctl=ctl))
+        self.assertFalse(any(call[1] == "bootout" for call in ctl.calls))
+
     def test_format_agent_plist_matches_example_placeholders(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist
 
@@ -1380,6 +1504,8 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("ABOUT_FRAME_RGB", source)
         self.assertIn("ABOUT_LABEL_RGB", source)
         self.assertIn("ABOUT_LINK_RGB", source)
+        self.assertIn("ABOUT_WARN_RGB", source)
+        self.assertIn("Update available:", source)
         self.assertIn("SpottyBunnyAboutPanel", source)
         self.assertIn("cancelOperation_", source)
         self.assertIn("performKeyEquivalent_", source)
@@ -1393,6 +1519,14 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("pointingHandCursor", source)
         self.assertIn("NSTrackingActiveAlways", source)
         self.assertIn("_AboutLinkField", source)
+        self.assertIn("load_about_runtime_info", source)
+        self.assertIn("Bookmarks:", source)
+        self.assertIn("GitHub:", source)
+        info_source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_about_info.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Local server", info_source)
+        self.assertIn("Remote server", info_source)
 
     def test_search_field_is_centered_with_logo_on_right(self) -> None:
         source = (
@@ -1430,6 +1564,25 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         ).read_text(encoding="utf-8")
         self.assertNotIn('setTitle_("spotty-bunny")', source)
         self.assertIn("showAbout:", source)
+        self.assertIn("SpottyBunnyLogoButton", source)
+        self.assertIn("def quitSpottyBunny_", source)
+        self.assertIn("def uninstallSpottyBunny_", source)
+        self.assertIn("def upgradeSpottyBunny_", source)
+        self.assertIn("menuNeedsUpdate_", source)
+        self.assertIn("outdated=outdated", source)
+        menu_source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_menu.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Quit Spotty Bunny", menu_source)
+        self.assertIn("Uninstall Spotty Bunny", menu_source)
+        self.assertIn("Upgrade Spotty Bunny", menu_source)
+        self.assertIn("quitSpottyBunny:", menu_source)
+        self.assertIn("uninstallSpottyBunny:", menu_source)
+        self.assertIn("upgradeSpottyBunny:", menu_source)
+        self.assertIn("setMenu_(menu)", source)
+        self.assertIn("rightMouseDown_", source)
+        self.assertIn("bootout_loaded_agent", source)
+        self.assertIn("self._about_panel.close()", source)
 
     def test_about_panel_build_info_prewarmed(self) -> None:
         source = (
@@ -1698,6 +1851,124 @@ class SpottyBunnyStatusTests(SimpleTestCase):
         self.assertIn("apply_spotty_chrome", source)
         self.assertIn("fill_rgb=PANEL_FILL_RGB", source)
         self.assertIn("frame_rgb=PANEL_FRAME_RGB", source)
+
+
+class SpottyBunnyUpdateTests(SimpleTestCase):
+    def test_cache_is_stale_after_a_day(self) -> None:
+        from app.spotty_bunny_update import CHECK_INTERVAL_S, cache_is_stale
+
+        self.assertTrue(cache_is_stale(None, now=100.0))
+        self.assertFalse(cache_is_stale(100.0, now=100.0 + CHECK_INTERVAL_S - 1))
+        self.assertTrue(cache_is_stale(100.0, now=100.0 + CHECK_INTERVAL_S))
+
+    def test_is_version_outdated_compares_pep440(self) -> None:
+        from app.spotty_bunny_update import is_version_outdated
+
+        self.assertTrue(is_version_outdated("0.6.1", "0.7.0"))
+        self.assertFalse(is_version_outdated("0.7.0", "0.7.0"))
+        self.assertFalse(is_version_outdated("0.7.0", "0.6.1"))
+        self.assertFalse(is_version_outdated("0.6.1", None))
+
+    def test_logo_menu_specs_are_sorted_and_hide_upgrade_when_current(self) -> None:
+        from app.spotty_bunny_menu import (
+            QUIT_MENU_TITLE,
+            UNINSTALL_MENU_TITLE,
+            UPGRADE_MENU_TITLE,
+            logo_menu_specs,
+        )
+
+        current = logo_menu_specs(outdated=False)
+        titles = [title for title, _action in current]
+        self.assertEqual(titles, sorted(titles))
+        self.assertEqual(
+            titles,
+            [QUIT_MENU_TITLE, UNINSTALL_MENU_TITLE],
+        )
+        outdated = logo_menu_specs(outdated=True)
+        outdated_titles = [title for title, _action in outdated]
+        self.assertEqual(outdated_titles, sorted(outdated_titles))
+        self.assertEqual(
+            outdated_titles,
+            [QUIT_MENU_TITLE, UNINSTALL_MENU_TITLE, UPGRADE_MENU_TITLE],
+        )
+
+    def test_pypi_latest_version_reads_info_version(self) -> None:
+        from app.pypi import pypi_latest_version
+
+        class _Response:
+            def __enter__(self) -> _Response:
+                return self
+
+            def __exit__(self, *_exc: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b'{"info": {"version": "1.2.3"}}'
+
+        latest = pypi_latest_version(urlopen=lambda *_a, **_k: _Response())
+        self.assertEqual(latest, "1.2.3")
+
+    def test_refresh_update_status_caches_and_skips_fresh_fetch(self) -> None:
+        from app.spotty_bunny_update import (
+            CHECK_INTERVAL_S,
+            refresh_update_status,
+        )
+
+        fetches: list[int] = []
+
+        def fetch() -> str:
+            fetches.append(1)
+            return "9.9.9"
+
+        with TemporaryDirectory() as tmp:
+            cache = Path(tmp) / "pypi-latest.json"
+            first = refresh_update_status(
+                cache_path=cache,
+                current="0.1.0",
+                fetch=fetch,
+                now=1_000.0,
+            )
+            self.assertTrue(first.outdated)
+            self.assertEqual(first.latest, "9.9.9")
+            self.assertEqual(len(fetches), 1)
+            second = refresh_update_status(
+                cache_path=cache,
+                current="0.1.0",
+                fetch=fetch,
+                now=1_000.0 + CHECK_INTERVAL_S - 1,
+            )
+            self.assertEqual(len(fetches), 1)
+            self.assertTrue(second.outdated)
+            third = refresh_update_status(
+                cache_path=cache,
+                current="0.1.0",
+                fetch=fetch,
+                now=1_000.0 + CHECK_INTERVAL_S,
+            )
+            self.assertEqual(len(fetches), 2)
+            self.assertTrue(third.outdated)
+
+    def test_refresh_keeps_cache_when_fetch_fails(self) -> None:
+        from app.spotty_bunny_update import refresh_update_status
+
+        with TemporaryDirectory() as tmp:
+            cache = Path(tmp) / "pypi-latest.json"
+            refresh_update_status(
+                cache_path=cache,
+                current="0.1.0",
+                fetch=lambda: "2.0.0",
+                now=50.0,
+            )
+            failed = refresh_update_status(
+                cache_path=cache,
+                current="0.1.0",
+                fetch=lambda: None,
+                force=True,
+                now=99.0,
+            )
+            self.assertEqual(failed.latest, "2.0.0")
+            self.assertEqual(failed.checked_at, 50.0)
+            self.assertTrue(failed.outdated)
 
 
 class _FakeClock:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -730,6 +730,66 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertGreaterEqual(tcc.probes, 2)
             self.assertFalse(any(call[1] == "kickstart" for call in ctl.calls))
 
+    def test_refresh_agent_plist_rewrites_without_bootout(self) -> None:
+        from app.spotty_bunny_agent import (
+            AGENT_LABEL,
+            format_agent_plist,
+            refresh_agent_plist,
+        )
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            plist.write_text(
+                format_agent_plist(
+                    home=home,
+                    program_arguments=["/old/spotty-bunny"],
+                ),
+                encoding="utf-8",
+            )
+            new_program = Path("/new/spotty-bunny")
+            code = refresh_agent_plist(
+                home=home,
+                platform="darwin",
+                print_err=lambda _m: None,
+                program=new_program,
+            )
+            self.assertEqual(code, 0)
+            self.assertIn(str(new_program), plist.read_text(encoding="utf-8"))
+            self.assertNotIn("/old/spotty-bunny", plist.read_text(encoding="utf-8"))
+
+    def test_uninstall_removes_plist_before_bootout(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, uninstall_agent
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            plist.write_text("plist", encoding="utf-8")
+
+            class _OrderLaunchctl(_FakeLaunchctl):
+                def __call__(
+                    self, argv: list[str], **kwargs: object
+                ) -> subprocess.CompletedProcess[str]:
+                    if len(argv) >= 2 and argv[1] == "bootout":
+                        self.plist_existed_at_bootout = plist.exists()
+                    return super().__call__(argv, **kwargs)
+
+            ctl = _OrderLaunchctl()
+            ctl.loaded = True
+            ctl.plist_existed_at_bootout = True
+            with patch("app.spotty_bunny_agent.stop_spotty_bunny"):
+                code = uninstall_agent(
+                    home=home,
+                    launchctl=ctl,
+                    platform="darwin",
+                    print_err=lambda _m: None,
+                )
+            self.assertEqual(code, 0)
+            self.assertFalse(plist.exists())
+            self.assertIs(ctl.plist_existed_at_bootout, False)
+
 
 class _FakeLaunchctl:
     def __init__(self) -> None:
@@ -1581,6 +1641,8 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("upgradeSpottyBunny:", menu_source)
         self.assertIn("setMenu_(menu)", source)
         self.assertIn("rightMouseDown_", source)
+        self.assertIn("refresh_agent_plist", source)
+        self.assertIn("if refresh_agent_plist() != 0", source)
         self.assertIn("bootout_loaded_agent", source)
         self.assertIn("self._about_panel.close()", source)
 
@@ -1869,6 +1931,12 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
         self.assertFalse(is_version_outdated("0.7.0", "0.6.1"))
         self.assertFalse(is_version_outdated("0.6.1", None))
 
+    def test_is_version_outdated_unparseable_current_is_not_outdated(self) -> None:
+        from app.spotty_bunny_update import is_version_outdated
+
+        self.assertFalse(is_version_outdated("unknown", "0.7.0"))
+        self.assertFalse(is_version_outdated("0.7.0", "not-a-version"))
+
     def test_logo_menu_specs_are_sorted_and_hide_upgrade_when_current(self) -> None:
         from app.spotty_bunny_menu import (
             QUIT_MENU_TITLE,
@@ -1907,6 +1975,36 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
 
         latest = pypi_latest_version(urlopen=lambda *_a, **_k: _Response())
         self.assertEqual(latest, "1.2.3")
+
+    def test_read_cached_update_status_malformed_cache(self) -> None:
+        from app.spotty_bunny_update import read_cached_update_status
+
+        with TemporaryDirectory() as tmp:
+            cache = Path(tmp) / "pypi-latest.json"
+            cache.write_text("{not json", encoding="utf-8")
+            status = read_cached_update_status(cache_path=cache, current="1.0.0")
+            self.assertIsNone(status.checked_at)
+            self.assertIsNone(status.latest)
+            self.assertFalse(status.outdated)
+
+    def test_read_cached_update_status_round_trip(self) -> None:
+        from app.spotty_bunny_update import (
+            read_cached_update_status,
+            refresh_update_status,
+        )
+
+        with TemporaryDirectory() as tmp:
+            cache = Path(tmp) / "pypi-latest.json"
+            refresh_update_status(
+                cache_path=cache,
+                current="1.0.0",
+                fetch=lambda: "2.0.0",
+                now=10.0,
+            )
+            status = read_cached_update_status(cache_path=cache, current="1.0.0")
+            self.assertEqual(status.checked_at, 10.0)
+            self.assertEqual(status.latest, "2.0.0")
+            self.assertTrue(status.outdated)
 
     def test_refresh_update_status_caches_and_skips_fresh_fetch(self) -> None:
         from app.spotty_bunny_update import (
@@ -1967,8 +2065,41 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
                 now=99.0,
             )
             self.assertEqual(failed.latest, "2.0.0")
-            self.assertEqual(failed.checked_at, 50.0)
+            self.assertEqual(failed.checked_at, 99.0)
             self.assertTrue(failed.outdated)
+
+    def test_refresh_throttles_after_failed_fetch(self) -> None:
+        from app.spotty_bunny_update import (
+            CHECK_INTERVAL_S,
+            refresh_update_status,
+        )
+
+        fetches: list[int] = []
+
+        def fetch() -> str | None:
+            fetches.append(1)
+            return None
+
+        with TemporaryDirectory() as tmp:
+            cache = Path(tmp) / "pypi-latest.json"
+            first = refresh_update_status(
+                cache_path=cache,
+                current="0.1.0",
+                fetch=fetch,
+                now=10.0,
+            )
+            self.assertIsNone(first.latest)
+            self.assertEqual(first.checked_at, 10.0)
+            self.assertFalse(first.outdated)
+            self.assertEqual(len(fetches), 1)
+            second = refresh_update_status(
+                cache_path=cache,
+                current="0.1.0",
+                fetch=fetch,
+                now=10.0 + CHECK_INTERVAL_S - 1,
+            )
+            self.assertEqual(len(fetches), 1)
+            self.assertEqual(second.checked_at, 10.0)
 
 
 class _FakeClock:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -15,6 +15,9 @@ to `~/.config/bunnify` when `XDG_CONFIG_HOME` is unset:
   `BUNNIFY_MODE`, `BUNNIFY_BASE_URL`, and `BUNNIFY_LOCAL_PORT`.
 - `run/` contains PID and selected-port files for the CLI-managed local server.
 
+Writable data (logs, SQLite, Spotty Bunny’s daily PyPI check cache
+`pypi-latest.json`) lives under `$XDG_DATA_HOME/bunnify` or `BUNNIFY_DATA_DIR`.
+
 These files are user data and are not tracked by Git.
 
 ## Setup

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -158,8 +158,9 @@ agent out so KeepAlive cannot immediately respawn it. The plist stays; the
 agent starts again at next login (`RunAtLoad`) until you `uninstall`.
 
 The same menu lists **Uninstall Spotty Bunny** (confirms, then removes the
-LaunchAgent) and, when a newer PyPI release is known, **Upgrade Spotty Bunny**
-(`pipx upgrade` plus a LaunchAgent refresh). Items are listed A–Z by title.
+plist before booting the agent out) and, when a newer PyPI release is known,
+**Upgrade Spotty Bunny** (`pipx upgrade`, rewrite the plist, then quit so
+KeepAlive relaunches). Items are listed A–Z by title.
 
 Spotty Bunny checks PyPI at most once per day (cached as
 `pypi-latest.json` under the data directory). When this install is behind,

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -87,6 +87,8 @@ Needs the optional `macos` extra (PyObjC). Bare `spotty-bunny` still runs the
 overlay **in the foreground**. The login LaunchAgent is a distinct label from
 the server agent (`com.thehcma.bunnify`).
 
+### Install
+
 ```bash
 # pipx
 pipx install 'bunnify[macos]'
@@ -94,8 +96,6 @@ spotty-bunny                     # foreground overlay
 bunnify spotty-bunny             # same (reserved CLI token)
 bunnify spotty-bunny install     # LaunchAgent (KeepAlive + RunAtLoad)
 bunnify spotty-bunny status
-bunnify spotty-bunny upgrade     # after `bunnify upgrade` (pipx)
-bunnify spotty-bunny uninstall
 
 # development checkout (wrapper syncs extra macos)
 ./scripts/spotty-bunny
@@ -127,6 +127,13 @@ path, the application log
 Accessibility / Input Monitoring yes/no. Exit `0` only when the plist exists,
 the agent is loaded, and the process is running.
 
+### Upgrade
+
+```bash
+bunnify upgrade                  # pipx package (preferred)
+bunnify spotty-bunny upgrade     # rewrite plist + bounce launchd
+```
+
 `upgrade` rewrites the plist if `command -v spotty-bunny` moved (pipx venv
 path / shebang), re-verifies TCC for that interpreter, then reloads the agent
 with `launchctl bootout` and `launchctl bootstrap` so launchd picks up the new
@@ -135,9 +142,31 @@ Package updates stay on `bunnify upgrade` (`pipx upgrade bunnify`); run that
 first, then `bunnify spotty-bunny upgrade` so launchd does not keep a stale
 binary path.
 
+### Uninstall
+
+```bash
+bunnify spotty-bunny uninstall
+```
+
 `uninstall` boots the agent out, removes the plist, stops a leftover overlay
-process, and clears the pid file. It does not delete the application log.
-If the agent was never installed, it still succeeds.
+process, and clears the pid file. It does not delete the application log or
+your bookmarks. If the agent was never installed, it still succeeds.
+
+To stop the overlay **without** removing the LaunchAgent, right-click the bunny
+icon and choose **Quit Spotty Bunny**. That exits the process and boots the
+agent out so KeepAlive cannot immediately respawn it. The plist stays; the
+agent starts again at next login (`RunAtLoad`) until you `uninstall`.
+
+The same menu lists **Uninstall Spotty Bunny** (confirms, then removes the
+LaunchAgent) and, when a newer PyPI release is known, **Upgrade Spotty Bunny**
+(`pipx upgrade` plus a LaunchAgent refresh). Items are listed A–Z by title.
+
+Spotty Bunny checks PyPI at most once per day (cached as
+`pypi-latest.json` under the data directory). When this install is behind,
+the bunny icon shows a small up-arrow badge and About includes
+“Update available: …”.
+
+### Using the overlay
 
 Hold **one** Control, then press the **other** to show the search box. Esc
 (or the same chord again) hides it. Up/down walks the CLI REPL history file
@@ -151,8 +180,14 @@ for per-key tap debug). Launchd stdout/stderr under `~/Library/Logs/` are
 separate from that application log.
 
 The search box is centered on the **main display** (menu-bar monitor), with a
-small bunny icon to the right of the field. Click the icon for version, commit, and
-project links (domesti-bot-style about panel).
+small bunny icon to the right of the field. **Left-click** the icon for the
+About card: version, commit, license, Bunnify source, a hyperlink to your
+bookmarks file (`BUNNIFY_BOOKMARKS` or `~/.config/bunnify/bookmarks.json`), the
+GitHub repo when that file lives in a git checkout whose `origin` is GitHub,
+whether Spotty Bunny is using a **local** or **remote** server (with its
+URL from `config.env`), and an **Update available** line when PyPI is newer.
+An up-arrow badge on the bunny also marks an outdated install. **Right-click**
+the icon for **Quit**, **Uninstall**, and (when outdated) **Upgrade**.
 
 If the chord does nothing, run with `--verbose` and watch stderr (or the
 application log). Lines named `tap …` show whether key events arrive. If none


### PR DESCRIPTION
## Summary
- Right-click the Spotty Bunny icon for Quit, Uninstall, and (when PyPI is newer) Upgrade, listed A–Z.
- About links the bookmarks file, the GitHub repo when that file lives in a GitHub checkout, and whether the server is local or remote (with its URL).
- A daily PyPI check (cached under the data directory) badges an outdated install and surfaces “Update available” in About.

## Test plan
- [x] `./scripts/checks` (ruff, pyright, unit, packaging smoke, integration)
- [ ] Right-click the bunny: Quit stops this session; Uninstall confirms then removes the LaunchAgent; Upgrade appears only when PyPI is newer
- [ ] Left-click About: bookmarks file link, GitHub repo when applicable, local/remote + URL
- [ ] Outdated badge and About line after a stale/missing `pypi-latest.json` cache