### PR TITLE
fix: keep example bookmarks path in sdist for uv build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,10 @@ packages = ["app", "bookmarks"]
 [tool.hatch.build.targets.sdist]
 packages = ["app", "bookmarks"]
 
+# Keep the repo-root path inside the sdist so `uv build` (wheel-from-sdist) can
+# still resolve the wheel force-include source path above.
 [tool.hatch.build.targets.sdist.force-include]
-"bunnify.json.example" = "app/data/bookmarks.example.json"
+"bunnify.json.example" = "bunnify.json.example"
 
 [dependency-groups]
 dev = [

--- a/test_packaging
+++ b/test_packaging
@@ -43,15 +43,43 @@ export BUNNIFY_EMBED_VERSION="${version}"
 export BUNNIFY_EMBED_COMMIT="${commit}"
 uv run python "${embed_build_metadata}"
 
-echo "📦 Building wheel..."
-timeout 120 uv build --wheel --out-dir "$build_dir"
+echo "📦 Building sdist + wheel (same path as Publish PyPI)..."
+# Prefer full `uv build` over `--wheel`: publish builds the wheel from the sdist,
+# and hatch force-include paths must still resolve in that layout.
+timeout 120 uv build --out-dir "$build_dir"
 restore_build_metadata
 wheels=("$build_dir"/*.whl)
+sdists=("$build_dir"/*.tar.gz)
 wheel_path="${wheels[0]}"
+sdist_path="${sdists[0]}"
 if [[ ! -f "$wheel_path" ]]; then
     echo "No wheel produced under $build_dir" >&2
     exit 1
 fi
+if [[ ! -f "$sdist_path" ]]; then
+    echo "No sdist produced under $build_dir" >&2
+    exit 1
+fi
+
+echo "📦 Verifying sdist keeps bunnify.json.example at repo-root path..."
+uv run python - "$repo_root/bunnify.json.example" "$sdist_path" <<'PY'
+import sys
+import tarfile
+from pathlib import Path
+
+canonical = Path(sys.argv[1]).read_bytes()
+with tarfile.open(sys.argv[2], "r:gz") as sdist:
+    members = [
+        name
+        for name in sdist.getnames()
+        if name.endswith("/bunnify.json.example") or name == "bunnify.json.example"
+    ]
+    if len(members) != 1:
+        raise SystemExit(f"Expected one bunnify.json.example in sdist, got {members!r}")
+    packaged = sdist.extractfile(members[0]).read()
+if packaged != canonical:
+    raise SystemExit("Sdist bunnify.json.example does not match repo file")
+PY
 
 echo "📦 Verifying wheel bundles bunnify.json.example..."
 uv run python - "$repo_root/bunnify.json.example" "$wheel_path" <<'PY'


### PR DESCRIPTION
## Summary
- Keep `bunnify.json.example` at the repo-root path inside the sdist so `uv build` can still resolve the wheel force-include when building the wheel from the sdist (the Publish PyPI path).
- Update `test_packaging` to exercise full `uv build` (sdist + wheel-from-sdist) instead of `uv build --wheel`, which missed the 0.8.2 publish failure.

This unblocks shipping **0.8.3** after we remove the failed GitHub release/tag `bunnify-v0.8.2` (PyPI never received 0.8.2).

## Test plan
- [x] `uv build` succeeds locally (sdist contains root `bunnify.json.example`; wheel has `app/data/bookmarks.example.json`)
- [x] `./test_packaging`
- [x] `./test_bunnify`
- [ ] CI green on this PR