### PR TITLE
chore(deps): batch dependency updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "jsonschema>=4.26.0",
     "packaging>=26.3",
     "pathspec==1.1.1",
-    "platformdirs>=4.11.1",
+    "platformdirs>=4.11.2",
     "prompt-toolkit>=3.0.53",
     "rpds-py>=2026.6.3",
     "sqlparse>=0.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,11 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+
+[options.exclude-newer-package]
+platformdirs = "2026-08-11T07:01:31Z"
+
 [[package]]
 name = "asgiref"
 version = "3.12.1"
@@ -60,7 +65,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "packaging", specifier = ">=26.3" },
     { name = "pathspec", specifier = "==1.1.1" },
-    { name = "platformdirs", specifier = ">=4.11.1" },
+    { name = "platformdirs", specifier = ">=4.11.2" },
     { name = "prompt-toolkit", specifier = ">=3.0.53" },
     { name = "pyobjc-core", marker = "sys_platform == 'darwin' and extra == 'macos'", specifier = "==12.2.1" },
     { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin' and extra == 'macos'", specifier = "==12.2.1" },
@@ -169,11 +174,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.3"
+version = "4.11.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/98/0bf930c4f97d0266b58a89e36c015f56232c52b5d2f207215d48cca9e8f7/platformdirs-4.11.2.tar.gz", hash = "sha256:3a2ae5fca3520a01ab1be8b45613537f52ddf5b5f6f53d88233892dfbf0cd82d", size = 32716, upload-time = "2026-08-10T15:48:06.092Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e2/4e6eee633809c376c024821b91ade709cbfd040ec53939ffbcc292aa7eee/platformdirs-4.11.2-py3-none-any.whl", hash = "sha256:7f89089b6ea71bda7962953edcf784b2e2d9d285b40ad88be2bb75c6e9d82ab4", size = 23361, upload-time = "2026-08-10T15:48:04.855Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Batch dependency updates

Automated dependency updates via `dep-updater --batch`.

All outdated packages and CVE fixes combined into a single PR.

## Dependency update summary

| Ecosystem | Package | From | To | CVE? | CVEs |
|---|---|---|---|---|---|
| python/uv | `platformdirs` | `4.11.1` | `4.11.2` | no | - |

## Python updates

| Package | From | To |
|---|---|---|
| `platformdirs` | `4.11.1` | `4.11.2` |
