### PR TITLE
fix: harden spotty-bunny LaunchAgent install and TCC handling

### DIFF
--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -171,12 +171,9 @@ def interpreter_for_program(program: Path) -> Path:
     if pipx_exec:
         return Path(pipx_exec.group("python"))
 
-    shell_exec = re.search(
-        r"exec\s+(?:\"|\')?(?P<python>[^\"'\n]+?/bin/python(?:3(?:\.\d+)?)?)",
-        raw,
-    )
-    if shell_exec:
-        return Path(shell_exec.group("python"))
+    shell_exec = _shell_exec_python_from_wrapper(raw)
+    if shell_exec is not None:
+        return shell_exec
 
     first_line = raw.splitlines()[:1]
     if not first_line or not first_line[0].startswith("#!"):
@@ -326,13 +323,19 @@ def status_agent(
         return 1
     root = home if home is not None else Path.home()
     plist = agent_plist_path(home=root)
-    binary = program if program is not None else spotty_bunny_program()
-    loaded = is_agent_loaded(launchctl=launchctl) if plist.is_file() else False
+    installed = plist.is_file()
+    if program is not None:
+        binary = program
+    elif installed:
+        plist_argv = _plist_program_arguments(plist)
+        binary = Path(plist_argv[0]) if plist_argv else spotty_bunny_program()
+    else:
+        binary = spotty_bunny_program()
+    loaded = is_agent_loaded(launchctl=launchctl) if installed else False
     running = spotty_bunny_is_running(pid_dir=pid_dir)
     pid_text = "none"
     if running:
         pid_text = _pid_text(pid_dir=pid_dir)
-    installed = plist.is_file()
     interpreter = interpreter_for_program(binary) if binary is not None else None
     binary_ok = binary is not None and _program_launch_target_ok(Path(binary))
     tcc = _probe_tcc_for_status(
@@ -721,6 +724,24 @@ def _probe_tcc_for_status(
         return TccStatus(False, False)
     except OSError, subprocess.SubprocessError, ValueError:
         return TccStatus(False, False)
+
+
+def _shell_exec_python_from_wrapper(raw: str) -> Path | None:
+    """Return the python path from a bash ``exec`` line, ignoring comments."""
+    pattern = re.compile(
+        r"^exec\s+(?:\"|\')?(?P<python>[^\"'\n]+?/bin/python(?:3(?:\.\d+)?)?)",
+    )
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = pattern.match(stripped)
+        if match is None:
+            continue
+        token = match.group("python").strip("\"'")
+        expanded = token.replace("$HOME", str(Path.home()))
+        return Path(expanded).expanduser()
+    return None
 
 
 def _write_plist(plist: Path, *, home: Path, program_arguments: Sequence[str]) -> None:

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -32,6 +32,9 @@ AGENT_LABEL = "com.thehcma.bunnify.spotty-bunny"
 AGENT_PLIST_NAME = f"{AGENT_LABEL}.plist"
 LAUNCHCTL_TIMEOUT_S = 10
 LAUNCHD_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+POST_INSTALL_HINT = (
+    f"{COMMAND_NAME}: hold one Control and press the other to test the overlay."
+)
 TCC_INSTRUCTIONS = f"""\
 {COMMAND_NAME}: Accessibility and Input Monitoring must be granted to the
 Python interpreter launchd will exec (the pipx/venv interpreter behind
@@ -120,7 +123,15 @@ def install_agent(
     if program_argv is None or binary is None:
         err(f"{COMMAND_NAME}: could not find the spotty-bunny binary on PATH.")
         return 1
-    interpreter = interpreter_for_program(Path(program_argv[0]))
+    prepared = _prepare_program_launch(
+        program_argv=program_argv,
+        binary=binary,
+        err=err,
+        plist=None,
+    )
+    if prepared is None:
+        return 1
+    program_argv, binary, interpreter = prepared
     status = _require_current_tcc(
         interpreter,
         err=err,
@@ -138,6 +149,8 @@ def install_agent(
         return 1
     err(f"{COMMAND_NAME}: installed LaunchAgent {AGENT_LABEL}")
     err(f"{COMMAND_NAME}: plist {plist}")
+    err(f"{COMMAND_NAME}: interpreter {interpreter_realpath(interpreter)}")
+    err(POST_INSTALL_HINT)
     return 0
 
 
@@ -158,6 +171,13 @@ def interpreter_for_program(program: Path) -> Path:
     if pipx_exec:
         return Path(pipx_exec.group("python"))
 
+    shell_exec = re.search(
+        r"exec\s+(?:\"|\')?(?P<python>[^\"'\n]+?/bin/python(?:3(?:\.\d+)?)?)",
+        raw,
+    )
+    if shell_exec:
+        return Path(shell_exec.group("python"))
+
     first_line = raw.splitlines()[:1]
     if not first_line or not first_line[0].startswith("#!"):
         return program
@@ -174,6 +194,14 @@ def interpreter_for_program(program: Path) -> Path:
             return Path(parts[1])
         return Path(resolved)
     return executable
+
+
+def interpreter_realpath(interpreter: Path) -> Path:
+    """Return the canonical interpreter path for TCC display and comparisons."""
+    try:
+        return Path(os.path.realpath(interpreter))
+    except OSError:
+        return interpreter
 
 
 def is_agent_installed(*, home: Path | None = None) -> bool:
@@ -306,6 +334,7 @@ def status_agent(
         pid_text = _pid_text(pid_dir=pid_dir)
     installed = plist.is_file()
     interpreter = interpreter_for_program(binary) if binary is not None else None
+    binary_ok = binary is not None and _program_launch_target_ok(Path(binary))
     tcc = _probe_tcc_for_status(
         interpreter,
         err=err,
@@ -319,7 +348,16 @@ def status_agent(
         out("launchd: not installed")
     else:
         out(f"launchd: {'loaded' if loaded else 'not loaded'}")
-    out(f"binary: {binary if binary is not None else 'none'}")
+    if binary is None:
+        out("binary: none")
+    elif binary_ok:
+        out(f"binary: {binary}")
+    else:
+        out(f"binary: {binary} (missing or not executable)")
+    if interpreter is None:
+        out("interpreter: none")
+    else:
+        out(f"interpreter: {interpreter_realpath(interpreter)}")
     out(f"application_log: {app_log}")
     out(f'follow_logs: tail --follow=name --retry "{app_log}"')
     out(f'follow_logs_alt: tail -f "{app_log}"')
@@ -328,7 +366,8 @@ def status_agent(
     out(f"version: {build_version()}")
     out(f"accessibility: {'yes' if tcc.accessibility else 'no'}")
     out(f"input_monitoring: {'yes' if tcc.input_monitoring else 'no'}")
-    return 0 if installed and loaded and running else 1
+    healthy = installed and loaded and running and binary_ok
+    return 0 if healthy else 1
 
 
 def uninstall_agent(
@@ -388,7 +427,15 @@ def upgrade_agent(
     if program_argv is None or binary is None:
         err(f"{COMMAND_NAME}: could not find the spotty-bunny binary on PATH.")
         return 1
-    interpreter = interpreter_for_program(Path(program_argv[0]))
+    prepared = _prepare_program_launch(
+        program_argv=program_argv,
+        binary=binary,
+        err=err,
+        plist=plist,
+    )
+    if prepared is None:
+        return 1
+    program_argv, binary, interpreter = prepared
     status = _require_current_tcc(
         interpreter,
         err=err,
@@ -407,6 +454,8 @@ def upgrade_agent(
             return 1
     err(f"{COMMAND_NAME}: refreshed LaunchAgent {AGENT_LABEL}")
     err(f"{COMMAND_NAME}: binary {binary}")
+    err(f"{COMMAND_NAME}: interpreter {interpreter_realpath(interpreter)}")
+    err(POST_INSTALL_HINT)
     return 0
 
 
@@ -476,6 +525,79 @@ def _pid_text(*, pid_dir: Path | None) -> str:
     if runtime is None:
         return "none"
     return str(runtime[0])
+
+
+def _plist_program_arguments(plist: Path) -> list[str] | None:
+    if not plist.is_file():
+        return None
+    try:
+        text = plist.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    marker = "<key>ProgramArguments</key>"
+    start = text.find(marker)
+    if start < 0:
+        return None
+    chunk = text[start:]
+    array_start = chunk.find("<array>")
+    array_end = chunk.find("</array>")
+    if array_start < 0 or array_end < 0 or array_end <= array_start:
+        return None
+    body = chunk[array_start + len("<array>") : array_end]
+    args: list[str] = []
+    while True:
+        open_tag = body.find("<string>")
+        if open_tag < 0:
+            break
+        close_tag = body.find("</string>", open_tag)
+        if close_tag < 0:
+            break
+        args.append(body[open_tag + len("<string>") : close_tag])
+        body = body[close_tag + len("</string>") :]
+    return args or None
+
+
+def _prepare_program_launch(
+    *,
+    program_argv: list[str],
+    binary: Path,
+    err: Callable[[str], None],
+    plist: Path | None,
+) -> tuple[list[str], Path, Path] | None:
+    launch_binary = Path(program_argv[0])
+    if not _program_launch_target_ok(launch_binary):
+        err(
+            f"{COMMAND_NAME}: binary missing or not executable: "
+            f"{launch_binary.expanduser()}"
+        )
+        return None
+    interpreter = interpreter_for_program(launch_binary)
+    if plist is not None and plist.is_file():
+        old_argv = _plist_program_arguments(plist)
+        if old_argv:
+            old_interp = interpreter_realpath(
+                interpreter_for_program(Path(old_argv[0]))
+            )
+            new_interp = interpreter_realpath(interpreter)
+            if old_interp != new_interp:
+                err(
+                    f"{COMMAND_NAME}: Python interpreter changed "
+                    f"({old_interp} → {new_interp})."
+                )
+                err(
+                    f"{COMMAND_NAME}: re-grant Accessibility and Input Monitoring "
+                    f"to {new_interp} in System Settings → Privacy & Security, "
+                    f"then re-run: {COMMAND_NAME} upgrade"
+                )
+    return program_argv, binary, interpreter
+
+
+def _program_launch_target_ok(path: Path) -> bool:
+    try:
+        resolved = path.expanduser().resolve(strict=False)
+    except OSError:
+        return False
+    return resolved.is_file() and os.access(resolved, os.X_OK)
 
 
 def _plist_string(text: str, key: str) -> str | None:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -76,6 +76,7 @@ from Quartz import (
     CGEventSourceKeyState,
     CGEventTapCreate,
     CGEventTapEnable,
+    CGRequestListenEventAccess,
     kCFRunLoopCommonModes,
     kCGEventFlagMaskAlternate,
     kCGEventFlagMaskCommand,
@@ -1319,9 +1320,10 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
                 controller.chord.held_left,
                 controller.chord.held_right,
             )
-            controller.toggle()
+            _run_on_main(lambda: controller.toggle())
         return event
 
+    CGRequestListenEventAccess()
     tap = CGEventTapCreate(
         kCGSessionEventTap,
         kCGHeadInsertEventTap,

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -146,6 +146,9 @@ def read_spotty_bunny_runtime(
 
 def spotty_bunny_command() -> list[str]:
     """Return the argv used to launch Spotty Bunny."""
+    local = Path.home() / ".local" / "bin" / "spotty-bunny"
+    if local.is_file():
+        return [str(local)]
     binary = shutil.which("spotty-bunny")
     if binary:
         return [binary]

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -147,7 +147,7 @@ def read_spotty_bunny_runtime(
 def spotty_bunny_command() -> list[str]:
     """Return the argv used to launch Spotty Bunny."""
     local = Path.home() / ".local" / "bin" / "spotty-bunny"
-    if local.is_file():
+    if local.is_file() and os.access(local, os.X_OK):
         return [str(local)]
     binary = shutil.which("spotty-bunny")
     if binary:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -857,6 +857,38 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 Path("/opt/pipx/venvs/bunnify/bin/python"),
             )
 
+    def test_interpreter_for_program_expands_home_in_exec_line(self) -> None:
+        from app.spotty_bunny_agent import interpreter_for_program
+
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "spotty-bunny"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                'exec "$HOME/.local/share/uv/python/cpython-3.14/bin/python" '
+                '-m app.spotty_bunny_cli "$@"\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                interpreter_for_program(script),
+                Path.home() / ".local/share/uv/python/cpython-3.14/bin/python",
+            )
+
+    def test_interpreter_for_program_ignores_commented_exec_line(self) -> None:
+        from app.spotty_bunny_agent import interpreter_for_program
+
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "spotty-bunny"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "# old: exec /usr/local/bin/python2.7\n"
+                'exec "/opt/venvs/bunnify/bin/python" -m app.spotty_bunny_cli "$@"\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                interpreter_for_program(script),
+                Path("/opt/venvs/bunnify/bin/python"),
+            )
+
     def test_install_rejects_missing_binary(self) -> None:
         from app.spotty_bunny_agent import install_agent
 
@@ -931,6 +963,40 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertIn("version: " + build_version(), text)
             self.assertIn("accessibility: yes", text)
             self.assertIn("input_monitoring: no", text)
+
+    def test_status_fails_when_plist_binary_missing(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = True
+        stdout = StringIO()
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            stale = home / "removed-spotty-bunny"
+            plist.write_text(
+                format_agent_plist(
+                    home=home,
+                    program_arguments=[str(stale)],
+                ),
+                encoding="utf-8",
+            )
+            with patch(
+                "app.spotty_bunny_agent.spotty_bunny_is_running",
+                return_value=True,
+            ):
+                code = status_agent(
+                    home=home,
+                    launchctl=ctl,
+                    platform="darwin",
+                    print_fn=lambda line: stdout.write(line + "\n"),
+                    probe_tcc=lambda _p: TccStatus(True, True),
+                )
+            text = stdout.getvalue()
+            self.assertEqual(code, 1)
+            self.assertIn("missing or not executable", text)
+            self.assertIn(str(stale), text)
 
     def test_uninstall_bootout_removes_plist_and_pid(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, uninstall_agent
@@ -2055,6 +2121,50 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                     )
                 )
             self.assertFalse((pid_dir / SPOTTY_BUNNY_PID_FILE).exists())
+
+    def test_spotty_bunny_command_prefers_executable_local_bin(self) -> None:
+        from app.spotty_bunny_launch import spotty_bunny_command
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            local_bin = home / ".local" / "bin"
+            local_bin.mkdir(parents=True)
+            preferred = local_bin / "spotty-bunny"
+            _write_executable(preferred)
+            path_bin = home / "path-bin"
+            path_bin.mkdir()
+            other = path_bin / "spotty-bunny"
+            _write_executable(other)
+            with (
+                patch("app.spotty_bunny_launch.Path.home", return_value=home),
+                patch(
+                    "app.spotty_bunny_launch.shutil.which",
+                    return_value=str(other),
+                ),
+            ):
+                self.assertEqual(spotty_bunny_command(), [str(preferred)])
+
+    def test_spotty_bunny_command_skips_non_executable_local_bin(self) -> None:
+        from app.spotty_bunny_launch import spotty_bunny_command
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            local_bin = home / ".local" / "bin"
+            local_bin.mkdir(parents=True)
+            stale = local_bin / "spotty-bunny"
+            stale.write_text("stale wrapper\n", encoding="utf-8")
+            path_bin = home / "path-bin"
+            path_bin.mkdir()
+            other = path_bin / "spotty-bunny"
+            _write_executable(other)
+            with (
+                patch("app.spotty_bunny_launch.Path.home", return_value=home),
+                patch(
+                    "app.spotty_bunny_launch.shutil.which",
+                    return_value=str(other),
+                ),
+            ):
+                self.assertEqual(spotty_bunny_command(), [str(other)])
 
     def test_spotty_bunny_is_running_clears_stale_pid(self) -> None:
         from app.spotty_bunny_launch import (

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -592,7 +592,8 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             home = Path(tmp)
             plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
             plist.parent.mkdir(parents=True)
-            program = Path("/opt/spotty-bunny")
+            program = home / "spotty-bunny"
+            _write_executable(program)
             plist.write_text(
                 format_agent_plist(
                     home=home,
@@ -625,8 +626,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
             program = home / "bin" / "spotty-bunny"
-            program.parent.mkdir(parents=True)
-            program.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+            _write_executable(program, content="#!/usr/bin/env python3\n")
             stderr = StringIO()
             code = install_agent(
                 home=home,
@@ -655,7 +655,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
             program = home / "spotty-bunny"
-            program.write_text("#!/opt/venv/bin/python\n", encoding="utf-8")
+            _write_executable(program, content="#!/opt/venv/bin/python\n")
             stderr = StringIO()
             code = install_agent(
                 home=home,
@@ -685,7 +685,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
             program = home / "spotty-bunny"
-            program.write_text("#!/opt/venv/bin/python\n", encoding="utf-8")
+            _write_executable(program, content="#!/opt/venv/bin/python\n")
             with (
                 patch("app.spotty_bunny_agent.sys.stdin") as stdin,
                 patch("app.spotty_bunny_agent.sys.stdout") as stdout,
@@ -722,7 +722,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
             program = home / "spotty-bunny"
-            program.write_text("#!/opt/venv/bin/python\n", encoding="utf-8")
+            _write_executable(program, content="#!/opt/venv/bin/python\n")
             stderr = StringIO()
             with (
                 patch("app.spotty_bunny_agent.sys.stdin") as stdin,
@@ -760,7 +760,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
             program = home / "spotty-bunny"
-            program.write_text("#!/opt/venv/bin/python\n", encoding="utf-8")
+            _write_executable(program, content="#!/opt/venv/bin/python\n")
             with (
                 patch("app.spotty_bunny_agent.sys.stdin") as stdin,
                 patch("app.spotty_bunny_agent.sys.stdout") as stdout,
@@ -789,7 +789,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
             program = home / "spotty-bunny"
-            program.write_text("#!/opt/venv/bin/python\n", encoding="utf-8")
+            _write_executable(program, content="#!/opt/venv/bin/python\n")
             code = install_agent(
                 home=home,
                 launchctl=ctl,
@@ -826,6 +826,21 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 Path("/opt/pipx/venvs/bunnify/bin/python"),
             )
 
+    def test_interpreter_for_program_reads_bash_exec_wrapper(self) -> None:
+        from app.spotty_bunny_agent import interpreter_for_program
+
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "spotty-bunny"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                'exec "/opt/venvs/bunnify/bin/python" -m app.spotty_bunny_cli "$@"\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                interpreter_for_program(script),
+                Path("/opt/venvs/bunnify/bin/python"),
+            )
+
     def test_interpreter_for_program_reads_pipx_sh_wrapper(self) -> None:
         from app.spotty_bunny_agent import interpreter_for_program
 
@@ -841,6 +856,19 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 interpreter_for_program(script),
                 Path("/opt/pipx/venvs/bunnify/bin/python"),
             )
+
+    def test_install_rejects_missing_binary(self) -> None:
+        from app.spotty_bunny_agent import install_agent
+
+        stderr = StringIO()
+        code = install_agent(
+            platform="darwin",
+            print_err=stderr.write,
+            program=Path("/no/such/spotty-bunny"),
+            probe_tcc=lambda _p: TccStatus(True, True),
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("missing or not executable", stderr.getvalue())
 
     def test_is_agent_installed_checks_plist(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, is_agent_installed
@@ -864,7 +892,8 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             home = Path(tmp)
             plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
             plist.parent.mkdir(parents=True)
-            program = Path("/opt/spotty-bunny")
+            program = home / "spotty-bunny"
+            _write_executable(program)
             plist.write_text(
                 format_agent_plist(
                     home=home,
@@ -893,7 +922,9 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertIn("running: yes", text)
             self.assertIn("pid: 99", text)
             self.assertIn("launchd: loaded", text)
-            self.assertIn("binary: /opt/spotty-bunny", text)
+            self.assertIn("binary: ", text)
+            self.assertIn(str(program), text)
+            self.assertIn("interpreter:", text)
             self.assertIn("application_log:", text)
             self.assertIn("follow_logs: tail --follow=name --retry", text)
             self.assertIn("launchd_stdout:", text)
@@ -963,7 +994,8 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 ),
                 encoding="utf-8",
             )
-            new_program = Path("/new/spotty-bunny")
+            _write_executable(home / "old-spotty-bunny")
+            new_program = _write_executable(home / "new-spotty-bunny")
             code = upgrade_agent(
                 home=home,
                 launchctl=ctl,
@@ -1000,13 +1032,14 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 ),
                 encoding="utf-8",
             )
+            program = _write_executable(home / "spotty-bunny")
             code = upgrade_agent(
                 home=home,
                 launchctl=ctl,
                 platform="darwin",
                 print_err=lambda _m: None,
                 probe_tcc=tcc.probe,
-                program=Path("/opt/spotty-bunny"),
+                program=program,
                 request_tcc=tcc.request,
             )
             self.assertEqual(code, 1)
@@ -1073,6 +1106,13 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertEqual(code, 0)
             self.assertFalse(plist.exists())
             self.assertIs(ctl.plist_existed_at_bootout, False)
+
+
+def _write_executable(path: Path, *, content: str = "#!/bin/sh\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+    return path
 
 
 class _FakeLaunchctl:

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -134,12 +134,19 @@ grants. A process that started before TCC was granted may not receive Control
 chord events until it is restarted.
 
 `status` prints running/pid, whether launchd has loaded the agent, the binary
-path, the application log
+path, the **Python interpreter** launchd will exec (real path for TCC lookups),
+the application log
 (`~/.local/share/bunnify/spotty-bunny.log` or `BUNNIFY_SPOTTY_BUNNY_LOG_FILE` /
 `$BUNNIFY_DATA_DIR`), a suggested log-follow command
 (`tail --follow=name --retry "<application_log>"`), launchd stdout/stderr paths
 from the plist, version, and Accessibility / Input Monitoring yes/no. Exit `0`
-only when the plist exists, the agent is loaded, and the process is running.
+only when the plist exists, the agent is loaded, the process is running, and
+the plist binary path still exists and is executable.
+
+`install` / `upgrade` prefer `~/.local/bin/spotty-bunny` when present (stable
+operator wrapper), validate that the plist target exists before bootstrap, warn
+when the interpreter identity changes (for example pipx → local clone), and
+remind you to test the Control chord after a successful reload.
 
 ### Upgrade
 
@@ -148,10 +155,14 @@ bunnify upgrade                  # pipx package (preferred)
 bunnify spotty-bunny upgrade     # rewrite plist + bounce launchd
 ```
 
-`upgrade` rewrites the plist if `command -v spotty-bunny` moved (pipx venv
-path / shebang), re-verifies TCC for that interpreter, then reloads the agent
-with `launchctl bootout` and `launchctl bootstrap` so launchd picks up the new
-ProgramArguments.
+`upgrade` rewrites the plist when `spotty-bunny` moved (pipx uninstall, venv
+path / shebang, or `~/.local/bin` wrapper), re-verifies TCC for the new
+interpreter, warns when the interpreter real path changed, then reloads the
+agent with `launchctl bootout` and `launchctl bootstrap` so launchd picks up the
+new ProgramArguments.
+After moving off pipx or changing Python builds, re-grant Accessibility and
+Input Monitoring to the interpreter shown by `bunnify spotty-bunny status`,
+then run `bunnify spotty-bunny upgrade`.
 Package updates stay on `bunnify upgrade` (`pipx upgrade bunnify`); run that
 first, then `bunnify spotty-bunny upgrade` so launchd does not keep a stale
 binary path.


### PR DESCRIPTION
## Summary
- Resolve the **real Python interpreter** for TCC checks from bash wrappers (not `/bin/bash`).
- Prefer `~/.local/bin/spotty-bunny` in LaunchAgent `ProgramArguments` when present.
- Fail install/upgrade when the plist binary is missing; warn when the interpreter identity changes (pipx → local clone).
- Show `interpreter:` in `spotty-bunny status`; exit non-zero when the binary path is stale.
- Call `CGRequestListenEventAccess()` at overlay startup and dispatch chord `toggle()` on the main thread.
- Document migration notes in `docs/LOCAL.md`.

## Test plan
- [x] `./test_bunnify bookmarks.test_spotty_bunny.SpottyBunnyAgentTests`
- [x] `scripts/checks`