### PR TITLE
feat: reuse Spotty Bunny and server, and add Install to the logo menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ bunnify spotty-bunny uninstall
 
 That boots the agent out, removes the plist, and stops a leftover overlay
 process. Bookmarks and `config.env` are unchanged. Right-click the bunny icon
-for **Quit Spotty Bunny**, **Uninstall Spotty Bunny**, and (when a newer
-PyPI version is known) **Upgrade Spotty Bunny**. An up-arrow badge on the
+for **Install Spotty Bunny** (when the LaunchAgent is missing), **Quit Spotty
+Bunny**, **Uninstall Spotty Bunny**, and (when installed and a newer PyPI
+version is known) **Upgrade Spotty Bunny**. An up-arrow badge on the
 icon and an About line mark an outdated install (PyPI is checked at most
 once a day).
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -156,14 +156,22 @@ def ensure_ready_base_url(
                 raise ClientError(message)
             continue
         if interactive:
-            base_url, actual_port = _restart_local_server_if_build_mismatch(
-                base_url=base_url,
-                bookmarks=bookmarks,
-                pid_dir=pid_dir,
-                port=actual_port,
-                print_fn=log,
-                prompt_fn=ask,
-            )
+            try:
+                base_url, actual_port = _restart_local_server_if_build_mismatch(
+                    base_url=base_url,
+                    bookmarks=bookmarks,
+                    pid_dir=pid_dir,
+                    port=actual_port,
+                    print_fn=log,
+                    prompt_fn=ask,
+                )
+            except (OSError, RuntimeError, ValueError) as exc:
+                if not interactive or not _retry_requested(
+                    ask, f"Local server failed: {exc}\nRetry? [Y/n]: "
+                ):
+                    raise ClientError(str(exc)) from exc
+                preferred_port = None
+                continue
         if actual_port != preferences.local_port or base_url != preferences.base_url:
             path = env_path if env_path is not None else env_file_path(environ=environ)
             save_preferences(
@@ -635,18 +643,19 @@ def _offer_restart_mismatched_server(
     pid_dir: Path,
     print_fn: Callable[[str], None],
     theme: Theme,
-) -> int | None:
+) -> tuple[int, bool] | None:
     """Offer a restart when a busy port serves a different Bunnify build.
 
-    Returns the port when the caller should reuse or restart into it, or
-    ``None`` when the prompt loop should continue (stop failed / still busy).
+    Returns ``(port, restart)`` when the caller should reuse (*restart* False)
+    or start this CLI's build on *port* (*restart* True). ``None`` means stop
+    failed and the prompt loop should continue.
     """
     local_version, local_commit = get_build_info()
     local_label = f"{local_version} ({local_commit})"
     running_label = _format_running_build(health)
     print_fn(theme.ok(f"✓ Port {port} is already serving Bunnify {running_label}"))
     if _builds_match(health):
-        return port
+        return port, False
     if health.version is None or health.commit is None:
         print_fn(
             theme.warn(
@@ -676,7 +685,7 @@ def _offer_restart_mismatched_server(
             )
     if not _confirm_explicit_yes(prompt_fn, prompt):
         print_fn(theme.dim(f"Reusing the running server ({running_label})."))
-        return port
+        return port, False
     try:
         stop_local_server(
             pid_dir,
@@ -687,7 +696,7 @@ def _offer_restart_mismatched_server(
         print_fn(theme.warn(f"Could not stop the managed server: {exc}"))
         return None
     print_fn(theme.ok(f"✓ Stopped previous server; port {port} is free"))
-    return port
+    return port, True
 
 
 def _parse_version_line(output: str) -> str | None:
@@ -778,7 +787,7 @@ def _prompt_local_port(
                 theme=colors,
             )
             if chosen is not None:
-                return chosen
+                return chosen[0]
             continue
         log(colors.warn(f"Port {port} is already in use. Searching for a free port…"))
         found = _find_usable_local_port(port + 1)
@@ -835,7 +844,7 @@ def _restart_local_server_if_build_mismatch(
     health = fetch_health(base_url)
     if not health.ok or _builds_match(health):
         return base_url, port
-    chosen = _offer_restart_mismatched_server(
+    decided = _offer_restart_mismatched_server(
         prompt_fn,
         port=port,
         health=health,
@@ -843,7 +852,12 @@ def _restart_local_server_if_build_mismatch(
         print_fn=print_fn,
         theme=colors,
     )
-    if chosen is None or check_health(base_url):
+    if decided is None:
+        if check_health(base_url):
+            return base_url, port
+        raise RuntimeError(f"Could not stop the mismatched server on port {port}")
+    chosen, restart = decided
+    if not restart:
         return base_url, port
     started_url, started_port = ensure_local_server(
         port=chosen,

--- a/app/cli.py
+++ b/app/cli.py
@@ -133,11 +133,12 @@ def ensure_ready_base_url(
         print_fn=log,
     )
     preferred_port = preferences.local_port
+    pid_dir = run_dir(environ=environ)
     while True:
         try:
             base_url, actual_port = ensure_local_server(
                 port=preferred_port,
-                pid_dir=run_dir(environ=environ),
+                pid_dir=pid_dir,
                 bookmarks=bookmarks,
             )
         except (OSError, RuntimeError, ValueError) as exc:
@@ -154,6 +155,15 @@ def ensure_ready_base_url(
             ):
                 raise ClientError(message)
             continue
+        if interactive:
+            base_url, actual_port = _restart_local_server_if_build_mismatch(
+                base_url=base_url,
+                bookmarks=bookmarks,
+                pid_dir=pid_dir,
+                port=actual_port,
+                print_fn=log,
+                prompt_fn=ask,
+            )
         if actual_port != preferences.local_port or base_url != preferences.base_url:
             path = env_path if env_path is not None else env_file_path(environ=environ)
             save_preferences(
@@ -810,6 +820,39 @@ def _retry_requested(prompt_fn: Callable[[str], str], message: str) -> bool:
     return answer.strip().lower() not in {"abort", "n", "no", "q", "quit"}
 
 
+def _restart_local_server_if_build_mismatch(
+    *,
+    base_url: str,
+    bookmarks: Path,
+    pid_dir: Path,
+    port: int,
+    print_fn: Callable[[str], None],
+    prompt_fn: Callable[[str], str],
+    theme: Theme | None = None,
+) -> tuple[str, int]:
+    """Reuse a healthy local server, or restart it when the CLI commit differs."""
+    colors = theme if theme is not None else Theme(enabled=False)
+    health = fetch_health(base_url)
+    if not health.ok or _builds_match(health):
+        return base_url, port
+    chosen = _offer_restart_mismatched_server(
+        prompt_fn,
+        port=port,
+        health=health,
+        pid_dir=pid_dir,
+        print_fn=print_fn,
+        theme=colors,
+    )
+    if chosen is None or check_health(base_url):
+        return base_url, port
+    started_url, started_port = ensure_local_server(
+        port=chosen,
+        pid_dir=pid_dir,
+        bookmarks=bookmarks,
+    )
+    return started_url, started_port
+
+
 def _wait_for_healthy_remote(
     base_url: str,
     *,
@@ -936,7 +979,24 @@ def _run_repl(
     if sys.platform == "darwin" and input_fn is None:
         from app.spotty_bunny_launch import ensure_spotty_bunny_running
 
-        if ensure_spotty_bunny_running():
+        def offer_restart(recorded: str | None, current: str) -> bool:
+            running = recorded or "unknown"
+            click.echo(
+                theme.warn(
+                    f"Spotty Bunny is running commit {running}; this CLI is {current}."
+                ),
+                err=True,
+            )
+            return _confirm_explicit_yes(
+                lambda message: click.prompt(
+                    message.rstrip(": "),
+                    default="",
+                    show_default=False,
+                ),
+                "Restart Spotty Bunny with this CLI? [y/N]: ",
+            )
+
+        if ensure_spotty_bunny_running(restart=offer_restart):
             click.echo(
                 theme.dim(
                     "Spotty Bunny overlay ready (hold one Control, tap the other)"

--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -37,7 +37,11 @@ from Cocoa import (
 )
 from Foundation import NSAttributedString, NSMakeRange, NSMutableAttributedString
 
-from app.spotty_bunny_about_info import load_about_runtime_info
+from app.spotty_bunny_about_info import (
+    load_about_runtime_info,
+    open_path_in_text_editor,
+    path_from_file_uri,
+)
 from app.spotty_bunny_hotkey import ESCAPE_KEYCODE
 from app.spotty_bunny_update import UpdateStatus, read_cached_update_status
 from app.version import get_build_info
@@ -58,6 +62,7 @@ ABOUT_LINK_RGB = (0.08, 0.28, 0.58)
 ABOUT_MUTED_RGB = (0.38, 0.30, 0.22)
 ABOUT_PANEL_MAX_WIDTH = 640.0
 ABOUT_PANEL_MIN_WIDTH = 320.0
+ABOUT_ROW_GAP = 8.0
 ABOUT_SUMMARY = (
     "Search and open your Bunnify shortcuts from anywhere on macOS. "
     "Hold one Control and tap the other to show this box, type a shortcut "
@@ -132,7 +137,8 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
         if not status.outdated or not status.latest
         else f"Update available: {status.latest}"
     )
-    repo_text = "github.com/the-hcma/bunnify"
+    repo_text = "Repository: github.com/the-hcma/bunnify"
+    license_text = f"License: {ABOUT_LICENSE}"
     bookmarks_text = f"Bookmarks: {runtime.bookmarks_display}"
     github_text = (
         None if runtime.github_display is None else f"GitHub: {runtime.github_display}"
@@ -142,6 +148,7 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
         _measure_text("Spotty Bunny", title_font, max_width=inner_cap)[0],
         _measure_text(ABOUT_COPYRIGHT, body_font, max_width=inner_cap)[0],
         _measure_text(bookmarks_text, body_font, max_width=inner_cap)[0],
+        _measure_text(license_text, body_font, max_width=inner_cap)[0],
         _measure_text(repo_text, body_font, max_width=inner_cap)[0],
         _measure_text(runtime.server_display, body_font, max_width=inner_cap)[0],
         _measure_text(version_text, body_font, max_width=inner_cap)[0],
@@ -168,6 +175,11 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
     bookmarks_height = max(
         18.0,
         _measure_text(bookmarks_text, body_font, max_width=inner)[1] + ABOUT_CELL_PAD,
+    )
+    repo_license_height = max(
+        36.0,
+        _measure_text(f"{repo_text}\n{license_text}", body_font, max_width=inner)[1]
+        + ABOUT_CELL_PAD,
     )
     github_height = (
         0.0
@@ -232,21 +244,14 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
                 ),
             ),
             (
-                18.0,
-                lambda y, h: _link_field(
+                repo_license_height,
+                lambda y, h: _multi_link_field(
                     NSMakeRect(ABOUT_INSET, y, inner, h),
-                    ABOUT_LICENSE,
-                    ABOUT_LICENSE,
-                    ABOUT_LICENSE_URL,
-                ),
-            ),
-            (
-                18.0,
-                lambda y, h: _link_field(
-                    NSMakeRect(ABOUT_INSET, y, inner, h),
-                    repo_text,
-                    repo_text,
-                    SPOTTY_BUNNY_REPO_URL,
+                    f"{repo_text}\n{license_text}",
+                    (
+                        ("github.com/the-hcma/bunnify", SPOTTY_BUNNY_REPO_URL),
+                        (ABOUT_LICENSE, ABOUT_LICENSE_URL),
+                    ),
                 ),
             ),
             (
@@ -290,7 +295,7 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
             ),
         )
     )
-    gap = 8.0
+    gap = ABOUT_ROW_GAP
     height = ABOUT_INSET * 2.0 + sum(row_h for row_h, _ in rows) + gap * (len(rows) - 1)
 
     panel = SpottyBunnyAboutPanel.alloc().initWithContentRect_styleMask_backing_defer_(
@@ -355,6 +360,12 @@ class _AboutLinkField(NSTextField):
     def resetCursorRects(self) -> None:
         objc.super(_AboutLinkField, self).resetCursorRects()
         self.addCursorRect_cursor_(self.bounds(), NSCursor.pointingHandCursor())
+
+    def textView_clickedOnLink_atIndex_(self, _view, link, _index) -> bool:
+        path = path_from_file_uri(str(link))
+        if path is None:
+            return False
+        return open_path_in_text_editor(path)
 
     def updateTrackingAreas(self) -> None:
         objc.super(_AboutLinkField, self).updateTrackingAreas()
@@ -444,6 +455,51 @@ def _measure_text(text: str, font, *, max_width: float) -> tuple[float, float]:
         NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading,
     )
     return float(math.ceil(bounds.size.width)), float(math.ceil(bounds.size.height))
+
+
+def _multi_link_field(
+    frame,
+    text: str,
+    links: tuple[tuple[str, str], ...],
+) -> NSTextField:
+    """Return a wrapping label with each *(link_text, url)* span as a hyperlink."""
+    field = _AboutLinkField.alloc().initWithFrame_(frame)
+    field.setEditable_(False)
+    field.setSelectable_(True)
+    field.setBezeled_(False)
+    field.setDrawsBackground_(False)
+    field.setAllowsEditingTextAttributes_(True)
+    field.setUsesSingleLineMode_(False)
+    field.setLineBreakMode_(NSLineBreakByWordWrapping)
+    field.cell().setWraps_(True)
+    field.setFont_(NSFont.systemFontOfSize_(13.0))
+    attributed = NSMutableAttributedString.alloc().initWithString_(text)
+    attributed.addAttribute_value_range_(
+        NSForegroundColorAttributeName,
+        _srgb_color(ABOUT_LABEL_RGB),
+        NSMakeRange(0, len(text)),
+    )
+    search_from = 0
+    for link_text, url in links:
+        start = text.find(link_text, search_from)
+        if start < 0:
+            continue
+        span = NSMakeRange(start, len(link_text))
+        attributed.addAttribute_value_range_(NSLinkAttributeName, url, span)
+        attributed.addAttribute_value_range_(
+            NSForegroundColorAttributeName,
+            _srgb_color(ABOUT_LINK_RGB),
+            span,
+        )
+        attributed.addAttribute_value_range_(
+            NSUnderlineStyleAttributeName,
+            NSUnderlineStyleSingle,
+            span,
+        )
+        search_from = start + len(link_text)
+    field.setAttributedStringValue_(attributed)
+    field.setDelegate_(field)
+    return field
 
 
 def _srgb_color(rgb: tuple[float, float, float]):

--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -38,9 +38,9 @@ from Cocoa import (
 from Foundation import NSAttributedString, NSMakeRange, NSMutableAttributedString
 
 from app.spotty_bunny_about_info import (
+    about_link_spans,
+    handle_about_link_click,
     load_about_runtime_info,
-    open_path_in_text_editor,
-    path_from_file_uri,
 )
 from app.spotty_bunny_hotkey import ESCAPE_KEYCODE
 from app.spotty_bunny_update import UpdateStatus, read_cached_update_status
@@ -362,10 +362,7 @@ class _AboutLinkField(NSTextField):
         self.addCursorRect_cursor_(self.bounds(), NSCursor.pointingHandCursor())
 
     def textView_clickedOnLink_atIndex_(self, _view, link, _index) -> bool:
-        path = path_from_file_uri(str(link))
-        if path is None:
-            return False
-        return open_path_in_text_editor(path)
+        return handle_about_link_click(str(link))
 
     def updateTrackingAreas(self) -> None:
         objc.super(_AboutLinkField, self).updateTrackingAreas()
@@ -479,12 +476,8 @@ def _multi_link_field(
         _srgb_color(ABOUT_LABEL_RGB),
         NSMakeRange(0, len(text)),
     )
-    search_from = 0
-    for link_text, url in links:
-        start = text.find(link_text, search_from)
-        if start < 0:
-            continue
-        span = NSMakeRange(start, len(link_text))
+    for start, length, url in about_link_spans(text, links):
+        span = NSMakeRange(start, length)
         attributed.addAttribute_value_range_(NSLinkAttributeName, url, span)
         attributed.addAttribute_value_range_(
             NSForegroundColorAttributeName,
@@ -496,7 +489,6 @@ def _multi_link_field(
             NSUnderlineStyleSingle,
             span,
         )
-        search_from = start + len(link_text)
     field.setAttributedStringValue_(attributed)
     field.setDelegate_(field)
     return field

--- a/app/spotty_bunny_about_info.py
+++ b/app/spotty_bunny_about_info.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from app.config import (
     default_bookmarks_path,
@@ -125,6 +125,34 @@ def load_about_runtime_info(
         server_display=f"{label} · {base_url}",
         server_url=base_url,
     )
+
+
+def open_path_in_text_editor(
+    path: Path,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> bool:
+    """Open *path* in the default text editor (``open -t`` on macOS)."""
+    runner = run if run is not None else subprocess.run
+    try:
+        completed = runner(
+            ["open", "-t", str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return False
+    return completed.returncode == 0
+
+
+def path_from_file_uri(uri: str) -> Path | None:
+    """Return a filesystem path for a ``file:`` URI, or None."""
+    parsed = urlparse(uri.strip())
+    if parsed.scheme != "file" or not parsed.path:
+        return None
+    return Path(unquote(parsed.path))
 
 
 _GIT_REMOTE_TIMEOUT_S = 2

--- a/app/spotty_bunny_about_info.py
+++ b/app/spotty_bunny_about_info.py
@@ -32,6 +32,22 @@ class AboutRuntimeInfo:
 OriginUrlFor = Callable[[Path], str | None]
 
 
+def about_link_spans(
+    text: str,
+    links: tuple[tuple[str, str], ...],
+) -> tuple[tuple[int, int, str], ...]:
+    """Return ``(start, length, url)`` for each link span, searched left to right."""
+    spans: list[tuple[int, int, str]] = []
+    search_from = 0
+    for link_text, url in links:
+        start = text.find(link_text, search_from)
+        if start < 0:
+            continue
+        spans.append((start, len(link_text), url))
+        search_from = start + len(link_text)
+    return tuple(spans)
+
+
 def display_user_path(path: Path) -> str:
     """Return *path* with the home directory replaced by ``~`` when possible."""
     expanded = path.expanduser()
@@ -82,6 +98,21 @@ def github_repo_url_for_path(
     if not remote:
         return None
     return github_https_url(remote)
+
+
+def handle_about_link_click(
+    link: str,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> bool:
+    """Handle an About-panel click. True when a local file was opened.
+
+    Returning False leaves http(s) links to AppKit's default URL handler.
+    """
+    path = path_from_file_uri(str(link))
+    if path is None:
+        return False
+    return open_path_in_text_editor(path, run=run)
 
 
 def load_about_runtime_info(

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -161,6 +161,11 @@ def interpreter_for_program(program: Path) -> Path:
     return executable
 
 
+def is_agent_installed(*, home: Path | None = None) -> bool:
+    """True when the LaunchAgent plist is present under *home*."""
+    return agent_plist_path(home=home).is_file()
+
+
 def is_agent_loaded(
     *,
     launchctl: LaunchctlFn | None = None,
@@ -447,13 +452,12 @@ def _launchd_log_paths(plist: Path) -> tuple[str | None, str | None]:
 
 
 def _pid_text(*, pid_dir: Path | None) -> str:
-    from app.spotty_bunny_launch import spotty_bunny_pid_path
+    from app.spotty_bunny_launch import read_spotty_bunny_runtime
 
-    path = spotty_bunny_pid_path(pid_dir=pid_dir)
-    try:
-        return path.read_text(encoding="utf-8").strip() or "none"
-    except OSError:
+    runtime = read_spotty_bunny_runtime(pid_dir=pid_dir)
+    if runtime is None:
         return "none"
+    return str(runtime[0])
 
 
 def _plist_string(text: str, key: str) -> str | None:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -105,6 +105,8 @@ from app.spotty_bunny_about import (
 )
 from app.spotty_bunny_agent import (
     bootout_loaded_agent,
+    install_agent,
+    is_agent_installed,
     refresh_agent_plist,
     uninstall_agent,
 )
@@ -136,6 +138,7 @@ from app.spotty_bunny_hotkey import (
 from app.spotty_bunny_icon import make_spotty_bunny_icon
 from app.spotty_bunny_io import ThreadIo
 from app.spotty_bunny_menu import (
+    INSTALL_STATUS,
     UNINSTALL_INFORMATIVE,
     UNINSTALL_MENU_TITLE,
     UPGRADE_STATUS,
@@ -306,6 +309,12 @@ class SpottyBunnyController(NSObject):
         self._io.submit(get_build_info, lambda _result: None)
         self._schedule_update_check()
         return self
+
+    def installSpottyBunny_(self, _sender) -> None:
+        """Install the login LaunchAgent, then quit so launchd owns the overlay."""
+        logger.info("install from logo menu")
+        self._set_status(INSTALL_STATUS)
+        self._io.submit(self._perform_install, self._install_ready)
 
     def menuNeedsUpdate_(self, menu) -> None:
         self._rebuild_logo_menu(menu)
@@ -636,6 +645,17 @@ class SpottyBunnyController(NSObject):
             self.table.reloadData()
         self._set_table_visible(False)
 
+    def _install_ready(self, result: object) -> None:
+        def apply() -> None:
+            if isinstance(result, Exception):
+                logger.warning("install failed: %s", result)
+                self._set_status(format_spotty_bunny_status(result))
+                return
+            logger.info("install finished; quitting for LaunchAgent")
+            quit_ns_app(ns_app=NSApp, post_wake=_post_wake_event)
+
+        _run_on_main(apply)
+
     def _layout_search_chrome(
         self, *, table_visible: bool, status_message: str | None = None
     ) -> None:
@@ -715,6 +735,10 @@ class SpottyBunnyController(NSObject):
         if container is not None:
             container.setLineFragmentPadding_(0.0)
 
+    def _perform_install(self) -> None:
+        if install_agent() != 0:
+            raise RuntimeError("LaunchAgent install failed")
+
     def _perform_upgrade(self) -> None:
         from app.cli import run_upgrade
 
@@ -738,7 +762,10 @@ class SpottyBunnyController(NSObject):
 
     def _rebuild_logo_menu(self, menu) -> None:
         menu.removeAllItems()
-        for title, action in logo_menu_specs(outdated=self._update_status.outdated):
+        for title, action in logo_menu_specs(
+            installed=is_agent_installed(),
+            outdated=self._update_status.outdated,
+        ):
             item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
                 title,
                 action,
@@ -987,7 +1014,7 @@ class SpottyBunnyController(NSObject):
 
 
 class SpottyBunnyLogoButton(NSButton):
-    """Bunny icon: left-click About; right-click Quit / Uninstall / Upgrade."""
+    """Bunny icon: left-click About; right-click Install/Quit/Uninstall/Upgrade."""
 
     def rightMouseDown_(self, event) -> None:
         menu = self.menu()

--- a/app/spotty_bunny_cli.py
+++ b/app/spotty_bunny_cli.py
@@ -119,7 +119,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"{COMMAND_NAME}: logging to stderr only", file=sys.stderr)
     if sys.platform == "darwin":
         write_spotty_bunny_pid(os.getpid())
-        atexit.register(clear_spotty_bunny_pid)
+        pid = os.getpid()
+        atexit.register(lambda: clear_spotty_bunny_pid(only_pid=pid))
     return run_spotty_bunny()
 
 

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -18,6 +18,7 @@ from app.version import git_commit
 logger = logging.getLogger(__name__)
 
 RestartFn = Callable[[str | None, str], bool]
+SPOTTY_BUNNY_LAUNCHD_WAIT_S = 2.0
 SPOTTY_BUNNY_PID_FILE = ".spotty-bunny.pid"
 SPOTTY_BUNNY_STARTUP_WAIT_S = 0.05
 
@@ -95,13 +96,20 @@ def ensure_spotty_bunny_running(
         from app.spotty_bunny_agent import install_agent
 
         if install_agent() == 0:
-            time.sleep(SPOTTY_BUNNY_STARTUP_WAIT_S)
-            if spotty_bunny_is_running(pid_dir=directory):
-                logger.info("started spotty-bunny via LaunchAgent")
-                return True
-            logger.warning("LaunchAgent bootstrap did not produce a live overlay")
-        else:
-            logger.warning("LaunchAgent install failed; falling back to spawn")
+            deadline = time.monotonic() + SPOTTY_BUNNY_LAUNCHD_WAIT_S
+            while True:
+                if spotty_bunny_is_running(pid_dir=directory):
+                    logger.info("started spotty-bunny via LaunchAgent")
+                    return True
+                if time.monotonic() >= deadline:
+                    break
+                time.sleep(SPOTTY_BUNNY_STARTUP_WAIT_S)
+            logger.warning(
+                "LaunchAgent bootstrap did not produce a live overlay; "
+                "not spawning a second one"
+            )
+            return False
+        logger.warning("LaunchAgent install failed; falling back to spawn")
     command = spotty_bunny_command()
     spawn_fn = spawn or _spawn_detached
     try:

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -22,13 +22,27 @@ SPOTTY_BUNNY_PID_FILE = ".spotty-bunny.pid"
 SPOTTY_BUNNY_STARTUP_WAIT_S = 0.05
 
 
-def clear_spotty_bunny_pid(*, pid_dir: Path | None = None) -> None:
-    """Remove the recorded Spotty Bunny PID file."""
+def clear_spotty_bunny_pid(
+    *,
+    only_pid: int | None = None,
+    pid_dir: Path | None = None,
+) -> None:
+    """Remove the recorded Spotty Bunny PID file.
+
+    When *only_pid* is set, the file is left in place if it records a
+    different process (so a successor overlay's pid is not erased).
+    """
+    if only_pid is not None:
+        runtime = read_spotty_bunny_runtime(pid_dir=pid_dir)
+        if runtime is None or runtime[0] != only_pid:
+            return
     spotty_bunny_pid_path(pid_dir=pid_dir).unlink(missing_ok=True)
 
 
 def ensure_spotty_bunny_running(
     *,
+    installed: bool | None = None,
+    loaded: bool | None = None,
     pid_dir: Path | None = None,
     restart: RestartFn | None = None,
     spawn: Callable[[Sequence[str]], int] | None = None,
@@ -43,14 +57,19 @@ def ensure_spotty_bunny_running(
         return False
     directory = pid_dir if pid_dir is not None else run_dir()
     current = git_commit()
-    inspect_launchd = pid_dir is None
-    loaded = False
-    installed = False
-    if inspect_launchd:
-        from app.spotty_bunny_agent import is_agent_installed, is_agent_loaded
+    if loaded is None or installed is None:
+        if pid_dir is None:
+            from app.spotty_bunny_agent import is_agent_installed, is_agent_loaded
 
-        loaded = is_agent_loaded()
-        installed = is_agent_installed()
+            if loaded is None:
+                loaded = is_agent_loaded()
+            if installed is None:
+                installed = is_agent_installed()
+        else:
+            if loaded is None:
+                loaded = False
+            if installed is None:
+                installed = False
     runtime = read_spotty_bunny_runtime(pid_dir=directory)
     pid_alive = runtime is not None and _spotty_bunny_process_alive(runtime[0])
     if pid_alive or loaded:
@@ -75,7 +94,14 @@ def ensure_spotty_bunny_running(
     if installed:
         from app.spotty_bunny_agent import install_agent
 
-        return install_agent() == 0
+        if install_agent() == 0:
+            time.sleep(SPOTTY_BUNNY_STARTUP_WAIT_S)
+            if spotty_bunny_is_running(pid_dir=directory):
+                logger.info("started spotty-bunny via LaunchAgent")
+                return True
+            logger.warning("LaunchAgent bootstrap did not produce a live overlay")
+        else:
+            logger.warning("LaunchAgent install failed; falling back to spawn")
     command = spotty_bunny_command()
     spawn_fn = spawn or _spawn_detached
     try:

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -13,9 +13,11 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from app.config import run_dir
+from app.version import git_commit
 
 logger = logging.getLogger(__name__)
 
+RestartFn = Callable[[str | None, str], bool]
 SPOTTY_BUNNY_PID_FILE = ".spotty-bunny.pid"
 SPOTTY_BUNNY_STARTUP_WAIT_S = 0.05
 
@@ -28,18 +30,52 @@ def clear_spotty_bunny_pid(*, pid_dir: Path | None = None) -> None:
 def ensure_spotty_bunny_running(
     *,
     pid_dir: Path | None = None,
+    restart: RestartFn | None = None,
     spawn: Callable[[Sequence[str]], int] | None = None,
 ) -> bool:
     """Start Spotty Bunny in the background when it is not already running.
 
-    Returns ``True`` when a process was already running or was started successfully.
+    When an overlay is already running on a different commit, *restart* is
+    asked whether to stop it and spawn this CLI's build. Returns ``True``
+    when a process was already running or was started successfully.
     """
     if sys.platform != "darwin":
         return False
     directory = pid_dir if pid_dir is not None else run_dir()
-    if spotty_bunny_is_running(pid_dir=directory):
-        logger.debug("spotty-bunny already running (pid file %s)", directory)
-        return True
+    current = git_commit()
+    inspect_launchd = pid_dir is None
+    loaded = False
+    installed = False
+    if inspect_launchd:
+        from app.spotty_bunny_agent import is_agent_installed, is_agent_loaded
+
+        loaded = is_agent_loaded()
+        installed = is_agent_installed()
+    runtime = read_spotty_bunny_runtime(pid_dir=directory)
+    pid_alive = runtime is not None and _spotty_bunny_process_alive(runtime[0])
+    if pid_alive or loaded:
+        running_commit = runtime[1] if runtime is not None else None
+        if running_commit is None or running_commit == current:
+            logger.debug("spotty-bunny already running (pid file %s)", directory)
+            return True
+        if restart is None or not restart(running_commit, current):
+            logger.debug(
+                "spotty-bunny already running with commit %s (cli %s)",
+                running_commit,
+                current,
+            )
+            return True
+        if loaded:
+            from app.spotty_bunny_agent import bootout_loaded_agent
+
+            bootout_loaded_agent()
+        stop_spotty_bunny(pid_dir=directory)
+    elif runtime is not None:
+        spotty_bunny_pid_path(pid_dir=directory).unlink(missing_ok=True)
+    if installed:
+        from app.spotty_bunny_agent import install_agent
+
+        return install_agent() == 0
     command = spotty_bunny_command()
     spawn_fn = spawn or _spawn_detached
     try:
@@ -54,9 +90,24 @@ def ensure_spotty_bunny_running(
     if not _spotty_bunny_process_alive(pid):
         logger.warning("spotty-bunny exited immediately after spawn (pid %s)", pid)
         return False
-    write_spotty_bunny_pid(pid, pid_dir=directory)
+    write_spotty_bunny_pid(pid, pid_dir=directory, commit=current)
     logger.info("started spotty-bunny (pid %s)", pid)
     return True
+
+
+def read_spotty_bunny_runtime(
+    *,
+    pid_dir: Path | None = None,
+) -> tuple[int, str | None] | None:
+    """Return ``(pid, commit)`` from the pid file, or None if missing/invalid."""
+    path = spotty_bunny_pid_path(pid_dir=pid_dir)
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        pid = int(lines[0].strip())
+    except OSError, ValueError, IndexError:
+        return None
+    commit = lines[1].strip() if len(lines) > 1 and lines[1].strip() else None
+    return pid, commit
 
 
 def spotty_bunny_command() -> list[str]:
@@ -69,14 +120,12 @@ def spotty_bunny_command() -> list[str]:
 
 def spotty_bunny_is_running(*, pid_dir: Path | None = None) -> bool:
     """True when the pid file points at a live Spotty Bunny process."""
-    path = spotty_bunny_pid_path(pid_dir=pid_dir)
-    try:
-        raw = path.read_text(encoding="utf-8").strip()
-        pid = int(raw)
-    except OSError, ValueError:
+    runtime = read_spotty_bunny_runtime(pid_dir=pid_dir)
+    if runtime is None:
         return False
+    pid, _commit = runtime
     if not _spotty_bunny_process_alive(pid):
-        path.unlink(missing_ok=True)
+        spotty_bunny_pid_path(pid_dir=pid_dir).unlink(missing_ok=True)
         return False
     return True
 
@@ -89,11 +138,12 @@ def spotty_bunny_pid_path(*, pid_dir: Path | None = None) -> Path:
 
 def stop_spotty_bunny(*, pid_dir: Path | None = None) -> bool:
     """SIGTERM (then SIGKILL) a leftover overlay. Returns True if signaled."""
+    runtime = read_spotty_bunny_runtime(pid_dir=pid_dir)
     path = spotty_bunny_pid_path(pid_dir=pid_dir)
-    try:
-        pid = int(path.read_text(encoding="utf-8").strip())
-    except OSError, ValueError:
+    if runtime is None:
+        path.unlink(missing_ok=True)
         return False
+    pid, _commit = runtime
     if not _spotty_bunny_process_alive(pid):
         path.unlink(missing_ok=True)
         return False
@@ -102,11 +152,17 @@ def stop_spotty_bunny(*, pid_dir: Path | None = None) -> bool:
     return True
 
 
-def write_spotty_bunny_pid(pid: int, *, pid_dir: Path | None = None) -> None:
-    """Record *pid* for later ``spotty_bunny_is_running`` checks."""
+def write_spotty_bunny_pid(
+    pid: int,
+    *,
+    commit: str | None = None,
+    pid_dir: Path | None = None,
+) -> None:
+    """Record *pid* and build commit for later ``spotty_bunny_is_running`` checks."""
     path = spotty_bunny_pid_path(pid_dir=pid_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(f"{pid}\n", encoding="utf-8")
+    recorded = commit if commit is not None else git_commit()
+    path.write_text(f"{pid}\n{recorded}\n", encoding="utf-8")
 
 
 def _is_spotty_bunny_command(command: str) -> bool:

--- a/app/spotty_bunny_menu.py
+++ b/app/spotty_bunny_menu.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+INSTALL_MENU_TITLE = "Install Spotty Bunny"
+INSTALL_STATUS = "Installing LaunchAgent…"
 QUIT_MENU_TITLE = "Quit Spotty Bunny"
 UNINSTALL_INFORMATIVE = (
     "Removes the login LaunchAgent and stops Spotty Bunny. "
@@ -12,16 +14,21 @@ UPGRADE_MENU_TITLE = "Upgrade Spotty Bunny"
 UPGRADE_STATUS = "Upgrading Bunnify from PyPI…"
 
 
-def logo_menu_specs(*, outdated: bool) -> tuple[tuple[str, str], ...]:
+def logo_menu_specs(
+    *,
+    installed: bool,
+    outdated: bool,
+) -> tuple[tuple[str, str], ...]:
     """Return logo menu (title, action) pairs in lexicographic title order.
 
-    Upgrade is included only when a newer PyPI version is known.
+    Install is shown when the LaunchAgent is missing. Upgrade is shown only
+    when the agent is installed and a newer PyPI version is known.
     """
-    items = (
-        (QUIT_MENU_TITLE, "quitSpottyBunny:"),
-        (UNINSTALL_MENU_TITLE, "uninstallSpottyBunny:"),
-        (UPGRADE_MENU_TITLE, "upgradeSpottyBunny:"),
-    )
-    if outdated:
-        return items
-    return tuple(item for item in items if item[0] != UPGRADE_MENU_TITLE)
+    items: list[tuple[str, str]] = [(QUIT_MENU_TITLE, "quitSpottyBunny:")]
+    if installed:
+        items.append((UNINSTALL_MENU_TITLE, "uninstallSpottyBunny:"))
+        if outdated:
+            items.append((UPGRADE_MENU_TITLE, "upgradeSpottyBunny:"))
+    else:
+        items.append((INSTALL_MENU_TITLE, "installSpottyBunny:"))
+    return tuple(sorted(items, key=lambda item: item[0]))

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -830,6 +830,153 @@ class ConfigUnitTests(TestCase):
             self.assertIn("already serving Bunnify 0.2.0 (oldoldoldold)", joined)
             self.assertIn("older than this CLI", joined)
 
+    def test_ensure_ready_base_url_retries_when_restart_start_fails(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.client import ClientError
+        from app.config import ServerPreferences, save_preferences
+
+        remote = _healthy_status(version="0.2.0", commit="oldoldoldold")
+        responses = iter(["y", "n"])
+        starts = {"count": 0}
+
+        def ensure_server(**_kwargs: object) -> tuple[str, int]:
+            starts["count"] += 1
+            if starts["count"] == 1:
+                return ("http://127.0.0.1:8123", 8123)
+            raise RuntimeError("failed to start")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            with (
+                patch(
+                    "app.cli.ensure_user_bookmarks",
+                    return_value=bookmarks,
+                ),
+                patch("app.cli.ensure_local_server", side_effect=ensure_server),
+                patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.stop_local_server"),
+            ):
+                with self.assertRaises(ClientError) as raised:
+                    ensure_ready_base_url(
+                        environ={"XDG_CONFIG_HOME": tmp},
+                        env_path=path,
+                        allow_prompt=True,
+                        prompt_fn=lambda _message: next(responses),
+                        print_fn=lambda _message: None,
+                    )
+
+            self.assertIn("failed to start", str(raised.exception))
+
+    def test_ensure_ready_base_url_reuses_server_when_restart_declined(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.config import ServerPreferences, save_preferences
+
+        remote = _healthy_status(version="0.2.0", commit="oldoldoldold")
+        messages: list[str] = []
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            with (
+                patch(
+                    "app.cli.ensure_user_bookmarks",
+                    return_value=bookmarks,
+                ),
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8123", 8123),
+                ) as ensure_server,
+                patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.stop_local_server") as stop_server,
+            ):
+                result = ensure_ready_base_url(
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    allow_prompt=True,
+                    prompt_fn=lambda _message: "",
+                    print_fn=messages.append,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8123")
+            self.assertEqual(ensure_server.call_count, 1)
+            stop_server.assert_not_called()
+            self.assertIn("Reusing the running server", "\n".join(messages))
+
+    def test_ensure_ready_base_url_reuses_when_stop_fails_and_server_healthy(
+        self,
+    ) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.config import ServerPreferences, save_preferences
+
+        remote = _healthy_status(version="0.2.0", commit="oldoldoldold")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            with (
+                patch(
+                    "app.cli.ensure_user_bookmarks",
+                    return_value=bookmarks,
+                ),
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8123", 8123),
+                ) as ensure_server,
+                patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch("app.cli.check_health", return_value=True),
+                patch(
+                    "app.cli.stop_local_server",
+                    side_effect=RuntimeError("Port 8123 is still busy after stop"),
+                ),
+            ):
+                result = ensure_ready_base_url(
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    allow_prompt=True,
+                    prompt_fn=lambda _message: "y",
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8123")
+            self.assertEqual(ensure_server.call_count, 1)
+
     def test_ensure_ready_base_url_remote_unreachable_raises(self) -> None:
         import tempfile
         from pathlib import Path

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -774,6 +774,62 @@ class ConfigUnitTests(TestCase):
                 print_fn=ANY,
             )
 
+    def test_ensure_ready_base_url_offers_restart_on_commit_mismatch(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.config import ServerPreferences, save_preferences
+
+        remote = _healthy_status(version="0.2.0", commit="oldoldoldold")
+        health_ok = {"value": True}
+        messages: list[str] = []
+
+        def check_health(_url: str) -> bool:
+            return health_ok["value"]
+
+        def stop_server(_pid_dir: object, **_kwargs: object) -> None:
+            health_ok["value"] = False
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            with (
+                patch(
+                    "app.cli.ensure_user_bookmarks",
+                    return_value=bookmarks,
+                ),
+                patch(
+                    "app.cli.ensure_local_server",
+                    return_value=("http://127.0.0.1:8123", 8123),
+                ) as ensure_server,
+                patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch("app.cli.check_health", side_effect=check_health),
+                patch("app.cli.stop_local_server", side_effect=stop_server),
+            ):
+                result = ensure_ready_base_url(
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    allow_prompt=True,
+                    prompt_fn=lambda _message: "y",
+                    print_fn=messages.append,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8123")
+            self.assertEqual(ensure_server.call_count, 2)
+            joined = "\n".join(messages)
+            self.assertIn("already serving Bunnify 0.2.0 (oldoldoldold)", joined)
+            self.assertIn("older than this CLI", joined)
+
     def test_ensure_ready_base_url_remote_unreachable_raises(self) -> None:
         import tempfile
         from pathlib import Path
@@ -874,6 +930,8 @@ class ConfigUnitTests(TestCase):
                     ],
                 ) as ensure_server,
                 patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=_healthy_status()),
+                patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
             ):
                 result = ensure_ready_base_url(
                     environ={"XDG_CONFIG_HOME": tmp},

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1679,6 +1679,34 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 )
             bootout.assert_called_once()
 
+    def test_ensure_spotty_bunny_running_does_not_spawn_after_install_timeout(
+        self,
+    ) -> None:
+        from app.spotty_bunny_launch import ensure_spotty_bunny_running
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch("app.spotty_bunny_agent.install_agent", return_value=0),
+                patch(
+                    "app.spotty_bunny_launch.SPOTTY_BUNNY_LAUNCHD_WAIT_S",
+                    0,
+                ),
+                patch(
+                    "app.spotty_bunny_launch.spotty_bunny_is_running",
+                    return_value=False,
+                ),
+            ):
+                self.assertFalse(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        installed=True,
+                        loaded=False,
+                        spawn=lambda _cmd: self.fail("should not spawn"),
+                    )
+                )
+
     def test_ensure_spotty_bunny_running_installs_when_agent_present(self) -> None:
         from app.spotty_bunny_launch import ensure_spotty_bunny_running
 
@@ -1704,6 +1732,38 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                     )
                 )
             install.assert_called_once()
+
+    def test_ensure_spotty_bunny_running_polls_until_launchd_overlay_is_live(
+        self,
+    ) -> None:
+        from app.spotty_bunny_launch import ensure_spotty_bunny_running
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch("app.spotty_bunny_agent.install_agent", return_value=0),
+                patch(
+                    "app.spotty_bunny_launch.SPOTTY_BUNNY_LAUNCHD_WAIT_S",
+                    1.0,
+                ),
+                patch(
+                    "app.spotty_bunny_launch.SPOTTY_BUNNY_STARTUP_WAIT_S",
+                    0,
+                ),
+                patch(
+                    "app.spotty_bunny_launch.spotty_bunny_is_running",
+                    side_effect=[False, False, True],
+                ),
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        installed=True,
+                        loaded=False,
+                        spawn=lambda _cmd: self.fail("should not spawn"),
+                    )
+                )
 
     def test_ensure_spotty_bunny_running_spawns_when_install_fails(self) -> None:
         from app.spotty_bunny_launch import (

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -268,6 +268,44 @@ class SpottyBunnyCliTests(SimpleTestCase):
 
 
 class SpottyBunnyAboutInfoTests(SimpleTestCase):
+    def test_about_link_spans_search_left_to_right(self) -> None:
+        from app.spotty_bunny_about_info import about_link_spans
+
+        text = "Repository: github.com/the-hcma/bunnify\nLicense: MIT License"
+        spans = about_link_spans(
+            text,
+            (
+                ("github.com/the-hcma/bunnify", "https://github.com/the-hcma/bunnify"),
+                ("MIT License", "https://example.com/license"),
+            ),
+        )
+        self.assertEqual(
+            spans,
+            (
+                (
+                    text.index("github.com/the-hcma/bunnify"),
+                    len("github.com/the-hcma/bunnify"),
+                    "https://github.com/the-hcma/bunnify",
+                ),
+                (
+                    text.index("MIT License"),
+                    len("MIT License"),
+                    "https://example.com/license",
+                ),
+            ),
+        )
+        nested = about_link_spans(
+            "github.com/the-hcma/bunnify",
+            (
+                ("github.com/the-hcma/bunnify", "https://repo"),
+                ("bunnify", "https://skipped-if-before-cursor"),
+            ),
+        )
+        self.assertEqual(
+            nested,
+            ((0, len("github.com/the-hcma/bunnify"), "https://repo"),),
+        )
+
     def test_display_user_path_uses_tilde_for_home(self) -> None:
         from app.spotty_bunny_about_info import display_user_path
 
@@ -320,6 +358,31 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             bookmarks = Path(tmp) / "bookmarks.json"
             bookmarks.write_text("{}", encoding="utf-8")
             self.assertIsNone(github_repo_url_for_path(bookmarks))
+
+    def test_handle_about_link_click_leaves_https_to_appkit(self) -> None:
+        from app.spotty_bunny_about_info import handle_about_link_click
+
+        def run(
+            _argv: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            self.fail("https links must not call open -t")
+            return subprocess.CompletedProcess([], 1, "", "")
+
+        self.assertFalse(
+            handle_about_link_click("https://github.com/the-hcma/bunnify", run=run)
+        )
+
+    def test_handle_about_link_click_opens_file_uri(self) -> None:
+        from app.spotty_bunny_about_info import handle_about_link_click
+
+        calls: list[list[str]] = []
+
+        def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        self.assertTrue(handle_about_link_click("file:///tmp/bookmarks.json", run=run))
+        self.assertEqual(calls, [["open", "-t", "/tmp/bookmarks.json"]])
 
     def test_load_about_runtime_info_local_server_and_file_link(self) -> None:
         from app.spotty_bunny_about_info import load_about_runtime_info
@@ -1575,6 +1638,113 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 "99\nnewcommit\n",
             )
 
+    def test_ensure_spotty_bunny_running_bootout_then_installs(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            (pid_dir / SPOTTY_BUNNY_PID_FILE).write_text(
+                "4242\noldcommit\n",
+                encoding="utf-8",
+            )
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch.git_commit",
+                    return_value="newcommit",
+                ),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+                patch("app.spotty_bunny_launch._terminate_pid"),
+                patch("app.spotty_bunny_agent.bootout_loaded_agent") as bootout,
+                patch("app.spotty_bunny_agent.install_agent", return_value=0),
+                patch(
+                    "app.spotty_bunny_launch.spotty_bunny_is_running",
+                    return_value=True,
+                ),
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        installed=True,
+                        loaded=True,
+                        restart=lambda _recorded, _current: True,
+                        spawn=lambda _cmd: self.fail("should not spawn"),
+                    )
+                )
+            bootout.assert_called_once()
+
+    def test_ensure_spotty_bunny_running_installs_when_agent_present(self) -> None:
+        from app.spotty_bunny_launch import ensure_spotty_bunny_running
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_agent.install_agent",
+                    return_value=0,
+                ) as install,
+                patch(
+                    "app.spotty_bunny_launch.spotty_bunny_is_running",
+                    return_value=True,
+                ),
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        installed=True,
+                        loaded=False,
+                        spawn=lambda _cmd: self.fail("should not spawn"),
+                    )
+                )
+            install.assert_called_once()
+
+    def test_ensure_spotty_bunny_running_spawns_when_install_fails(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        spawned: list[int] = []
+
+        def spawn(_cmd: object) -> int:
+            spawned.append(99)
+            return 99
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch.git_commit",
+                    return_value="abc1234",
+                ),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+                patch("app.spotty_bunny_agent.install_agent", return_value=1),
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        installed=True,
+                        loaded=False,
+                        spawn=spawn,
+                    )
+                )
+            self.assertEqual(spawned, [99])
+            self.assertEqual(
+                (pid_dir / SPOTTY_BUNNY_PID_FILE).read_text(encoding="utf-8"),
+                "99\nabc1234\n",
+            )
+
     def test_ensure_spotty_bunny_running_fails_when_child_exits(self) -> None:
         from app.spotty_bunny_launch import (
             SPOTTY_BUNNY_PID_FILE,
@@ -1634,6 +1804,21 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 )
             self.assertEqual(len(spawned), 1)
             self.assertEqual(pid_path.read_text(encoding="utf-8"), "4242\nabc1234\n")
+
+    def test_clear_spotty_bunny_pid_leaves_successor(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            clear_spotty_bunny_pid,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            pid_path = pid_dir / SPOTTY_BUNNY_PID_FILE
+            pid_path.write_text("99\nnewcommit\n", encoding="utf-8")
+            clear_spotty_bunny_pid(only_pid=1, pid_dir=pid_dir)
+            self.assertTrue(pid_path.exists())
+            clear_spotty_bunny_pid(only_pid=99, pid_dir=pid_dir)
+            self.assertFalse(pid_path.exists())
 
     def test_stop_spotty_bunny_clears_pid_file(self) -> None:
         from app.spotty_bunny_launch import (
@@ -1707,12 +1892,15 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("Repository:", source)
         self.assertIn("_multi_link_field", source)
         self.assertIn("textView_clickedOnLink_atIndex_", source)
+        self.assertIn("handle_about_link_click", source)
         info_source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_about_info.py"
         ).read_text(encoding="utf-8")
         self.assertIn("Local server", info_source)
         self.assertIn("Remote server", info_source)
         self.assertIn('["open", "-t", str(path)]', info_source)
+        self.assertIn("def about_link_spans", info_source)
+        self.assertIn("def handle_about_link_click", info_source)
 
     def test_search_field_is_centered_with_logo_on_right(self) -> None:
         source = (

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -373,6 +373,28 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             )
             self.assertEqual(info.server_url, "https://bun.example.com")
 
+    def test_open_path_in_text_editor_uses_open_t(self) -> None:
+        from app.spotty_bunny_about_info import open_path_in_text_editor
+
+        calls: list[list[str]] = []
+
+        def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(list(argv))
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        path = Path("/tmp/bookmarks.json")
+        self.assertTrue(open_path_in_text_editor(path, run=run))
+        self.assertEqual(calls, [["open", "-t", str(path)]])
+
+    def test_path_from_file_uri_decodes_path(self) -> None:
+        from app.spotty_bunny_about_info import path_from_file_uri
+
+        self.assertEqual(
+            path_from_file_uri("file:///tmp/bookmarks.json"),
+            Path("/tmp/bookmarks.json"),
+        )
+        self.assertIsNone(path_from_file_uri("https://example.com/x"))
+
 
 class SpottyBunnyAgentTests(SimpleTestCase):
     def test_bootout_loaded_agent_issues_bootout_when_loaded(self) -> None:
@@ -569,6 +591,17 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 interpreter_for_program(script),
                 Path("/opt/pipx/venvs/bunnify/bin/python"),
             )
+
+    def test_is_agent_installed_checks_plist(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, is_agent_installed
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            self.assertFalse(is_agent_installed(home=home))
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            plist.write_text("plist", encoding="utf-8")
+            self.assertTrue(is_agent_installed(home=home))
 
     def test_status_reports_log_version_and_tcc(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
@@ -1443,6 +1476,10 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
             with (
                 patch("app.spotty_bunny_launch.sys.platform", "darwin"),
                 patch(
+                    "app.spotty_bunny_launch.git_commit",
+                    return_value="abc1234",
+                ),
+                patch(
                     "app.spotty_bunny_launch._spotty_bunny_process_alive",
                     return_value=True,
                 ),
@@ -1455,7 +1492,87 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 )
             self.assertEqual(
                 (pid_dir / SPOTTY_BUNNY_PID_FILE).read_text(encoding="utf-8"),
-                "4242\n",
+                "4242\nabc1234\n",
+            )
+
+    def test_ensure_spotty_bunny_running_keeps_mismatch_when_declined(
+        self,
+    ) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            (pid_dir / SPOTTY_BUNNY_PID_FILE).write_text(
+                "4242\noldcommit\n",
+                encoding="utf-8",
+            )
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch.git_commit",
+                    return_value="newcommit",
+                ),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        restart=lambda _recorded, _current: False,
+                        spawn=lambda _cmd: self.fail("should not spawn"),
+                    )
+                )
+
+    def test_ensure_spotty_bunny_running_restarts_on_commit_mismatch(
+        self,
+    ) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        spawned: list[int] = []
+
+        def spawn(_cmd: object) -> int:
+            spawned.append(99)
+            return 99
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            (pid_dir / SPOTTY_BUNNY_PID_FILE).write_text(
+                "4242\noldcommit\n",
+                encoding="utf-8",
+            )
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch.git_commit",
+                    return_value="newcommit",
+                ),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+                patch("app.spotty_bunny_launch._terminate_pid"),
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        pid_dir=pid_dir,
+                        restart=lambda recorded, current: (
+                            recorded == "oldcommit" and current == "newcommit"
+                        ),
+                        spawn=spawn,
+                    )
+                )
+            self.assertEqual(spawned, [99])
+            self.assertEqual(
+                (pid_dir / SPOTTY_BUNNY_PID_FILE).read_text(encoding="utf-8"),
+                "99\nnewcommit\n",
             )
 
     def test_ensure_spotty_bunny_running_fails_when_child_exits(self) -> None:
@@ -1504,6 +1621,10 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
             with (
                 patch("app.spotty_bunny_launch.sys.platform", "darwin"),
                 patch(
+                    "app.spotty_bunny_launch.git_commit",
+                    return_value="abc1234",
+                ),
+                patch(
                     "app.spotty_bunny_launch._spotty_bunny_process_alive",
                     return_value=True,
                 ),
@@ -1512,7 +1633,7 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                     ensure_spotty_bunny_running(pid_dir=pid_dir, spawn=spawn)
                 )
             self.assertEqual(len(spawned), 1)
-            self.assertEqual(pid_path.read_text(encoding="utf-8"), "4242\n")
+            self.assertEqual(pid_path.read_text(encoding="utf-8"), "4242\nabc1234\n")
 
     def test_stop_spotty_bunny_clears_pid_file(self) -> None:
         from app.spotty_bunny_launch import (
@@ -1582,11 +1703,16 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("load_about_runtime_info", source)
         self.assertIn("Bookmarks:", source)
         self.assertIn("GitHub:", source)
+        self.assertIn("License:", source)
+        self.assertIn("Repository:", source)
+        self.assertIn("_multi_link_field", source)
+        self.assertIn("textView_clickedOnLink_atIndex_", source)
         info_source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_about_info.py"
         ).read_text(encoding="utf-8")
         self.assertIn("Local server", info_source)
         self.assertIn("Remote server", info_source)
+        self.assertIn('["open", "-t", str(path)]', info_source)
 
     def test_search_field_is_centered_with_logo_on_right(self) -> None:
         source = (
@@ -1625,17 +1751,21 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertNotIn('setTitle_("spotty-bunny")', source)
         self.assertIn("showAbout:", source)
         self.assertIn("SpottyBunnyLogoButton", source)
+        self.assertIn("def installSpottyBunny_", source)
         self.assertIn("def quitSpottyBunny_", source)
         self.assertIn("def uninstallSpottyBunny_", source)
         self.assertIn("def upgradeSpottyBunny_", source)
         self.assertIn("menuNeedsUpdate_", source)
-        self.assertIn("outdated=outdated", source)
+        self.assertIn("installed=is_agent_installed()", source)
+        self.assertIn("outdated=self._update_status.outdated", source)
         menu_source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_menu.py"
         ).read_text(encoding="utf-8")
+        self.assertIn("Install Spotty Bunny", menu_source)
         self.assertIn("Quit Spotty Bunny", menu_source)
         self.assertIn("Uninstall Spotty Bunny", menu_source)
         self.assertIn("Upgrade Spotty Bunny", menu_source)
+        self.assertIn("installSpottyBunny:", menu_source)
         self.assertIn("quitSpottyBunny:", menu_source)
         self.assertIn("uninstallSpottyBunny:", menu_source)
         self.assertIn("upgradeSpottyBunny:", menu_source)
@@ -1939,20 +2069,25 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
 
     def test_logo_menu_specs_are_sorted_and_hide_upgrade_when_current(self) -> None:
         from app.spotty_bunny_menu import (
+            INSTALL_MENU_TITLE,
             QUIT_MENU_TITLE,
             UNINSTALL_MENU_TITLE,
             UPGRADE_MENU_TITLE,
             logo_menu_specs,
         )
 
-        current = logo_menu_specs(outdated=False)
+        missing = logo_menu_specs(installed=False, outdated=True)
+        missing_titles = [title for title, _action in missing]
+        self.assertEqual(missing_titles, sorted(missing_titles))
+        self.assertEqual(missing_titles, [INSTALL_MENU_TITLE, QUIT_MENU_TITLE])
+        current = logo_menu_specs(installed=True, outdated=False)
         titles = [title for title, _action in current]
         self.assertEqual(titles, sorted(titles))
         self.assertEqual(
             titles,
             [QUIT_MENU_TITLE, UNINSTALL_MENU_TITLE],
         )
-        outdated = logo_menu_specs(outdated=True)
+        outdated = logo_menu_specs(installed=True, outdated=True)
         outdated_titles = [title for title, _action in outdated]
         self.assertEqual(outdated_titles, sorted(outdated_titles))
         self.assertEqual(

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -157,10 +157,17 @@ icon and choose **Quit Spotty Bunny**. That exits the process and boots the
 agent out so KeepAlive cannot immediately respawn it. The plist stays; the
 agent starts again at next login (`RunAtLoad`) until you `uninstall`.
 
-The same menu lists **Uninstall Spotty Bunny** (confirms, then removes the
-plist before booting the agent out) and, when a newer PyPI release is known,
-**Upgrade Spotty Bunny** (`pipx upgrade`, rewrite the plist, then quit so
-KeepAlive relaunches). Items are listed A–Z by title.
+The same menu lists **Install Spotty Bunny** when the LaunchAgent is missing
+(then quits so launchd owns the overlay). When the agent is installed it
+offers **Uninstall Spotty Bunny** (confirms, then removes the plist before
+booting the agent out) and, when a newer PyPI release is known, **Upgrade
+Spotty Bunny** (`pipx upgrade`, rewrite the plist, then quit so KeepAlive
+relaunches). Items are listed A–Z by title.
+
+Invoking `bunnify` reuses a running local server and Spotty Bunny overlay
+when they match this CLI's commit. If either is missing it is started; if
+either is running an older or different commit, the CLI offers to restart
+it.
 
 Spotty Bunny checks PyPI at most once per day (cached as
 `pypi-latest.json` under the data directory). When this install is behind,


### PR DESCRIPTION
## Summary
- Reuse a running Spotty Bunny overlay and local server when they match this CLI's commit; start them when missing, and offer a restart when the commit differs.
- Label About's repository and license rows, stack them without extra gap, and open the bookmarks file in the default text editor (`open -t`).
- Right-click the logo for **Install** when the LaunchAgent is missing, and for **Upgrade** only when the install is behind PyPI.

## Test plan
- [x] `scripts/checks` (ruff, pyright, shellcheck, `./test_bunnify`, packaging smoke, integration)
- [ ] On macOS, invoke `bunnify` twice and confirm a second overlay/server is not spawned when the commit matches
- [ ] With a mismatched overlay or server commit, confirm the CLI offers a restart and respects yes/no
- [ ] About: repository/license labels with no extra blank line; bookmarks click opens the default text editor
- [ ] Right-click: Install when uninstalled; Quit/Uninstall when installed; Upgrade only when outdated

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>