### PR TITLE
fix: restore Spotty Bunny Tab completion and Google fallback

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -46,6 +46,8 @@ from app.config import (
 from app.github_complete import (
     bootstrap_github_completion_cache,
     ensure_github_authenticated,
+    gh_install_guidance,
+    gh_is_available,
     suggest_param_values,
 )
 from app.interactive import (
@@ -1058,7 +1060,14 @@ def _run_repl(
         return
 
     interactive_auth = sys.stdin.isatty() and sys.stdout.isatty()
-    github_token = ensure_github_authenticated(interactive=interactive_auth)
+    github_token = ensure_github_authenticated(
+        interactive=interactive_auth,
+        confirm_install=(
+            (lambda message: click.confirm(message, default=True))
+            if interactive_auth
+            else None
+        ),
+    )
     if github_token:
         bootstrapped = bootstrap_github_completion_cache(
             url_templates=[entry.url for entry in entries],
@@ -1077,12 +1086,15 @@ def _run_repl(
             status += " (warming in background…)"
         click.echo(theme.dim(status))
     else:
-        click.echo(
-            theme.meta(
-                "GitHub not authenticated — set GITHUB_TOKEN / GH_TOKEN "
-                "or run `gh auth login` for repo Tab completion"
+        if not gh_is_available():
+            click.echo(theme.meta(gh_install_guidance()))
+        else:
+            click.echo(
+                theme.meta(
+                    "GitHub not authenticated — set GITHUB_TOKEN / GH_TOKEN "
+                    "or run `gh auth login` for repo Tab completion"
+                )
             )
-        )
 
     def suggestions_fn(query: str) -> list[str]:
         return fetch_suggestions(query, base_url=base_url)

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -444,7 +444,7 @@ def user_is_admin() -> bool:
 
         username = pwd.getpwuid(os.getuid()).pw_name
         return username in grp.getgrnam("admin").gr_mem
-    except (KeyError, OSError):
+    except KeyError, OSError:
         return False
 
 

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import threading
 import time
@@ -232,7 +233,7 @@ def _run_gh(
 ) -> subprocess.CompletedProcess[str]:
     run = runner or subprocess.run
     kwargs: dict[str, Any] = {
-        "args": ["gh", *args],
+        "args": [resolve_gh_executable(), *args],
         "text": True,
         "timeout": timeout,
         "check": False,
@@ -264,6 +265,24 @@ def github_token_from_gh(
         return None
     token = (completed.stdout or "").strip()
     return token or None
+
+
+def resolve_gh_executable() -> str:
+    """Return an absolute ``gh`` path when possible (LaunchAgent-safe PATH)."""
+    found = shutil.which("gh")
+    if found:
+        return found
+    for candidate in (
+        Path("/opt/homebrew/bin/gh"),
+        Path("/usr/local/bin/gh"),
+        Path.home() / ".local" / "bin" / "gh",
+    ):
+        try:
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+        except OSError:
+            continue
+    return "gh"
 
 
 def resolve_github_token(

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -21,8 +22,11 @@ from app.completion_spec import ParamCompleteSpec, repo_arg_from_filled
 
 logger = logging.getLogger(__name__)
 
+ConfirmInstallFn = Callable[[str], bool]
+
 _CACHE_TTL_SECONDS = 300.0
 _DEFAULT_TIMEOUT_SECONDS = 8.0
+_GH_BREW_INSTALL_TIMEOUT_SECONDS = 600.0
 _GH_TOKEN_TIMEOUT_SECONDS = 8.0
 _GH_LOGIN_TIMEOUT_SECONDS = 600.0
 _PERSIST_VERSION = 1
@@ -132,12 +136,41 @@ def _cache_counts() -> dict[str, int]:
     return {"orgs": orgs, "repos": repos, "entries": len(snapshot)}
 
 
+def can_offer_gh_install() -> bool:
+    """True when an admin user can run ``brew install gh``."""
+    return user_is_admin() and shutil.which("brew") is not None
+
+
 def clear_github_completion_cache() -> None:
     """Test helper: drop in-process completion + token caches."""
     global _token_cache
     with _cache_lock:
         _cache.clear()
     _token_cache = _UNSET
+
+
+def gh_install_guidance() -> str:
+    """User-facing text when ``gh`` is missing and no env token is set."""
+    parts = [
+        "GitHub Tab completion needs the GitHub CLI (gh) or GITHUB_TOKEN / GH_TOKEN",
+        "Install: brew install gh",
+        "Then: gh auth login",
+    ]
+    if sys.platform == "darwin" and shutil.which("brew") is None:
+        parts.insert(1, "Homebrew: https://brew.sh")
+    return " · ".join(parts)
+
+
+def gh_is_available() -> bool:
+    """True when ``resolve_gh_executable`` points at a runnable binary."""
+    resolved = resolve_gh_executable()
+    if resolved != "gh":
+        path = Path(resolved)
+        try:
+            return path.is_file() and os.access(path, os.X_OK)
+        except OSError:
+            return False
+    return shutil.which("gh") is not None
 
 
 def load_github_completion_cache(
@@ -285,6 +318,35 @@ def resolve_gh_executable() -> str:
     return "gh"
 
 
+def install_gh_via_homebrew(
+    *,
+    brew: str | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> bool:
+    """Run ``brew install gh`` and return whether ``gh`` is then available."""
+    brew_bin = brew or shutil.which("brew")
+    if brew_bin is None:
+        logger.info("Homebrew not found; cannot install gh")
+        return False
+    run = runner or subprocess.run
+    try:
+        completed = run(
+            [brew_bin, "install", "gh"],
+            text=True,
+            timeout=_GH_BREW_INSTALL_TIMEOUT_SECONDS,
+            check=False,
+            capture_output=True,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.info("brew install gh failed: %s", exc)
+        return False
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        logger.info("brew install gh exited %s: %s", completed.returncode, stderr)
+        return False
+    return gh_is_available()
+
+
 def resolve_github_token(
     *,
     environ: dict[str, str] | None = None,
@@ -313,12 +375,17 @@ def ensure_github_authenticated(
     interactive: bool = False,
     environ: dict[str, str] | None = None,
     runner: GhRunner | None = None,
+    confirm_install: ConfirmInstallFn | None = None,
+    brew_runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
 ) -> str | None:
     """
-    Return a usable GitHub token, optionally running ``gh auth login`` first.
+    Return a usable GitHub token, optionally installing ``gh`` / logging in.
 
-    When ``interactive`` is true and no token is available, launches the
-    browser-oriented ``gh auth login`` flow (stdin/stdout inherited).
+    When ``interactive`` is true and no token is available:
+
+    - If ``gh`` is missing and the user is an admin with Homebrew, optionally
+      offer ``brew install gh`` (via ``confirm_install``).
+    - Then launch the browser-oriented ``gh auth login`` flow.
     """
     global _token_cache
     token = resolve_github_token(environ=environ, runner=runner)
@@ -326,6 +393,19 @@ def ensure_github_authenticated(
         return token
     if not interactive:
         return None
+    if not gh_is_available():
+        logger.info("%s", gh_install_guidance())
+        if not can_offer_gh_install():
+            return None
+        prompt = (
+            "GitHub CLI (gh) is required for repo Tab completion. "
+            "Install with Homebrew now (brew install gh)?"
+        )
+        confirm = confirm_install or (lambda _message: False)
+        if not confirm(prompt):
+            return None
+        if not install_gh_via_homebrew(runner=brew_runner):
+            return None
     logger.info("No GitHub token found; starting gh auth login")
     try:
         completed = _run_gh(
@@ -350,6 +430,22 @@ def ensure_github_authenticated(
         return None
     _token_cache = _UNSET
     return resolve_github_token(environ=environ, runner=runner, use_cache=True)
+
+
+def user_is_admin() -> bool:
+    """True for root or macOS users in the ``admin`` group."""
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        return True
+    if sys.platform != "darwin":
+        return False
+    try:
+        import grp
+        import pwd
+
+        username = pwd.getpwuid(os.getuid()).pw_name
+        return username in grp.getgrnam("admin").gr_mem
+    except KeyError, OSError:
+        return False
 
 
 def _github_get_json(

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -444,7 +444,7 @@ def user_is_admin() -> bool:
 
         username = pwd.getpwuid(os.getuid()).pw_name
         return username in grp.getgrnam("admin").gr_mem
-    except KeyError, OSError:
+    except (KeyError, OSError):
         return False
 
 

--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -67,6 +67,7 @@ ABOUT_SUMMARY = (
     "Search and open your Bunnify shortcuts from anywhere on macOS. "
     "Hold one Control and tap the other to show this box, type a shortcut "
     "(Tab completes, like the CLI), and press Return to open it in your browser. "
+    "Text that is not a shortcut opens a Google search, like the browser. "
     "Esc hides the box."
 )
 ABOUT_WARN_RGB = (0.62, 0.28, 0.08)

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -31,7 +31,7 @@ AGENT_COMMANDS = frozenset({"install", "status", "uninstall", "upgrade"})
 AGENT_LABEL = "com.thehcma.bunnify.spotty-bunny"
 AGENT_PLIST_NAME = f"{AGENT_LABEL}.plist"
 LAUNCHCTL_TIMEOUT_S = 10
-LAUNCHD_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 POST_INSTALL_HINT = (
     f"{COMMAND_NAME}: hold one Control and press the other to test the overlay."
 )
@@ -94,8 +94,11 @@ def format_agent_plist(*, home: Path, program_arguments: Sequence[str]) -> str:
     args_xml = "\n".join(
         f"    <string>{escape(arg)}</string>" for arg in program_arguments
     )
-    return _PLIST_TEMPLATE.replace("__PROGRAM_ARGUMENTS__", args_xml).replace(
-        "__HOME__", escape(str(home))
+    path = launchd_path_for_home(home)
+    return (
+        _PLIST_TEMPLATE.replace("__PROGRAM_ARGUMENTS__", args_xml)
+        .replace("__HOME__", escape(str(home)))
+        .replace("__LAUNCHD_PATH__", escape(path))
     )
 
 
@@ -217,6 +220,12 @@ def is_agent_loaded(
         launchctl=launchctl,
     )
     return completed.returncode == 0
+
+
+def launchd_path_for_home(home: Path) -> str:
+    """PATH for the Spotty Bunny LaunchAgent (Homebrew + ``~/.local/bin``)."""
+    local_bin = str((home / ".local" / "bin").resolve())
+    return f"{local_bin}:{LAUNCHD_PATH}"
 
 
 def refresh_agent_plist(
@@ -728,6 +737,10 @@ def _probe_tcc_for_status(
 
 def _shell_exec_python_from_wrapper(raw: str) -> Path | None:
     """Return the python path from a bash ``exec`` line, ignoring comments."""
+    assignments: dict[str, str] = {}
+    assign_pattern = re.compile(
+        r"^(?P<name>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>[\"']?)(?P<body>[^\"'\n]*)(?P=value)$"
+    )
     pattern = re.compile(
         r"^exec\s+(?:\"|\')?(?P<python>[^\"'\n]+?/bin/python(?:3(?:\.\d+)?)?)",
     )
@@ -735,11 +748,23 @@ def _shell_exec_python_from_wrapper(raw: str) -> Path | None:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
+        assign = assign_pattern.match(stripped)
+        if assign is not None:
+            assignments[assign.group("name")] = assign.group("body")
+            continue
         match = pattern.match(stripped)
         if match is None:
             continue
         token = match.group("python").strip("\"'")
-        expanded = token.replace("$HOME", str(Path.home()))
+        expanded = token.replace("$HOME", str(Path.home())).replace(
+            "${HOME}", str(Path.home())
+        )
+        for name, value in assignments.items():
+            expanded = expanded.replace(f"${{{name}}}", value).replace(
+                f"${name}", value
+            )
+        if "$" in expanded:
+            continue
         return Path(expanded).expanduser()
     return None
 
@@ -765,6 +790,12 @@ _PLIST_TEMPLATE = """\
   <array>
 __PROGRAM_ARGUMENTS__
   </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>__LAUNCHD_PATH__</string>
+  </dict>
 
   <key>KeepAlive</key>
   <true/>

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -8,7 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from xml.sax.saxutils import escape
@@ -490,6 +490,21 @@ def _bootout_agent(
     )
 
 
+def _expand_shell_vars(token: str, assignments: Mapping[str, str]) -> str:
+    """Expand ``$HOME`` / ``$name`` / ``${name}`` with longest-name-first passes."""
+    home = str(Path.home())
+    values: dict[str, str] = {"HOME": home}
+    for name in sorted(assignments, key=len, reverse=True):
+        values[name] = _substitute_shell_vars(
+            assignments[name].replace("${HOME}", home).replace("$HOME", home),
+            values,
+        )
+    return _substitute_shell_vars(
+        token.replace("${HOME}", home).replace("$HOME", home),
+        values,
+    )
+
+
 def _gui_domain(uid: int | None = None) -> str:
     return f"gui/{os.getuid() if uid is None else uid}"
 
@@ -756,17 +771,26 @@ def _shell_exec_python_from_wrapper(raw: str) -> Path | None:
         if match is None:
             continue
         token = match.group("python").strip("\"'")
-        expanded = token.replace("$HOME", str(Path.home())).replace(
-            "${HOME}", str(Path.home())
-        )
-        for name, value in assignments.items():
+        expanded = _expand_shell_vars(token, assignments)
+        # Prefer a partially expanded exec path over falling through to the
+        # shebang shell (which misleads TCC probing).
+        return Path(expanded).expanduser()
+    return None
+
+
+def _substitute_shell_vars(text: str, values: Mapping[str, str]) -> str:
+    """Replace ``$name`` / ``${name}`` until stable (longest names first)."""
+    expanded = text
+    for _ in range(len(values) + 2):
+        previous = expanded
+        for name in sorted(values, key=len, reverse=True):
+            value = values[name]
             expanded = expanded.replace(f"${{{name}}}", value).replace(
                 f"${name}", value
             )
-        if "$" in expanded:
-            continue
-        return Path(expanded).expanduser()
-    return None
+        if expanded == previous:
+            break
+    return expanded
 
 
 def _write_plist(plist: Path, *, home: Path, program_arguments: Sequence[str]) -> None:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -118,6 +118,8 @@ from app.spotty_bunny_complete import (
     completion_row_after_selector,
     completion_still_current,
     completions_for,
+    field_editor_selector_name,
+    is_tab_completion_selector,
     make_spotty_completer,
 )
 from app.spotty_bunny_history import (
@@ -132,6 +134,7 @@ from app.spotty_bunny_hotkey import (
     DEVICE_LEFT_CONTROL_MASK,
     DEVICE_RIGHT_CONTROL_MASK,
     ESCAPE_KEYCODE,
+    TAB_KEYCODE,
     ChordTracker,
     apply_control_event,
     describe_key,
@@ -194,6 +197,10 @@ logger = logging.getLogger(__name__)
 class SpottyBunnyController(NSObject):
     """Owns the floating search panel and toggles it from the Control chord."""
 
+    def completeWithTab_(self, _sender) -> None:
+        """Run Tab completion (field editor, key-view loop, or event-tap fallback)."""
+        self._request_completions()
+
     def controlTextDidBeginEditing_(self, _notification) -> None:
         self._paint_search_editor()
 
@@ -202,14 +209,21 @@ class SpottyBunnyController(NSObject):
             return
         if self.status is not None and str(self.status.stringValue()):
             self._set_status("")
-        if self._completion_rows:
-            self._hide_completions()
+        if not self._completion_rows:
+            return
+        text = str(self.field.stringValue()) if self.field is not None else ""
+        if any(
+            apply_completion(self._completion_prefix, row) == text
+            for row in self._completion_rows
+        ):
+            return
+        self._hide_completions()
 
     def control_textView_doCommandBySelector_(self, _control, _text_view, selector):
         """Tab completions, history up/down, dismiss on Esc/Return."""
-        name = selector if isinstance(selector, str) else str(selector)
-        if name == "insertTab:":
-            self._request_completions()
+        name = field_editor_selector_name(selector)
+        if is_tab_completion_selector(name):
+            self.completeWithTab_(None)
             return True
         if self._completion_rows and name in {
             "moveDown:",
@@ -469,6 +483,7 @@ class SpottyBunnyController(NSObject):
         logo.setImageScaling_(NSImageScaleProportionallyUpOrDown)
         logo.setTarget_(self)
         logo.setAction_("showAbout:")
+        logo.setRefusesFirstResponder_(True)
         menu = NSMenu.alloc().initWithTitle_("")
         menu.setDelegate_(self)
         self._logo_menu = menu
@@ -564,6 +579,7 @@ class SpottyBunnyController(NSObject):
         table.setDataSource_(self)
         table.setDelegate_(self)
         table.setHeaderView_(None)
+        table.setRefusesFirstResponder_(True)
         scroll.setDocumentView_(table)
         panel.contentView().addSubview_(scroll)
 
@@ -782,6 +798,7 @@ class SpottyBunnyController(NSObject):
                 self._set_status(SHORTCUTS_LOAD_FAILED)
             return
         text = str(self.field.stringValue())
+        logger.info("tab complete %r", text)
         self._completion_rows = []
         if self.table is not None:
             self.table.reloadData()
@@ -814,10 +831,18 @@ class SpottyBunnyController(NSObject):
         if self.field is None:
             return
         self._applying_completion = True
-        try:
-            self.field.setStringValue_(text)
-        finally:
+        self.field.setStringValue_(text)
+        editor = self.field.currentEditor()
+        if editor is not None:
+            editor.setString_(text)
+            editor.setSelectedRange_(NSMakeRange(len(text), 0))
+
+        def clear_flag() -> None:
             self._applying_completion = False
+
+        # Deferred so a delayed controlTextDidChange_ still sees the flag and
+        # does not immediately hide the completion table we just showed.
+        NSOperationQueue.mainQueue().addOperationWithBlock_(clear_flag)
 
     def _set_status(self, message: str) -> None:
         if self.status is None:
@@ -1039,6 +1064,11 @@ class SpottyBunnyPanel(NSPanel):
     def keyDown_(self, event) -> None:
         if int(event.keyCode()) == ESCAPE_KEYCODE:
             self.cancelOperation_(self)
+            return
+        if int(event.keyCode()) == TAB_KEYCODE:
+            delegate = self.delegate()
+            if delegate is not None:
+                delegate.completeWithTab_(self)
             return
         objc.super(SpottyBunnyPanel, self).keyDown_(event)
 
@@ -1276,6 +1306,15 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
                 _run_on_main(lambda: controller.dismissWithEscape_(None))
             elif event_type == kCGEventKeyUp:
                 _run_on_main(lambda: controller.releaseEscape_(None))
+            return event
+        if keycode == TAB_KEYCODE:
+            if (
+                event_type == kCGEventKeyDown
+                and controller.visible
+                and not controller._about_open
+            ):
+                logger.info("tap Tab → complete")
+                _run_on_main(lambda: controller.completeWithTab_(None))
             return event
         if event_type != kCGEventFlagsChanged:
             logger.debug(

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -99,6 +99,13 @@ from Quartz import (
 from app.cli import open_url
 from app.client import fetch_key_entries, fetch_suggestions
 from app.config import resolve_base_url
+from app.github_complete import (
+    can_offer_gh_install,
+    gh_install_guidance,
+    gh_is_available,
+    github_token_from_environ,
+    install_gh_via_homebrew,
+)
 from app.spotty_bunny_about import (
     apply_spotty_chrome,
     build_about_panel,
@@ -372,6 +379,7 @@ class SpottyBunnyController(NSObject):
             self.panel.makeFirstResponder_(self.field)
             self._paint_search_editor()
         self._io.submit(self._load_completer, self._completer_loaded)
+        self._maybe_offer_gh_install()
         if cache_is_stale(self._update_status.checked_at):
             self._schedule_update_check()
 
@@ -643,6 +651,19 @@ class SpottyBunnyController(NSObject):
 
         _run_on_main(apply)
 
+    def _gh_install_ready(self, result: object) -> None:
+        def apply() -> None:
+            if isinstance(result, Exception):
+                logger.warning("gh install failed: %s", result)
+                self._set_status(format_spotty_bunny_status(result))
+                return
+            if result:
+                self._set_status("gh installed — run: gh auth login")
+                return
+            self._set_status(gh_install_guidance())
+
+        _run_on_main(apply)
+
     def _hide_about_panel(self) -> None:
         if self._about_panel is not None:
             self._about_panel.orderOut_(None)
@@ -716,6 +737,17 @@ class SpottyBunnyController(NSObject):
             suggestions_fn=lambda query: fetch_suggestions(query, base_url=base_url),
         )
         return completer, base_url
+
+    def _maybe_offer_gh_install(self) -> None:
+        """Surface missing ``gh``; admins with Homebrew may install in-place."""
+        if github_token_from_environ() or gh_is_available():
+            return
+        guidance = gh_install_guidance()
+        if can_offer_gh_install() and _confirm_install_gh():
+            self._set_status("Installing gh via Homebrew…")
+            self._io.submit(install_gh_via_homebrew, self._gh_install_ready)
+            return
+        self._set_status(guidance)
 
     def _move_completion(self, selector: str) -> None:
         if not self._completion_rows or self.table is None or self.field is None:
@@ -1230,6 +1262,20 @@ class _CenteredWrappingFieldCell(NSTextFieldCell):
             rect.size.width,
             text_height,
         )
+
+
+def _confirm_install_gh() -> bool:
+    """Ask before running ``brew install gh`` from the overlay."""
+    alert = NSAlert.alloc().init()
+    alert.setAlertStyle_(NSAlertStyleWarning)
+    alert.setMessageText_("Install GitHub CLI?")
+    alert.setInformativeText_(
+        "Repo Tab completion needs the GitHub CLI (gh). "
+        "Install it with Homebrew now (brew install gh)?"
+    )
+    alert.addButtonWithTitle_("Install")
+    alert.addButtonWithTitle_("Not now")
+    return int(alert.runModal()) == int(NSAlertFirstButtonReturn)
 
 
 def _confirm_uninstall() -> bool:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -198,7 +198,7 @@ class SpottyBunnyController(NSObject):
     """Owns the floating search panel and toggles it from the Control chord."""
 
     def completeWithTab_(self, _sender) -> None:
-        """Run Tab completion (field editor, key-view loop, or event-tap fallback)."""
+        """Run Tab completion (field editor or panel key-view)."""
         self._request_completions()
 
     def controlTextDidBeginEditing_(self, _notification) -> None:
@@ -1306,15 +1306,6 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
                 _run_on_main(lambda: controller.dismissWithEscape_(None))
             elif event_type == kCGEventKeyUp:
                 _run_on_main(lambda: controller.releaseEscape_(None))
-            return event
-        if keycode == TAB_KEYCODE:
-            if (
-                event_type == kCGEventKeyDown
-                and controller.visible
-                and not controller._about_open
-            ):
-                logger.info("tap Tab → complete")
-                _run_on_main(lambda: controller.completeWithTab_(None))
             return event
         if event_type != kCGEventFlagsChanged:
             logger.debug(

--- a/app/spotty_bunny_complete.py
+++ b/app/spotty_bunny_complete.py
@@ -25,6 +25,15 @@ class CompletionRow:
 
 COMPLETION_PAGE_STEP = 5
 
+TAB_COMPLETION_SELECTORS = frozenset(
+    {
+        "insertBacktab:",
+        "insertTab:",
+        "selectNextKeyView:",
+        "selectPreviousKeyView:",
+    }
+)
+
 
 def completion_row_after_selector(
     current: int,
@@ -81,6 +90,30 @@ def completions_for(text: str, completer: Completer) -> list[CompletionRow]:
             )
         )
     return rows
+
+
+def field_editor_selector_name(selector: object) -> str:
+    """Normalize a Cocoa ``doCommandBySelector:`` argument to an ObjC name."""
+    if isinstance(selector, (bytes, bytearray)):
+        return bytes(selector).decode("ascii", errors="replace")
+    raw = getattr(selector, "selector", None)
+    if isinstance(raw, (bytes, bytearray)):
+        return bytes(raw).decode("ascii", errors="replace")
+    if isinstance(raw, str) and raw:
+        return raw
+    text = selector if isinstance(selector, str) else str(selector)
+    marker = "selector "
+    start = text.find(marker)
+    if start >= 0:
+        token = text[start + len(marker) :].split(" ", 1)[0]
+        if token:
+            return token
+    return text
+
+
+def is_tab_completion_selector(selector: object) -> bool:
+    """True when *selector* should trigger Spotty Bunny Tab completion."""
+    return field_editor_selector_name(selector) in TAB_COMPLETION_SELECTORS
 
 
 def make_spotty_completer(

--- a/app/spotty_bunny_hotkey.py
+++ b/app/spotty_bunny_hotkey.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 CONTROL_LEFT_KEYCODE = 59
 CONTROL_RIGHT_KEYCODE = 62
 ESCAPE_KEYCODE = 53
+TAB_KEYCODE = 48
 
 
 class ChordTracker:

--- a/app/spotty_bunny_resolve.py
+++ b/app/spotty_bunny_resolve.py
@@ -1,4 +1,4 @@
-"""Resolve a Spotty Bunny query the same way as the CLI (strict)."""
+"""Resolve a Spotty Bunny query like browser search (Google fallback)."""
 
 from __future__ import annotations
 
@@ -15,12 +15,16 @@ def lookup_resolved_url(
     base_url: str,
     resolve_fn: Callable[..., object] | None = None,
 ) -> str:
-    """Strict-resolve *query* and return the URL without opening or history."""
+    """Resolve *query* and return the URL without opening or history.
+
+    Uses non-strict resolve so unknown shortcuts become a Google search, matching
+    the browser ``/search/`` behavior. The CLI stays strict separately.
+    """
     text = query.strip()
     if not text:
         raise ValueError("empty query")
     resolve = resolve_fn or resolve_shortcut
-    resolved = resolve(text, base_url=base_url, strict=True)
+    resolved = resolve(text, base_url=base_url, strict=False)
     url = getattr(resolved, "url", None)
     if not isinstance(url, str) or not url:
         raise ValueError("resolve response missing url")
@@ -35,10 +39,11 @@ def resolve_query(
     open_fn: Callable[..., None] | None = None,
     resolve_fn: Callable[..., object] | None = None,
 ) -> str:
-    """Resolve *query* strictly, open the URL, then append REPL history.
+    """Resolve *query*, open the URL, then append REPL history.
 
-    Returns the opened URL. Raises ``ClientError`` (or the resolver's error)
-    on failure; history is not written then.
+    Unknown shortcuts fall back to Google search (same as the browser). Returns
+    the opened URL. Raises ``ClientError`` (or the resolver's error) on failure;
+    history is not written then.
     """
     text = query.strip()
     opener = open_fn or open_url

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -3303,17 +3303,33 @@ class KeyUsageAndCompletionTests(TestCase):
         self.assertEqual(names, ["bunnify"])
         self.assertEqual(calls["n"], 2)
 
-    def test_resolve_gh_executable_finds_homebrew_off_path(self) -> None:
+    def test_resolve_gh_executable_finds_local_bin_off_path(self) -> None:
         import os
+        import stat
+        import tempfile
         from pathlib import Path
 
         from app.github_complete import resolve_gh_executable
 
-        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
-            with patch("app.github_complete.shutil.which", return_value=None):
-                resolved = resolve_gh_executable()
-        self.assertTrue(resolved.endswith("/gh"))
-        self.assertTrue(Path(resolved).is_file())
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            local_gh = home / ".local" / "bin" / "gh"
+            local_gh.parent.mkdir(parents=True)
+            local_gh.write_text("#!/bin/sh\n", encoding="utf-8")
+            local_gh.chmod(local_gh.stat().st_mode | stat.S_IXUSR)
+            with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
+                with patch("app.github_complete.shutil.which", return_value=None):
+                    with patch("app.github_complete.Path.home", return_value=home):
+                        with patch.object(
+                            Path,
+                            "is_file",
+                            lambda self: os.fspath(self) == os.fspath(local_gh),
+                        ):
+                            with patch(
+                                "app.github_complete.os.access", return_value=True
+                            ):
+                                resolved = resolve_gh_executable()
+            self.assertEqual(resolved, str(local_gh))
 
     def test_resolve_github_token_prefers_env_over_gh(self) -> None:
         import subprocess

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -3303,6 +3303,18 @@ class KeyUsageAndCompletionTests(TestCase):
         self.assertEqual(names, ["bunnify"])
         self.assertEqual(calls["n"], 2)
 
+    def test_resolve_gh_executable_finds_homebrew_off_path(self) -> None:
+        import os
+        from pathlib import Path
+
+        from app.github_complete import resolve_gh_executable
+
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
+            with patch("app.github_complete.shutil.which", return_value=None):
+                resolved = resolve_gh_executable()
+        self.assertTrue(resolved.endswith("/gh"))
+        self.assertTrue(Path(resolved).is_file())
+
     def test_resolve_github_token_prefers_env_over_gh(self) -> None:
         import subprocess
 
@@ -3325,7 +3337,10 @@ class KeyUsageAndCompletionTests(TestCase):
         clear_github_completion_cache()
 
         def gh_runner(*, args, **_kwargs):
-            self.assertEqual(args[:3], ["gh", "auth", "token"])
+            from app.github_complete import resolve_gh_executable
+
+            self.assertEqual(args[0], resolve_gh_executable())
+            self.assertEqual(list(args[1:3]), ["auth", "token"])
             return subprocess.CompletedProcess(
                 args=list(args), returncode=0, stdout="gh-token\n", stderr=""
             )

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -3378,6 +3378,65 @@ class KeyUsageAndCompletionTests(TestCase):
         )
         self.assertEqual(token, "gh-token")
 
+    def test_ensure_github_authenticated_offers_brew_install_when_admin(
+        self,
+    ) -> None:
+        import subprocess
+
+        from app.github_complete import (
+            clear_github_completion_cache,
+            ensure_github_authenticated,
+        )
+
+        clear_github_completion_cache()
+        brew_calls: list[list[str]] = []
+        prompts: list[str] = []
+
+        def brew_runner(args, **_kwargs):
+            brew_calls.append(list(args))
+            return subprocess.CompletedProcess(
+                args=list(args), returncode=0, stdout="", stderr=""
+            )
+
+        def gh_runner(*, args, **_kwargs):
+            if args[1:3] == ["auth", "token"]:
+                if brew_calls:
+                    return subprocess.CompletedProcess(
+                        args=list(args),
+                        returncode=0,
+                        stdout="after-install-token\n",
+                        stderr="",
+                    )
+                return subprocess.CompletedProcess(
+                    args=list(args), returncode=1, stdout="", stderr=""
+                )
+            if args[1:3] == ["auth", "login"]:
+                return subprocess.CompletedProcess(
+                    args=list(args), returncode=0, stdout="", stderr=""
+                )
+            raise AssertionError(args)
+
+        def fake_which(name: str) -> str | None:
+            if name == "brew":
+                return "/opt/homebrew/bin/brew"
+            return None
+
+        with (
+            patch("app.github_complete.gh_is_available", side_effect=[False, True]),
+            patch("app.github_complete.can_offer_gh_install", return_value=True),
+            patch("app.github_complete.shutil.which", side_effect=fake_which),
+        ):
+            token = ensure_github_authenticated(
+                interactive=True,
+                environ={"PATH": "/usr/bin"},
+                runner=gh_runner,
+                confirm_install=lambda message: prompts.append(message) or True,
+                brew_runner=brew_runner,
+            )
+        self.assertEqual(token, "after-install-token")
+        self.assertEqual(brew_calls[0][1:], ["install", "gh"])
+        self.assertTrue(prompts)
+
     def test_ensure_github_authenticated_runs_login_when_needed(self) -> None:
         import subprocess
 
@@ -3409,13 +3468,21 @@ class KeyUsageAndCompletionTests(TestCase):
                 )
             raise AssertionError(args)
 
-        token = ensure_github_authenticated(
-            interactive=True,
-            environ={"PATH": "/usr/bin"},
-            runner=runner,
-        )
+        with patch("app.github_complete.gh_is_available", return_value=True):
+            token = ensure_github_authenticated(
+                interactive=True,
+                environ={"PATH": "/usr/bin"},
+                runner=runner,
+            )
         self.assertEqual(token, "fresh-token")
         self.assertTrue(any(c[1:3] == ["auth", "login"] for c in calls))
+
+    def test_gh_install_guidance_mentions_brew(self) -> None:
+        from app.github_complete import gh_install_guidance
+
+        text = gh_install_guidance()
+        self.assertIn("brew install gh", text)
+        self.assertIn("gh auth login", text)
 
     def test_warm_github_completion_cache_lists_orgs_and_repos(self) -> None:
         from app.github_complete import (

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -3303,6 +3303,17 @@ class KeyUsageAndCompletionTests(TestCase):
         self.assertEqual(names, ["bunnify"])
         self.assertEqual(calls["n"], 2)
 
+    def test_resolve_gh_executable_falls_back_to_bare_name(self) -> None:
+        import os
+        from pathlib import Path
+
+        from app.github_complete import resolve_gh_executable
+
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
+            with patch("app.github_complete.shutil.which", return_value=None):
+                with patch.object(Path, "is_file", return_value=False):
+                    self.assertEqual(resolve_gh_executable(), "gh")
+
     def test_resolve_gh_executable_finds_local_bin_off_path(self) -> None:
         import os
         import stat

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -885,6 +885,49 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 Path.home() / ".local/share/uv/python/cpython-3.14/bin/python",
             )
 
+    def test_interpreter_for_program_expands_longest_assignment_name_first(
+        self,
+    ) -> None:
+        from app.spotty_bunny_agent import interpreter_for_program
+
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "spotty-bunny"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "a=/x\n"
+                "ab=/y\n"
+                'exec "$ab/.venv/bin/python" -m app.spotty_bunny_cli "$@"\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                interpreter_for_program(script),
+                Path("/y/.venv/bin/python"),
+            )
+
+    def test_interpreter_for_program_expands_nested_home_assignment(self) -> None:
+        from app.spotty_bunny_agent import interpreter_for_program
+
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "spotty-bunny"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                'UV_DIR="$HOME/.local/share/uv"\n'
+                'exec "$UV_DIR/python/cpython-3.14/bin/python" '
+                '-m app.spotty_bunny_cli "$@"\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                interpreter_for_program(script),
+                Path.home()
+                / ".local"
+                / "share"
+                / "uv"
+                / "python"
+                / "cpython-3.14"
+                / "bin"
+                / "python",
+            )
+
     def test_interpreter_for_program_expands_shell_var_assignment(self) -> None:
         from app.spotty_bunny_agent import interpreter_for_program
 
@@ -2390,7 +2433,7 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("TAB_KEYCODE", source)
         self.assertIn("completeWithTab_", source)
         self.assertIn("is_tab_completion_selector", source)
-        self.assertIn("tap Tab → complete", source)
+        self.assertNotIn("tap Tab → complete", source)
         self.assertIn("setRefusesFirstResponder_(True)", source)
         self.assertIn("_escape_held", source)
         self.assertNotIn("ESCAPE_DISMISS_WINDOW_S", source)

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -28,6 +28,7 @@ from app.spotty_bunny_hotkey import (
     CONTROL_LEFT_KEYCODE,
     CONTROL_RIGHT_KEYCODE,
     ESCAPE_KEYCODE,
+    TAB_KEYCODE,
     ChordTracker,
     apply_control_event,
     apply_hid_snapshot,
@@ -543,19 +544,28 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         self.assertFalse(any(call[1] == "bootout" for call in ctl.calls))
 
     def test_format_agent_plist_matches_example_placeholders(self) -> None:
-        from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist
+        from app.spotty_bunny_agent import (
+            AGENT_LABEL,
+            format_agent_plist,
+            launchd_path_for_home,
+        )
 
         root = Path(__file__).resolve().parents[1]
         example = (
             root / "etc" / "launchd" / "com.thehcma.bunnify.spotty-bunny.plist.example"
         ).read_text(encoding="utf-8")
-        expected = example.replace(
-            "    <string>__SPOTTY_BUNNY__</string>",
-            "    <string>/opt/spotty-bunny</string>",
-        ).replace("__HOME__", "/Users/test")
+        home = Path("/Users/test")
+        expected = (
+            example.replace(
+                "    <string>__SPOTTY_BUNNY__</string>",
+                "    <string>/opt/spotty-bunny</string>",
+            )
+            .replace("__HOME__", "/Users/test")
+            .replace("__LAUNCHD_PATH__", launchd_path_for_home(home))
+        )
         self.assertEqual(
             format_agent_plist(
-                home=Path("/Users/test"),
+                home=home,
                 program_arguments=["/opt/spotty-bunny"],
             ),
             expected,
@@ -563,6 +573,8 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         self.assertIn(AGENT_LABEL, expected)
         self.assertIn("<key>KeepAlive</key>", expected)
         self.assertIn("<key>RunAtLoad</key>", expected)
+        self.assertIn("<key>EnvironmentVariables</key>", expected)
+        self.assertIn("/opt/homebrew/bin", expected)
 
     def test_format_agent_plist_supports_module_argv(self) -> None:
         from app.spotty_bunny_agent import format_agent_plist
@@ -871,6 +883,22 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertEqual(
                 interpreter_for_program(script),
                 Path.home() / ".local/share/uv/python/cpython-3.14/bin/python",
+            )
+
+    def test_interpreter_for_program_expands_shell_var_assignment(self) -> None:
+        from app.spotty_bunny_agent import interpreter_for_program
+
+        with TemporaryDirectory() as tmp:
+            script = Path(tmp) / "spotty-bunny"
+            script.write_text(
+                "#!/usr/bin/env bash\n"
+                "wt=/opt/bunnify-wt\n"
+                'exec "$wt/.venv/bin/python" "$wt/.venv/bin/spotty-bunny" "$@"\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                interpreter_for_program(script),
+                Path("/opt/bunnify-wt/.venv/bin/python"),
             )
 
     def test_interpreter_for_program_ignores_commented_exec_line(self) -> None:
@@ -1258,6 +1286,21 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
             1,
         )
 
+    def test_field_editor_selector_name_normalizes_forms(self) -> None:
+        from app.spotty_bunny_complete import field_editor_selector_name
+
+        self.assertEqual(field_editor_selector_name("insertTab:"), "insertTab:")
+        self.assertEqual(field_editor_selector_name(b"insertTab:"), "insertTab:")
+        self.assertEqual(
+            field_editor_selector_name("<unbound selector insertTab: at 0x10ccfd840>"),
+            "insertTab:",
+        )
+
+        class _Sel:
+            selector = b"selectNextKeyView:"
+
+        self.assertEqual(field_editor_selector_name(_Sel()), "selectNextKeyView:")
+
     def test_first_token_fuzzy_matches_description(self) -> None:
         from app.client import KeyEntry
         from app.spotty_bunny_complete import completions_for, make_spotty_completer
@@ -1270,6 +1313,14 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         )
         rows = completions_for("hub", completer)
         self.assertEqual([row.insert for row in rows], ["gh"])
+
+    def test_is_tab_completion_selector_accepts_key_view_loop(self) -> None:
+        from app.spotty_bunny_complete import is_tab_completion_selector
+
+        self.assertTrue(is_tab_completion_selector("insertTab:"))
+        self.assertTrue(is_tab_completion_selector(b"selectNextKeyView:"))
+        self.assertTrue(is_tab_completion_selector("insertBacktab:"))
+        self.assertFalse(is_tab_completion_selector("insertNewline:"))
 
     def test_meta_commands_are_excluded(self) -> None:
         from app.spotty_bunny_complete import completions_for, make_spotty_completer
@@ -1439,6 +1490,10 @@ class SpottyBunnyHotkeyTests(SimpleTestCase):
     def test_describe_key_escape(self) -> None:
         self.assertEqual(ESCAPE_KEYCODE, 53)
         self.assertEqual(describe_key(ESCAPE_KEYCODE), "Escape")
+
+    def test_describe_key_tab(self) -> None:
+        self.assertEqual(TAB_KEYCODE, 48)
+        self.assertEqual(describe_key(TAB_KEYCODE), "Tab")
 
     def test_describe_key_letter_a(self) -> None:
         self.assertEqual(describe_key(0), "A")
@@ -2332,6 +2387,11 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("dismissWithEscape_", source)
         self.assertIn("releaseEscape_", source)
         self.assertIn("ESCAPE_KEYCODE", source)
+        self.assertIn("TAB_KEYCODE", source)
+        self.assertIn("completeWithTab_", source)
+        self.assertIn("is_tab_completion_selector", source)
+        self.assertIn("tap Tab → complete", source)
+        self.assertIn("setRefusesFirstResponder_(True)", source)
         self.assertIn("_escape_held", source)
         self.assertNotIn("ESCAPE_DISMISS_WINDOW_S", source)
         self.assertIn('{"cancel:", "cancelOperation:"}', source)
@@ -2439,7 +2499,29 @@ class SpottyBunnyResolveTests(SimpleTestCase):
             resolve_fn=resolve_fn,
         )
         self.assertEqual(url, "https://github.com")
-        self.assertIs(seen.get("strict"), True)
+        self.assertIs(seen.get("strict"), False)
+
+    def test_lookup_google_fallback_for_unknown_shortcut(self) -> None:
+        from app.client import ResolvedShortcut
+        from app.spotty_bunny_resolve import lookup_resolved_url
+
+        seen: dict[str, object] = {}
+
+        def resolve_fn(query: str, **kwargs: object) -> ResolvedShortcut:
+            seen.update(kwargs)
+            return ResolvedShortcut(
+                url=f"https://www.google.com/search?q={query}",
+                kind="google_fallback",
+                key=query.split()[0],
+            )
+
+        url = lookup_resolved_url(
+            "asdfasdf",
+            base_url="http://127.0.0.1:8000",
+            resolve_fn=resolve_fn,
+        )
+        self.assertEqual(url, "https://www.google.com/search?q=asdfasdf")
+        self.assertIs(seen.get("strict"), False)
 
     def test_open_failure_does_not_append_history(self) -> None:
         from app.client import ClientError, ResolvedShortcut
@@ -2504,7 +2586,7 @@ class SpottyBunnyResolveTests(SimpleTestCase):
             self.assertEqual(url, "https://github.com")
             self.assertEqual(opened, ["https://github.com"])
             self.assertEqual(load_history_lines(path=path), ["gh"])
-            self.assertIs(seen.get("strict"), True)
+            self.assertIs(seen.get("strict"), False)
 
 
 class SpottyBunnyStatusTests(SimpleTestCase):

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -2434,6 +2434,8 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("completeWithTab_", source)
         self.assertIn("is_tab_completion_selector", source)
         self.assertNotIn("tap Tab → complete", source)
+        self.assertIn("_maybe_offer_gh_install", source)
+        self.assertIn("_confirm_install_gh", source)
         self.assertIn("setRefusesFirstResponder_(True)", source)
         self.assertIn("_escape_held", source)
         self.assertNotIn("ESCAPE_DISMISS_WINDOW_S", source)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -109,8 +109,17 @@ Example (from `bunnify.json.example`):
 }
 ```
 
-GitHub-backed completion requires a token (`GITHUB_TOKEN`, `GH_TOKEN`, or
-`gh auth login`). Results are cached under `~/scratch/bunnify/github-completions.json`.
+GitHub-backed completion needs auth **and** a way to talk to GitHub:
+
+- Prefer `GITHUB_TOKEN` or `GH_TOKEN` in the environment, **or**
+- install the GitHub CLI (`gh`) and run `gh auth login`.
+
+Without a token, `github_repo` / `github_pull_request` / `github_issue`
+completions stay empty (fail-soft — no hard error in Tab UI). Spotty Bunny’s
+LaunchAgent ships a PATH that includes Homebrew and `~/.local/bin` so a
+typical `gh` install is found; if `gh` is missing entirely and no env token is
+set, those completions simply return nothing. Results are cached under
+`~/scratch/bunnify/github-completions.json`.
 
 ### Shell Tab completion
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -112,13 +112,15 @@ Example (from `bunnify.json.example`):
 GitHub-backed completion needs auth **and** a way to talk to GitHub:
 
 - Prefer `GITHUB_TOKEN` or `GH_TOKEN` in the environment, **or**
-- install the GitHub CLI (`gh`) and run `gh auth login`.
+- install the GitHub CLI (`gh`) and run `gh auth login`
+  (`brew install gh` on macOS/Linux with Homebrew).
 
-Without a token, `github_repo` / `github_pull_request` / `github_issue`
-completions stay empty (fail-soft — no hard error in Tab UI). Spotty Bunny’s
-LaunchAgent ships a PATH that includes Homebrew and `~/.local/bin` so a
-typical `gh` install is found; if `gh` is missing entirely and no env token is
-set, those completions simply return nothing. Results are cached under
+The interactive CLI and Spotty Bunny surface this when `gh` is missing. On
+macOS, **admin** users with Homebrew are offered an in-app / REPL confirm to
+run `brew install gh` and then verify the binary. Without a token, `github_repo`
+/ `github_pull_request` / `github_issue` completions stay empty (fail-soft).
+Spotty Bunny’s LaunchAgent PATH includes Homebrew and `~/.local/bin` so a
+typical install is found after setup. Results are cached under
 `~/scratch/bunnify/github-completions.json`.
 
 ### Shell Tab completion

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -205,9 +205,9 @@ Hold **one** Control, then press the **other** to show the search box. Esc
 (or the same chord again) hides it. Up/down walks the CLI REPL history file
 (`platformdirs` cache `bunnify/repl_history`). Tab uses the same completers as
 the CLI (`FirstTokenFuzzyCompleter` / `ShortcutCompleter`) and lists matches
-under the field. Enter resolves via `/api/resolve/?strict=1` and opens the URL
-in the default browser (unknown keys stay in the panel with an error). Ctrl-C
-in a foreground terminal quits. Startup prints the log file path on stderr
+under the field. Enter resolves via `/api/resolve/` (same as browser search:
+unknown text opens a Google query) and opens the URL in the default browser.
+Ctrl-C in a foreground terminal quits. Startup prints the log file path on stderr
 (`spotty-bunny: logging to …`). Default log level is **INFO** (use `--verbose`
 for per-key tap debug). Launchd stdout/stderr under `~/Library/Logs/` are
 separate from that application log.

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -205,7 +205,9 @@ Hold **one** Control, then press the **other** to show the search box. Esc
 (or the same chord again) hides it. Up/down walks the CLI REPL history file
 (`platformdirs` cache `bunnify/repl_history`). Tab uses the same completers as
 the CLI (`FirstTokenFuzzyCompleter` / `ShortcutCompleter`) and lists matches
-under the field. Enter resolves via `/api/resolve/` (same as browser search:
+under the field. GitHub-backed parameter completions (e.g. `repoh <repo>`) need
+`gh` installed (or `GITHUB_TOKEN`/`GH_TOKEN`); otherwise those candidates stay
+empty — see `docs/CONFIG.md`. Enter resolves via `/api/resolve/` (same as browser search:
 unknown text opens a Google query) and opens the URL in the default browser.
 Ctrl-C in a foreground terminal quits. Startup prints the log file path on stderr
 (`spotty-bunny: logging to …`). Default log level is **INFO** (use `--verbose`

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -206,8 +206,9 @@ Hold **one** Control, then press the **other** to show the search box. Esc
 (`platformdirs` cache `bunnify/repl_history`). Tab uses the same completers as
 the CLI (`FirstTokenFuzzyCompleter` / `ShortcutCompleter`) and lists matches
 under the field. GitHub-backed parameter completions (e.g. `repoh <repo>`) need
-`gh` installed (or `GITHUB_TOKEN`/`GH_TOKEN`); otherwise those candidates stay
-empty — see `docs/CONFIG.md`. Enter resolves via `/api/resolve/` (same as browser search:
+`gh` installed (or `GITHUB_TOKEN`/`GH_TOKEN`). If `gh` is missing, the overlay
+shows install guidance; macOS admins with Homebrew are offered
+`brew install gh`. See `docs/CONFIG.md`. Enter resolves via `/api/resolve/` (same as browser search:
 unknown text opens a Google query) and opens the URL in the default browser.
 Ctrl-C in a foreground terminal quits. Startup prints the log file path on stderr
 (`spotty-bunny: logging to …`). Default log level is **INFO** (use `--verbose`

--- a/etc/launchd/com.thehcma.bunnify.spotty-bunny.plist.example
+++ b/etc/launchd/com.thehcma.bunnify.spotty-bunny.plist.example
@@ -11,6 +11,12 @@
     <string>__SPOTTY_BUNNY__</string>
   </array>
 
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>__LAUNCHD_PATH__</string>
+  </dict>
+
   <key>KeepAlive</key>
   <true/>
   <key>RunAtLoad</key>


### PR DESCRIPTION
## Summary
- Fix LaunchAgent PATH (Homebrew + `~/.local/bin`) and `gh` resolution so Spotty Bunny Tab completion works for GitHub repo params (e.g. `repoh domes`).
- Harden Tab / field-editor completion handling in the Spotty Bunny UI.
- Unknown Spotty Bunny queries fall through to Google search like the browser (CLI stays strict).

## Test plan
- [x] `uv run ruff check .` / `ruff format --check` / `pyright --warnings`
- [x] `./test_bunnify`
- [x] `./test_integration`
- [ ] Dogfood: reinstall LaunchAgent, Tab-complete `repoh` with a prefix, unknown query opens Google

---
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>