### PR TITLE
feat: seamless macOS onboard and Spotty Bunny install flow

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import sys
@@ -33,7 +32,6 @@ from app.config import (
     LOCAL_PORT_FILE_NAME,
     MIN_LOCAL_PORT,
     ServerPreferences,
-    default_bookmarks_path,
     ensure_user_bookmarks,
     env_file_path,
     legacy_env_file_path,
@@ -61,6 +59,12 @@ from app.interactive import (
     repl_prompt_message,
 )
 from app.local_server import ensure_local_server, port_is_free, stop_local_server
+from app.onboard import run_onboard
+from app.pipx_install import (
+    install_macos_extra,
+    macos_extra_installed,
+    pipx_bunnify_path,
+)
 from app.pypi import pypi_latest_version as _pypi_latest_version
 from app.theme import Theme, stdout_color_enabled
 from app.usage import format_key_usage_lines
@@ -210,50 +214,6 @@ def format_browser_setup_text(base_url: str) -> str:
             "",
             f"Saved server base URL: {normalized}",
             "Guide: https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md",
-        ]
-    )
-
-
-def format_onboarding_text() -> str:
-    """Return post-install / post-upgrade next steps for the terminal."""
-    bookmarks = default_bookmarks_path()
-    config = env_file_path()
-    return "\n".join(
-        [
-            "Bunnify — next steps after install or upgrade",
-            "",
-            "1. Bookmarks (required before the server starts):",
-            "     bunnify setup   # offers to install the example shortcuts",
-            f"     # or create {bookmarks} yourself from bunnify.json.example",
-            "",
-            "2. Configure and start the server (local on a laptop; remote for a",
-            "   home/always-on host):",
-            "     bunnify setup",
-            "   Guide: https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md",
-            "",
-            "3. Configure Chrome or Edge using BUNNIFY_BASE_URL from:",
-            f"     {config}",
-            "   Guide: https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md",
-            "",
-            "4. Try it:  bunnify gh   (or address-bar keyword, e.g. b gh)",
-            "",
-            "5. macOS Spotty Bunny (optional search box):",
-            "     pipx install 'bunnify[macos]'   # if the extra is not installed",
-            "     bunnify spotty-bunny install    # login LaunchAgent",
-            "     bunnify spotty-bunny status",
-            "     bunnify upgrade && bunnify spotty-bunny upgrade",
-            "     bunnify spotty-bunny uninstall",
-            "   Guide: https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md",
-            "",
-            "Upgrade later (preferred):",
-            "     bunnify upgrade   # shows from/to versions, then pipx upgrade",
-            "   Bookmarks and config.env are kept across upgrades.",
-            "   If --version still shows a checkout SHA, PATH is using",
-            "   ./scripts/bunnify or a repo .venv — the pipx app lives in",
-            "   ~/.local/bin/bunnify.",
-            "",
-            "Docs: https://github.com/the-hcma/bunnify",
-            "Re-print this message anytime:  bunnify onboard",
         ]
     )
 
@@ -524,6 +484,7 @@ def run_upgrade(
     pypi_version = _pypi_latest_version()
     pipx_app = _pipx_bunnify_path()
     before_pipx = _read_executable_build(pipx_app) if pipx_app is not None else None
+    had_macos_extra = macos_extra_installed()
     if before_pipx is not None and pipx_app is not None:
         log(f"pipx app now: {before_pipx}")
         log(f"              {pipx_app}")
@@ -544,6 +505,20 @@ def run_upgrade(
         raise ClientError("Timed out running `pipx upgrade bunnify`") from exc
     if completed.returncode != 0:
         raise ClientError("pipx upgrade bunnify failed")
+
+    if had_macos_extra and not macos_extra_installed():
+        log(
+            colors.dim(
+                "Restoring macOS optional dependencies (PyObjC) after pipx upgrade…"
+            )
+        )
+        if not install_macos_extra(pipx, run_fn=runner):
+            log(
+                colors.warn(
+                    "Could not restore bunnify[macos] after upgrade. "
+                    "Run: pipx install --force 'bunnify[macos]'"
+                )
+            )
 
     pipx_app = _pipx_bunnify_path() or pipx_app
     after_pipx = _read_executable_build(pipx_app) if pipx_app is not None else None
@@ -716,18 +691,7 @@ def _parse_version_line(output: str) -> str | None:
 
 def _pipx_bunnify_path() -> Path | None:
     """Return the pipx ``bunnify`` app path when it exists."""
-    override = os.environ.get("PIPX_BIN_DIR", "").strip()
-    candidates = []
-    if override:
-        candidates.append(Path(override) / "bunnify")
-    candidates.append(Path.home() / ".local" / "bin" / "bunnify")
-    for candidate in candidates:
-        if candidate.is_file():
-            try:
-                return candidate.resolve()
-            except OSError:
-                return candidate
-    return None
+    return pipx_bunnify_path()
 
 
 def _prompt_local_port(
@@ -1550,15 +1514,6 @@ def main(
         _echo_version()
         return
 
-    if onboard_requested or shortcut_args == ("onboard",):
-        click.echo(format_onboarding_text())
-        return
-
-    if shortcut_args and shortcut_args[0] == "spotty-bunny":
-        from app.spotty_bunny_cli import main as spotty_bunny_main
-
-        raise SystemExit(spotty_bunny_main(list(shortcut_args[1:])))
-
     theme = Theme(enabled=stdout_color_enabled(color_mode.lower()))
 
     def prompt_fn(message: str) -> str:
@@ -1567,6 +1522,15 @@ def main(
             default="",
             show_default=False,
         )
+
+    if onboard_requested or shortcut_args == ("onboard",):
+        run_onboard(print_fn=click.echo, prompt_fn=prompt_fn, theme=theme)
+        return
+
+    if shortcut_args and shortcut_args[0] == "spotty-bunny":
+        from app.spotty_bunny_cli import main as spotty_bunny_main
+
+        raise SystemExit(spotty_bunny_main(list(shortcut_args[1:])))
 
     mode_name = (
         normalize_edit_mode_choice(edit_mode)

--- a/app/onboard.py
+++ b/app/onboard.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from packaging.version import InvalidVersion, Version
 
+from app.client import ClientError
 from app.config import default_bookmarks_path, env_file_path, load_preferences
 from app.pipx_install import (
     install_macos_extra,
@@ -183,8 +184,12 @@ def run_onboard(
             if upgrade is None:
                 from app.cli import run_upgrade as upgrade  # noqa: PLC0415
 
-            upgrade(print_fn=log, theme=colors)
-            state = detect_install_state(read_executable_build=reader)
+            try:
+                upgrade(print_fn=log, theme=colors)
+            except ClientError as exc:
+                log(colors.err(f"error: {exc}"))
+            else:
+                state = detect_install_state(read_executable_build=reader)
 
     if interactive and state.macos_platform and not state.macos_extra:
         if yes(

--- a/app/onboard.py
+++ b/app/onboard.py
@@ -1,0 +1,295 @@
+"""Interactive and static onboarding after pipx install or upgrade."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+from app.config import default_bookmarks_path, env_file_path, load_preferences
+from app.pipx_install import (
+    install_macos_extra,
+    macos_extra_installed,
+    pipx_bunnify_path,
+)
+from app.pypi import pypi_latest_version
+from app.theme import Theme
+from app.version import get_build_info, is_source_checkout, running_command_path
+
+
+@dataclass(frozen=True)
+class InstallState:
+    """Detected install / upgrade context for onboarding."""
+
+    bookmarks_ready: bool
+    command_path: str
+    macos_extra: bool
+    macos_platform: bool
+    pipx_app_path: str | None
+    pipx_version_label: str | None
+    preferences_ready: bool
+    pypi_latest: str | None
+    source_checkout: bool
+    spotty_agent_installed: bool
+    upgrade_available: bool
+    version_label: str
+
+
+def detect_install_state(
+    *,
+    read_executable_build: Callable[[Path], str | None],
+) -> InstallState:
+    """Gather pipx, PyPI, macOS, and config state for onboarding."""
+    package, commit = get_build_info()
+    version_label = f"{package} ({commit})"
+    command_path = running_command_path()
+    pipx_app = pipx_bunnify_path()
+    pipx_label = read_executable_build(pipx_app) if pipx_app is not None else None
+    pypi_latest = pypi_latest_version()
+    upgrade_available = _upgrade_available(package, pypi_latest)
+    bookmarks = default_bookmarks_path()
+    preferences = load_preferences()
+    spotty_installed = False
+    if sys.platform == "darwin":
+        from app.spotty_bunny_agent import is_agent_installed
+
+        spotty_installed = is_agent_installed()
+    return InstallState(
+        bookmarks_ready=bookmarks.is_file(),
+        command_path=command_path,
+        macos_extra=macos_extra_installed(),
+        macos_platform=sys.platform == "darwin",
+        pipx_app_path=str(pipx_app) if pipx_app is not None else None,
+        pipx_version_label=pipx_label,
+        preferences_ready=preferences is not None,
+        pypi_latest=pypi_latest,
+        source_checkout=is_source_checkout(),
+        spotty_agent_installed=spotty_installed,
+        upgrade_available=upgrade_available,
+        version_label=version_label,
+    )
+
+
+def format_onboarding_text(
+    state: InstallState | None = None,
+    *,
+    read_executable_build: Callable[[Path], str | None] | None = None,
+) -> str:
+    """Return post-install / post-upgrade next steps for the terminal."""
+    if state is None:
+        reader = read_executable_build
+        if reader is None:
+            from app.cli import _read_executable_build as reader  # noqa: PLC0415
+
+        state = detect_install_state(read_executable_build=reader)
+    bookmarks = default_bookmarks_path()
+    config = env_file_path()
+    lines = ["Bunnify — next steps after install or upgrade", ""]
+    lines.extend(_format_install_summary(state))
+    lines.append("")
+    step = 1
+    if not state.bookmarks_ready:
+        lines.extend(
+            [
+                f"{step}. Bookmarks (required before the server starts):",
+                "     bunnify setup   # offers to install the example shortcuts",
+                f"     # or create {bookmarks} yourself from bunnify.json.example",
+                "",
+            ]
+        )
+        step += 1
+    if not state.preferences_ready:
+        lines.extend(
+            [
+                f"{step}. Configure and start the server (local on a laptop;",
+                "   remote for a home/always-on host):",
+                "     bunnify setup",
+                "   Guide: https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md",
+                "",
+            ]
+        )
+        step += 1
+    lines.extend(
+        [
+            f"{step}. Configure Chrome or Edge using BUNNIFY_BASE_URL from:",
+            f"     {config}",
+            "   Guide: https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md",
+            "",
+        ]
+    )
+    step += 1
+    lines.extend(
+        [
+            f"{step}. Try it:  bunnify gh   (or address-bar keyword, e.g. b gh)",
+            "",
+        ]
+    )
+    if state.macos_platform:
+        step += 1
+        lines.extend(_format_spotty_bunny_section(state, step))
+    lines.extend(
+        [
+            "Upgrade later (preferred):",
+            "     bunnify upgrade   # shows from/to versions, then pipx upgrade",
+            "   Bookmarks and config.env are kept across upgrades.",
+            "   If --version still shows a checkout SHA, PATH is using",
+            "   ./scripts/bunnify or a repo .venv — the pipx app lives in",
+            "   ~/.local/bin/bunnify.",
+            "",
+            "Docs: https://github.com/the-hcma/bunnify",
+            "Re-print this message anytime:  bunnify onboard",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def run_onboard(
+    *,
+    confirm_yes: Callable[[Callable[[str], str], str], bool] | None = None,
+    print_fn: Callable[[str], None] | None = None,
+    prompt_fn: Callable[[str], str] | None = None,
+    read_executable_build: Callable[[Path], str | None] | None = None,
+    run_upgrade: Callable[..., None] | None = None,
+    theme: Theme | None = None,
+) -> None:
+    """Print onboarding guidance; interactively upgrade and install macOS extras."""
+    from app.cli import _command_banner, _read_executable_build  # noqa: PLC0415
+
+    log = print_fn or print
+    ask = prompt_fn or input
+    colors = theme if theme is not None else Theme(enabled=False)
+    reader = read_executable_build or _read_executable_build
+    state = detect_install_state(read_executable_build=reader)
+    yes = confirm_yes
+    if yes is None:
+        from app.cli import _confirm_explicit_yes as yes  # noqa: PLC0415
+
+    interactive = sys.stdin.isatty() and sys.stdout.isatty()
+    log(colors.header(_command_banner("onboard")))
+    for line in _format_install_summary(state):
+        log(line)
+    log("")
+
+    if interactive and state.upgrade_available and state.pypi_latest is not None:
+        if yes(
+            ask,
+            colors.brand(f"Upgrade pipx install to {state.pypi_latest} now? [y/N]: "),
+        ):
+            upgrade = run_upgrade
+            if upgrade is None:
+                from app.cli import run_upgrade as upgrade  # noqa: PLC0415
+
+            upgrade(print_fn=log, theme=colors)
+            state = detect_install_state(read_executable_build=reader)
+
+    if interactive and state.macos_platform and not state.macos_extra:
+        if yes(
+            ask,
+            colors.brand(
+                "Install macOS dependencies for Spotty Bunny (PyObjC)? [y/N]: "
+            ),
+        ):
+            pipx = shutil.which("pipx")
+            if pipx is None:
+                log(colors.warn("pipx not found on PATH; install PyObjC manually:"))
+                log("  pipx install --force 'bunnify[macos]'")
+            elif install_macos_extra(pipx):
+                log(colors.ok("✓ Installed bunnify[macos] (PyObjC) via pipx"))
+                state = detect_install_state(read_executable_build=reader)
+            else:
+                log(colors.warn("pipx install --force 'bunnify[macos]' failed."))
+
+    if interactive and state.macos_platform and state.macos_extra:
+        prompt = (
+            "Install or refresh Spotty Bunny (LaunchAgent + Control chord test)? "
+            "[y/N]: "
+        )
+        if not state.spotty_agent_installed or yes(ask, colors.brand(prompt)):
+            from app.spotty_bunny_agent import install_agent
+
+            code = install_agent(print_err=lambda message: log(message), prompt_fn=ask)
+            if code == 0:
+                log(
+                    colors.ok(
+                        "✓ Spotty Bunny is installed and the Control chord works."
+                    )
+                )
+            else:
+                log(
+                    colors.warn(
+                        "Spotty Bunny install did not finish; see messages above."
+                    )
+                )
+
+    log("")
+    log(format_onboarding_text(state))
+
+
+def _format_install_summary(state: InstallState) -> list[str]:
+    lines = [f"Already installed: {state.version_label}", f"  {state.command_path}"]
+    if state.pipx_app_path is not None:
+        lines.append("pipx app:")
+        if state.pipx_version_label is not None:
+            lines.append(f"  {state.pipx_version_label}")
+        lines.append(f"  {state.pipx_app_path}")
+    elif not state.source_checkout:
+        lines.append("pipx app: not found (~/.local/bin/bunnify)")
+    if state.source_checkout:
+        lines.append(
+            "Note: this process is a git checkout; `bunnify upgrade` updates the "
+            "pipx app, not this tree."
+        )
+    if state.pypi_latest is not None:
+        if state.upgrade_available:
+            lines.append(f"PyPI latest: {state.pypi_latest} (upgrade available)")
+        else:
+            lines.append(f"PyPI latest: {state.pypi_latest} (up to date)")
+    if state.macos_platform:
+        extra = "installed" if state.macos_extra else "not installed"
+        lines.append(f"macOS Spotty Bunny dependencies (PyObjC): {extra}")
+        if state.spotty_agent_installed:
+            lines.append("Spotty Bunny LaunchAgent: installed")
+        else:
+            lines.append("Spotty Bunny LaunchAgent: not installed")
+    return lines
+
+
+def _format_spotty_bunny_section(state: InstallState, step: int) -> list[str]:
+    if state.macos_extra and state.spotty_agent_installed:
+        return [
+            f"{step}. macOS Spotty Bunny (optional search box): installed",
+            "     bunnify spotty-bunny status",
+            "     bunnify upgrade && bunnify spotty-bunny upgrade",
+            "     bunnify spotty-bunny uninstall",
+            "   Guide: https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md",
+            "",
+        ]
+    if state.macos_extra:
+        return [
+            f"{step}. macOS Spotty Bunny (optional search box):",
+            "     bunnify spotty-bunny install    # LaunchAgent + chord test",
+            "     bunnify spotty-bunny status",
+            "   Guide: https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md",
+            "",
+        ]
+    return [
+        f"{step}. macOS Spotty Bunny (optional search box):",
+        "     bunnify onboard                 # offers macOS deps + install",
+        "     pipx install --force 'bunnify[macos]'",
+        "     bunnify spotty-bunny install",
+        "   Guide: https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md",
+        "",
+    ]
+
+
+def _upgrade_available(package: str, pypi_latest: str | None) -> bool:
+    if pypi_latest is None:
+        return False
+    try:
+        return Version(package) < Version(pypi_latest)
+    except InvalidVersion:
+        return False

--- a/app/pipx_install.py
+++ b/app/pipx_install.py
@@ -1,0 +1,82 @@
+"""pipx install detection and macOS optional-extra management."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+MACOS_EXTRA_PACKAGE = "bunnify[macos]"
+MACOS_EXTRA_PROBE = (
+    "import importlib.util, sys; "
+    "sys.exit(0 if importlib.util.find_spec('AppKit') else 1)"
+)
+PIPX_INSTALL_TIMEOUT_S = 180
+
+
+def install_macos_extra(
+    pipx_bin: str,
+    *,
+    run_fn: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> bool:
+    """Reinstall the pipx app with the ``macos`` extra. Return success."""
+    runner = run_fn or subprocess.run
+    try:
+        completed = runner(
+            [pipx_bin, "install", "--force", MACOS_EXTRA_PACKAGE],
+            check=False,
+            text=True,
+            timeout=PIPX_INSTALL_TIMEOUT_S,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return False
+    return completed.returncode == 0
+
+
+def macos_extra_installed(*, interpreter: Path | None = None) -> bool:
+    """Return whether PyObjC (``AppKit``) is importable in the pipx venv."""
+    python = interpreter
+    if python is None:
+        python = pipx_bunnify_venv_python()
+    if python is None:
+        python = Path(sys.executable)
+    try:
+        completed = subprocess.run(
+            [str(python), "-c", MACOS_EXTRA_PROBE],
+            capture_output=True,
+            check=False,
+            timeout=15,
+        )
+    except OSError, subprocess.TimeoutExpired:
+        return False
+    return completed.returncode == 0
+
+
+def pipx_bunnify_path() -> Path | None:
+    """Return the pipx ``bunnify`` app path when it exists."""
+    override = os.environ.get("PIPX_BIN_DIR", "").strip()
+    candidates: list[Path] = []
+    if override:
+        candidates.append(Path(override) / "bunnify")
+    candidates.append(Path.home() / ".local" / "bin" / "bunnify")
+    for candidate in candidates:
+        if candidate.is_file():
+            try:
+                return candidate.resolve()
+            except OSError:
+                return candidate
+    return None
+
+
+def pipx_bunnify_venv_python(*, pipx_home: Path | None = None) -> Path | None:
+    """Return the pipx venv python for ``bunnify``, if present."""
+    root = pipx_home
+    if root is None:
+        env_home = os.environ.get("PIPX_HOME", "").strip()
+        root = Path(env_home) if env_home else Path.home() / ".local" / "share" / "pipx"
+    python = root / "venvs" / "bunnify" / "bin" / "python"
+    if python.is_file():
+        return python
+    return None

--- a/app/pipx_install.py
+++ b/app/pipx_install.py
@@ -72,11 +72,23 @@ def pipx_bunnify_path() -> Path | None:
 
 def pipx_bunnify_venv_python(*, pipx_home: Path | None = None) -> Path | None:
     """Return the pipx venv python for ``bunnify``, if present."""
-    root = pipx_home
-    if root is None:
-        env_home = os.environ.get("PIPX_HOME", "").strip()
-        root = Path(env_home) if env_home else Path.home() / ".local" / "share" / "pipx"
-    python = root / "venvs" / "bunnify" / "bin" / "python"
-    if python.is_file():
-        return python
+    roots = [pipx_home] if pipx_home is not None else _pipx_home_candidates()
+    for root in roots:
+        python = root / "venvs" / "bunnify" / "bin" / "python"
+        if python.is_file():
+            return python
     return None
+
+
+def _pipx_home_candidates() -> list[Path]:
+    """Return likely pipx home directories (``PIPX_HOME`` and common defaults)."""
+    candidates: list[Path] = []
+    env_home = os.environ.get("PIPX_HOME", "").strip()
+    if env_home:
+        candidates.append(Path(env_home))
+    home = Path.home()
+    for relative in (Path(".local") / "share" / "pipx", Path(".local") / "pipx"):
+        candidate = home / relative
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return candidates

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -744,9 +744,8 @@ def _require_current_tcc(
             err(f"Then re-run: {COMMAND_NAME} install")
             return None
         while not status.ok:
-            err(TCC_RECHECK_PROMPT)
             try:
-                (prompt_fn or input)()
+                (prompt_fn or input)(TCC_RECHECK_PROMPT)
             except EOFError, KeyboardInterrupt:
                 return None
             try:

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -32,6 +32,11 @@ AGENT_LABEL = "com.thehcma.bunnify.spotty-bunny"
 AGENT_PLIST_NAME = f"{AGENT_LABEL}.plist"
 LAUNCHCTL_TIMEOUT_S = 10
 LAUNCHD_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+CHORD_RETRY_HINT = f"""\
+{COMMAND_NAME}: the overlay may need a fresh launchd process after granting
+Accessibility / Input Monitoring. Restarting the agent — test again when ready.
+"""
+CHORD_TEST_PROMPT = f"{COMMAND_NAME}: did the search box appear? [y/N]: "
 POST_INSTALL_HINT = (
     f"{COMMAND_NAME}: hold one Control and press the other to test the overlay."
 )
@@ -42,9 +47,11 @@ spotty-bunny), not only Terminal.app.
 
 System Settings → Privacy & Security → Accessibility
 System Settings → Privacy & Security → Input Monitoring
-
-Then re-run: {COMMAND_NAME} install
 """
+TCC_RECHECK_PROMPT = (
+    "Press Enter after granting Accessibility/Input Monitoring to re-check "
+    "(or Ctrl-C to cancel)."
+)
 TCC_PROBE_TIMEOUT_S = 15
 UNKNOWN_COMMAND_MESSAGE = (
     f"{COMMAND_NAME}: unknown command '{{command}}'. "
@@ -106,11 +113,14 @@ def install_agent(
     *,
     home: Path | None = None,
     launchctl: LaunchctlFn | None = None,
+    pid_dir: Path | None = None,
     platform: str | None = None,
     print_err: Callable[[str], None] | None = None,
     probe_tcc: TccFn | None = None,
     program: Path | None = None,
+    prompt_fn: Callable[[str], str] | None = None,
     request_tcc: TccFn | None = None,
+    skip_chord_confirm: bool = False,
 ) -> int:
     """Write the LaunchAgent, verify TCC, and bootstrap it."""
     err = print_err or _print_err
@@ -139,6 +149,7 @@ def install_agent(
         interpreter,
         err=err,
         probe_tcc=probe_tcc,
+        prompt_fn=prompt_fn,
         request_tcc=request_tcc,
     )
     if status is None:
@@ -146,15 +157,25 @@ def install_agent(
     root = home if home is not None else Path.home()
     plist = agent_plist_path(home=root)
     _write_plist(plist, home=root, program_arguments=program_argv)
-    _bootout_agent(launchctl=launchctl)
-    if not _bootstrap_agent(plist, launchctl=launchctl):
+    if not _reload_agent(
+        plist,
+        launchctl=launchctl,
+        pid_dir=pid_dir,
+    ):
         err(f"{COMMAND_NAME}: launchctl bootstrap failed for {plist}.")
         return 1
     err(f"{COMMAND_NAME}: installed LaunchAgent {AGENT_LABEL}")
     err(f"{COMMAND_NAME}: plist {plist}")
     err(f"{COMMAND_NAME}: interpreter {interpreter_realpath(interpreter)}")
-    err(POST_INSTALL_HINT)
-    return 0
+    if skip_chord_confirm or _confirm_chord_works(
+        plist,
+        err=err,
+        launchctl=launchctl,
+        pid_dir=pid_dir,
+        prompt_fn=prompt_fn,
+    ):
+        return 0
+    return 1
 
 
 def interpreter_for_program(program: Path) -> Path:
@@ -412,11 +433,14 @@ def upgrade_agent(
     *,
     home: Path | None = None,
     launchctl: LaunchctlFn | None = None,
+    pid_dir: Path | None = None,
     platform: str | None = None,
     print_err: Callable[[str], None] | None = None,
     probe_tcc: TccFn | None = None,
     program: Path | None = None,
+    prompt_fn: Callable[[str], str] | None = None,
     request_tcc: TccFn | None = None,
+    skip_chord_confirm: bool = False,
 ) -> int:
     """Rewrite the plist for the current binary, re-check TCC, and bounce."""
     err = print_err or _print_err
@@ -452,23 +476,31 @@ def upgrade_agent(
         interpreter,
         err=err,
         probe_tcc=probe_tcc,
+        prompt_fn=prompt_fn,
         request_tcc=request_tcc,
     )
     if status is None:
         return 1
-    was_loaded = is_agent_loaded(launchctl=launchctl)
     _write_plist(plist, home=root, program_arguments=program_argv)
-    if was_loaded:
-        _bootout_agent(launchctl=launchctl)
-    if was_loaded or not is_agent_loaded(launchctl=launchctl):
-        if not _bootstrap_agent(plist, launchctl=launchctl):
-            err(f"{COMMAND_NAME}: launchctl bootstrap failed for {plist}.")
-            return 1
+    if not _reload_agent(
+        plist,
+        launchctl=launchctl,
+        pid_dir=pid_dir,
+    ):
+        err(f"{COMMAND_NAME}: launchctl bootstrap failed for {plist}.")
+        return 1
     err(f"{COMMAND_NAME}: refreshed LaunchAgent {AGENT_LABEL}")
     err(f"{COMMAND_NAME}: binary {binary}")
     err(f"{COMMAND_NAME}: interpreter {interpreter_realpath(interpreter)}")
-    err(POST_INSTALL_HINT)
-    return 0
+    if skip_chord_confirm or _confirm_chord_works(
+        plist,
+        err=err,
+        launchctl=launchctl,
+        pid_dir=pid_dir,
+        prompt_fn=prompt_fn,
+    ):
+        return 0
+    return 1
 
 
 def _bootstrap_agent(
@@ -644,6 +676,33 @@ def _print_err(message: str) -> None:
     print(message, file=sys.stderr)
 
 
+def _confirm_chord_works(
+    plist: Path,
+    *,
+    err: Callable[[str], None],
+    launchctl: LaunchctlFn | None,
+    pid_dir: Path | None,
+    prompt_fn: Callable[[str], str] | None,
+) -> bool:
+    """Prompt until the user confirms the Control chord works, bouncing on retry."""
+    ask = prompt_fn or input
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        err(POST_INSTALL_HINT)
+        return True
+    while True:
+        err(POST_INSTALL_HINT)
+        try:
+            answer = ask(CHORD_TEST_PROMPT)
+        except EOFError, KeyboardInterrupt:
+            return False
+        if answer.strip().lower() in {"y", "yes"}:
+            return True
+        err(CHORD_RETRY_HINT)
+        if not _reload_agent(plist, launchctl=launchctl, pid_dir=pid_dir):
+            err(f"{COMMAND_NAME}: could not restart the LaunchAgent.")
+            return False
+
+
 def _probe_tcc(interpreter: Path) -> TccStatus:
     return _run_tcc_probe(interpreter, prompt=False)
 
@@ -657,6 +716,7 @@ def _require_current_tcc(
     *,
     err: Callable[[str], None],
     probe_tcc: TccFn | None,
+    prompt_fn: Callable[[str], str] | None = None,
     request_tcc: TccFn | None,
 ) -> TccStatus | None:
     probe = probe_tcc or _probe_tcc
@@ -680,16 +740,13 @@ def _require_current_tcc(
             f"{'yes' if status.accessibility else 'no'} "
             f"input_monitoring={'yes' if status.input_monitoring else 'no'}"
         )
-        # TCC prompts can be granted after we've already probed once.
-        # When running interactively, let the user confirm and re-check.
-        if sys.stdin.isatty() and sys.stdout.isatty():
-            err(
-                f"{COMMAND_NAME}: press Enter after granting "
-                f"Accessibility/Input Monitoring to {interpreter} "
-                "to re-check (or Ctrl-C to cancel)."
-            )
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            err(f"Then re-run: {COMMAND_NAME} install")
+            return None
+        while not status.ok:
+            err(TCC_RECHECK_PROMPT)
             try:
-                input()
+                (prompt_fn or input)()
             except EOFError, KeyboardInterrupt:
                 return None
             try:
@@ -702,8 +759,29 @@ def _require_current_tcc(
                 return None
             if status.ok:
                 return status
-        return None
+            err(
+                f"{COMMAND_NAME}: accessibility="
+                f"{'yes' if status.accessibility else 'no'} "
+                f"input_monitoring={'yes' if status.input_monitoring else 'no'}"
+            )
+        return status
     return status
+
+
+def _reload_agent(
+    plist: Path,
+    *,
+    launchctl: LaunchctlFn | None = None,
+    pid_dir: Path | None = None,
+) -> bool:
+    """Boot out, stop stale overlays, and bootstrap the LaunchAgent."""
+    _bootout_agent(launchctl=launchctl)
+    stop_spotty_bunny(pid_dir=pid_dir)
+    clear_spotty_bunny_pid(pid_dir=pid_dir)
+    if _bootstrap_agent(plist, launchctl=launchctl):
+        return True
+    _bootout_agent(launchctl=launchctl)
+    return _bootstrap_agent(plist, launchctl=launchctl)
 
 
 def _run_tcc_probe(interpreter: Path, *, prompt: bool) -> TccStatus:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -807,7 +807,7 @@ class SpottyBunnyController(NSObject):
             container.setLineFragmentPadding_(0.0)
 
     def _perform_install(self) -> None:
-        if install_agent() != 0:
+        if install_agent(skip_chord_confirm=True) != 0:
             raise RuntimeError("LaunchAgent install failed")
 
     def _perform_upgrade(self) -> None:

--- a/app/spotty_bunny_cli.py
+++ b/app/spotty_bunny_cli.py
@@ -36,7 +36,8 @@ LOG_MAX_BYTES = 10 * 1024 * 1024
 MACOS_EXTRA_HINT = f"""\
 {COMMAND_NAME}: PyObjC is required (optional extra 'macos').
 
-  pipx install 'bunnify[macos]'
+  pipx install --force 'bunnify[macos]'
+  # or: bunnify onboard   (offers to install macOS dependencies)
   # development checkout:
   uv sync --extra macos
 """

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -95,7 +95,7 @@ def ensure_spotty_bunny_running(
     if installed:
         from app.spotty_bunny_agent import install_agent
 
-        if install_agent() == 0:
+        if install_agent(skip_chord_confirm=True) == 0:
             deadline = time.monotonic() + SPOTTY_BUNNY_LAUNCHD_WAIT_S
             while True:
                 if spotty_bunny_is_running(pid_dir=directory):

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -2217,41 +2217,39 @@ class ConfigUnitTests(TestCase):
     def test_onboard_prints_next_steps(self) -> None:
         from app.cli import main
 
+        mock_state = InstallState(
+            bookmarks_ready=False,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=False,
+            macos_platform=False,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.3 (abc12345)",
+            preferences_ready=False,
+            pypi_latest="0.8.3",
+            source_checkout=False,
+            spotty_agent_installed=False,
+            upgrade_available=False,
+            version_label="0.8.3 (abc12345)",
+        )
         with (
-            patch(
-                "app.onboard.detect_install_state",
-                return_value=InstallState(
-                    bookmarks_ready=False,
-                    command_path="/Users/me/.local/bin/bunnify",
-                    macos_extra=False,
-                    macos_platform=False,
-                    pipx_app_path="/Users/me/.local/bin/bunnify",
-                    pipx_version_label="0.8.3 (abc12345)",
-                    preferences_ready=False,
-                    pypi_latest="0.8.3",
-                    source_checkout=False,
-                    spotty_agent_installed=False,
-                    upgrade_available=False,
-                    version_label="0.8.3 (abc12345)",
-                ),
-            ),
+            patch("app.onboard.detect_install_state", return_value=mock_state),
             patch("app.onboard.sys.stdin") as stdin,
             patch("app.onboard.sys.stdout") as stdout_tty,
         ):
             stdin.isatty.return_value = False
             stdout_tty.isatty.return_value = False
             result = CliRunner().invoke(main, ["onboard"])
-        self.assertEqual(result.exit_code, 0)
-        self.assertIn("Already installed:", result.output)
-        self.assertIn("bookmarks.json", result.output)
-        self.assertIn("bunnify setup", result.output)
-        self.assertIn("CHROME_SETUP.md", result.output)
-        self.assertIn("bunnify upgrade", result.output)
-        self.assertIn("preferred", result.output.lower())
+            self.assertEqual(result.exit_code, 0)
+            self.assertIn("Already installed:", result.output)
+            self.assertIn("bookmarks.json", result.output)
+            self.assertIn("bunnify setup", result.output)
+            self.assertIn("CHROME_SETUP.md", result.output)
+            self.assertIn("bunnify upgrade", result.output)
+            self.assertIn("preferred", result.output.lower())
 
-        flagged = CliRunner().invoke(main, ["--onboard"])
-        self.assertEqual(flagged.exit_code, 0)
-        self.assertIn("bunnify setup", flagged.output)
+            flagged = CliRunner().invoke(main, ["--onboard"])
+            self.assertEqual(flagged.exit_code, 0)
+            self.assertIn("bunnify setup", flagged.output)
 
     def test_upgrade_runs_pipx_and_explains_checkout(self) -> None:
         import subprocess
@@ -2292,6 +2290,41 @@ class ConfigUnitTests(TestCase):
         self.assertIn("git checkout", result.output)
         run.assert_called_once()
         self.assertEqual(run.call_args.args[0], ["/usr/bin/pipx", "upgrade", "bunnify"])
+
+    def test_upgrade_restores_macos_extra_after_pipx_upgrade(self) -> None:
+        import subprocess
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import main
+
+        completed = subprocess.CompletedProcess(
+            ["pipx", "upgrade", "bunnify"], 0, "", ""
+        )
+        with (
+            patch("app.cli.is_source_checkout", return_value=False),
+            patch("app.cli.shutil.which", return_value="/usr/bin/pipx"),
+            patch(
+                "app.cli.macos_extra_installed",
+                side_effect=[True, False],
+            ),
+            patch("app.cli.install_macos_extra", return_value=True) as restore,
+            patch("app.cli._pypi_latest_version", return_value="0.5.0"),
+            patch(
+                "app.cli._pipx_bunnify_path",
+                return_value=Path("/Users/me/.local/bin/bunnify"),
+            ),
+            patch(
+                "app.cli._read_executable_build",
+                side_effect=["0.4.0 (oldoldoldold)", "0.5.0 (newnewnewnew)"],
+            ),
+            patch("app.cli.subprocess.run", return_value=completed),
+        ):
+            result = CliRunner().invoke(main, ["upgrade"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        restore.assert_called_once()
+        self.assertEqual(restore.call_args.args[0], "/usr/bin/pipx")
 
     def test_upgrade_errors_when_pipx_missing(self) -> None:
         from unittest.mock import patch

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -15,6 +15,7 @@ from app import interactive
 from app.cli import _run, matching_keys
 from app.client import ClientError, KeyEntry, ResolvedShortcut, parse_keys_payload
 from app.completion_spec import ParamCompleteSpec
+from app.onboard import InstallState
 
 from .models import Bookmark
 
@@ -2216,14 +2217,37 @@ class ConfigUnitTests(TestCase):
     def test_onboard_prints_next_steps(self) -> None:
         from app.cli import main
 
-        result = CliRunner().invoke(main, ["onboard"])
+        with (
+            patch(
+                "app.onboard.detect_install_state",
+                return_value=InstallState(
+                    bookmarks_ready=False,
+                    command_path="/Users/me/.local/bin/bunnify",
+                    macos_extra=False,
+                    macos_platform=False,
+                    pipx_app_path="/Users/me/.local/bin/bunnify",
+                    pipx_version_label="0.8.3 (abc12345)",
+                    preferences_ready=False,
+                    pypi_latest="0.8.3",
+                    source_checkout=False,
+                    spotty_agent_installed=False,
+                    upgrade_available=False,
+                    version_label="0.8.3 (abc12345)",
+                ),
+            ),
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+        ):
+            stdin.isatty.return_value = False
+            stdout_tty.isatty.return_value = False
+            result = CliRunner().invoke(main, ["onboard"])
         self.assertEqual(result.exit_code, 0)
+        self.assertIn("Already installed:", result.output)
         self.assertIn("bookmarks.json", result.output)
         self.assertIn("bunnify setup", result.output)
         self.assertIn("CHROME_SETUP.md", result.output)
         self.assertIn("bunnify upgrade", result.output)
         self.assertIn("preferred", result.output.lower())
-        self.assertIn("spotty-bunny install", result.output)
 
         flagged = CliRunner().invoke(main, ["--onboard"])
         self.assertEqual(flagged.exit_code, 0)
@@ -2245,6 +2269,7 @@ class ConfigUnitTests(TestCase):
         with (
             patch("app.cli.is_source_checkout", return_value=True),
             patch("app.cli.shutil.which", return_value="/usr/bin/pipx"),
+            patch("app.cli.macos_extra_installed", return_value=False),
             patch("app.cli._pypi_latest_version", return_value="0.5.0"),
             patch(
                 "app.cli._pipx_bunnify_path",

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -48,7 +48,7 @@ class OnboardTests(SimpleTestCase):
 
     def test_run_onboard_offers_macos_extra_install(self) -> None:
         stdout = StringIO()
-        state = InstallState(
+        state_without_extra = InstallState(
             bookmarks_ready=True,
             command_path="/Users/me/.local/bin/bunnify",
             macos_extra=False,
@@ -62,18 +62,41 @@ class OnboardTests(SimpleTestCase):
             upgrade_available=False,
             version_label="0.8.3 (abc12345)",
         )
+        state_with_extra = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=True,
+            macos_platform=True,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.3 (abc12345)",
+            preferences_ready=True,
+            pypi_latest="0.8.3",
+            source_checkout=False,
+            spotty_agent_installed=False,
+            upgrade_available=False,
+            version_label="0.8.3 (abc12345)",
+        )
+        def ask(_message: str) -> str:
+            return "y"
+
         with (
-            patch("app.onboard.detect_install_state", return_value=state),
+            patch(
+                "app.onboard.detect_install_state",
+                side_effect=[state_without_extra, state_with_extra],
+            ),
             patch("app.onboard.sys.stdin") as stdin,
             patch("app.onboard.sys.stdout") as stdout_tty,
             patch("app.onboard.shutil.which", return_value="/usr/bin/pipx"),
             patch("app.onboard.install_macos_extra", return_value=True) as install,
+            patch("app.spotty_bunny_agent.install_agent", return_value=0) as agent,
             patch("app.cli._confirm_explicit_yes", side_effect=[True, False]),
         ):
             stdin.isatty.return_value = True
             stdout_tty.isatty.return_value = True
-            run_onboard(print_fn=stdout.write, prompt_fn=lambda _m: "y")
+            run_onboard(print_fn=stdout.write, prompt_fn=ask)
         install.assert_called_once_with("/usr/bin/pipx")
+        agent.assert_called_once()
+        self.assertIs(agent.call_args.kwargs.get("prompt_fn"), ask)
         self.assertIn("Already installed:", stdout.getvalue())
 
     def test_cli_onboard_prints_install_summary(self) -> None:

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -1,0 +1,110 @@
+"""Tests for interactive onboarding."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from django.test import SimpleTestCase
+
+from app.onboard import (
+    InstallState,
+    detect_install_state,
+    format_onboarding_text,
+    run_onboard,
+)
+
+
+class OnboardTests(SimpleTestCase):
+    def test_detect_install_state_marks_upgrade_when_pypi_is_newer(self) -> None:
+        with patch("app.onboard.pypi_latest_version", return_value="0.9.0"):
+            state = detect_install_state(
+                read_executable_build=lambda _path: "0.8.0 (abc12345)",
+            )
+        self.assertTrue(state.upgrade_available)
+        self.assertEqual(state.pypi_latest, "0.9.0")
+
+    def test_format_onboarding_text_includes_install_summary(self) -> None:
+        state = InstallState(
+            bookmarks_ready=False,
+            command_path="/usr/local/bin/bunnify",
+            macos_extra=False,
+            macos_platform=True,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.3 (abc12345)",
+            preferences_ready=False,
+            pypi_latest="0.8.3",
+            source_checkout=False,
+            spotty_agent_installed=False,
+            upgrade_available=False,
+            version_label="0.8.3 (abc12345)",
+        )
+        text = format_onboarding_text(state)
+        self.assertIn("Already installed:", text)
+        self.assertIn("pipx app:", text)
+        self.assertIn("bunnify onboard", text)
+        self.assertIn("pipx install --force", text)
+
+    def test_run_onboard_offers_macos_extra_install(self) -> None:
+        stdout = StringIO()
+        state = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=False,
+            macos_platform=True,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.3 (abc12345)",
+            preferences_ready=True,
+            pypi_latest="0.8.3",
+            source_checkout=False,
+            spotty_agent_installed=False,
+            upgrade_available=False,
+            version_label="0.8.3 (abc12345)",
+        )
+        with (
+            patch("app.onboard.detect_install_state", return_value=state),
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+            patch("app.onboard.shutil.which", return_value="/usr/bin/pipx"),
+            patch("app.onboard.install_macos_extra", return_value=True) as install,
+            patch("app.cli._confirm_explicit_yes", side_effect=[True, False]),
+        ):
+            stdin.isatty.return_value = True
+            stdout_tty.isatty.return_value = True
+            run_onboard(print_fn=stdout.write, prompt_fn=lambda _m: "y")
+        install.assert_called_once_with("/usr/bin/pipx")
+        self.assertIn("Already installed:", stdout.getvalue())
+
+    def test_cli_onboard_prints_install_summary(self) -> None:
+        from app.cli import main
+
+        with (
+            patch(
+                "app.onboard.detect_install_state",
+                return_value=InstallState(
+                    bookmarks_ready=False,
+                    command_path="/Users/me/.local/bin/bunnify",
+                    macos_extra=False,
+                    macos_platform=False,
+                    pipx_app_path="/Users/me/.local/bin/bunnify",
+                    pipx_version_label="0.8.3 (abc12345)",
+                    preferences_ready=False,
+                    pypi_latest="0.8.3",
+                    source_checkout=False,
+                    spotty_agent_installed=False,
+                    upgrade_available=False,
+                    version_label="0.8.3 (abc12345)",
+                ),
+            ),
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+        ):
+            stdin.isatty.return_value = False
+            stdout_tty.isatty.return_value = False
+            result = CliRunner().invoke(main, ["onboard"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Already installed:", result.output)
+        self.assertIn("bunnify setup", result.output)
+        self.assertIn("bunnify upgrade", result.output)

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -76,6 +76,7 @@ class OnboardTests(SimpleTestCase):
             upgrade_available=False,
             version_label="0.8.3 (abc12345)",
         )
+
         def ask(_message: str) -> str:
             return "y"
 

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -102,6 +102,38 @@ class OnboardTests(SimpleTestCase):
         self.assertIs(agent.call_args.kwargs.get("prompt_fn"), ask)
         self.assertIn("Already installed:", stdout.getvalue())
 
+    def test_run_onboard_warns_when_macos_extra_install_fails(self) -> None:
+        stdout = StringIO()
+        state = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=False,
+            macos_platform=True,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.3 (abc12345)",
+            preferences_ready=True,
+            pypi_latest="0.8.3",
+            source_checkout=False,
+            spotty_agent_installed=False,
+            upgrade_available=False,
+            version_label="0.8.3 (abc12345)",
+        )
+        with (
+            patch("app.onboard.detect_install_state", return_value=state),
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+            patch("app.onboard.shutil.which", return_value="/usr/bin/pipx"),
+            patch("app.onboard.install_macos_extra", return_value=False),
+            patch("app.spotty_bunny_agent.install_agent") as agent,
+            patch("app.cli._confirm_explicit_yes", return_value=True),
+        ):
+            stdin.isatty.return_value = True
+            stdout_tty.isatty.return_value = True
+            run_onboard(print_fn=stdout.write, prompt_fn=lambda _m: "y")
+        output = stdout.getvalue()
+        self.assertIn("pipx install --force 'bunnify[macos]' failed.", output)
+        agent.assert_not_called()
+
     def test_run_onboard_offers_upgrade_when_available(self) -> None:
         stdout = StringIO()
         before = InstallState(

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 from django.test import SimpleTestCase
@@ -99,6 +99,55 @@ class OnboardTests(SimpleTestCase):
         agent.assert_called_once()
         self.assertIs(agent.call_args.kwargs.get("prompt_fn"), ask)
         self.assertIn("Already installed:", stdout.getvalue())
+
+    def test_run_onboard_offers_upgrade_when_available(self) -> None:
+        stdout = StringIO()
+        before = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=True,
+            macos_platform=False,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.0 (abc12345)",
+            preferences_ready=True,
+            pypi_latest="0.9.0",
+            source_checkout=False,
+            spotty_agent_installed=True,
+            upgrade_available=True,
+            version_label="0.8.0 (abc12345)",
+        )
+        after = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=True,
+            macos_platform=False,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.9.0 (def67890)",
+            preferences_ready=True,
+            pypi_latest="0.9.0",
+            source_checkout=False,
+            spotty_agent_installed=True,
+            upgrade_available=False,
+            version_label="0.9.0 (def67890)",
+        )
+        upgrade = MagicMock()
+        with (
+            patch(
+                "app.onboard.detect_install_state",
+                side_effect=[before, after],
+            ),
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+            patch("app.cli._confirm_explicit_yes", return_value=True),
+        ):
+            stdin.isatty.return_value = True
+            stdout_tty.isatty.return_value = True
+            run_onboard(
+                print_fn=stdout.write,
+                prompt_fn=lambda _m: "y",
+                run_upgrade=upgrade,
+            )
+        upgrade.assert_called_once()
 
     def test_cli_onboard_prints_install_summary(self) -> None:
         from app.cli import main

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -134,6 +134,40 @@ class OnboardTests(SimpleTestCase):
         self.assertIn("pipx install --force 'bunnify[macos]' failed.", output)
         agent.assert_not_called()
 
+    def test_run_onboard_warns_when_pipx_missing(self) -> None:
+        stdout = StringIO()
+        state = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=False,
+            macos_platform=True,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.3 (abc12345)",
+            preferences_ready=True,
+            pypi_latest="0.8.3",
+            source_checkout=False,
+            spotty_agent_installed=False,
+            upgrade_available=False,
+            version_label="0.8.3 (abc12345)",
+        )
+        with (
+            patch("app.onboard.detect_install_state", return_value=state),
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+            patch("app.onboard.shutil.which", return_value=None),
+            patch("app.onboard.install_macos_extra") as install,
+            patch("app.spotty_bunny_agent.install_agent") as agent,
+            patch("app.cli._confirm_explicit_yes", return_value=True),
+        ):
+            stdin.isatty.return_value = True
+            stdout_tty.isatty.return_value = True
+            run_onboard(print_fn=stdout.write, prompt_fn=lambda _m: "y")
+        output = stdout.getvalue()
+        self.assertIn("pipx not found on PATH", output)
+        self.assertIn("pipx install --force 'bunnify[macos]'", output)
+        install.assert_not_called()
+        agent.assert_not_called()
+
     def test_run_onboard_offers_upgrade_when_available(self) -> None:
         stdout = StringIO()
         before = InstallState(

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 from django.test import SimpleTestCase
 
+from app.cli import run_upgrade
+from app.client import ClientError
 from app.onboard import (
     InstallState,
     detect_install_state,
@@ -130,7 +132,7 @@ class OnboardTests(SimpleTestCase):
             upgrade_available=False,
             version_label="0.9.0 (def67890)",
         )
-        upgrade = MagicMock()
+        upgrade = MagicMock(spec=run_upgrade)
         with (
             patch(
                 "app.onboard.detect_install_state",
@@ -148,6 +150,40 @@ class OnboardTests(SimpleTestCase):
                 run_upgrade=upgrade,
             )
         upgrade.assert_called_once()
+        self.assertIn("print_fn", upgrade.call_args.kwargs)
+        self.assertIn("theme", upgrade.call_args.kwargs)
+
+    def test_run_onboard_reports_upgrade_client_error(self) -> None:
+        stdout = StringIO()
+        state = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=True,
+            macos_platform=False,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.0 (abc12345)",
+            preferences_ready=True,
+            pypi_latest="0.9.0",
+            source_checkout=False,
+            spotty_agent_installed=True,
+            upgrade_available=True,
+            version_label="0.8.0 (abc12345)",
+        )
+        upgrade = MagicMock(spec=run_upgrade, side_effect=ClientError("pipx not found"))
+        with (
+            patch("app.onboard.detect_install_state", return_value=state),
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+            patch("app.cli._confirm_explicit_yes", return_value=True),
+        ):
+            stdin.isatty.return_value = True
+            stdout_tty.isatty.return_value = True
+            run_onboard(
+                print_fn=stdout.write,
+                prompt_fn=lambda _m: "y",
+                run_upgrade=upgrade,
+            )
+        self.assertIn("error: pipx not found", stdout.getvalue())
 
     def test_cli_onboard_prints_install_summary(self) -> None:
         from app.cli import main

--- a/bookmarks/test_pipx_install.py
+++ b/bookmarks/test_pipx_install.py
@@ -34,6 +34,30 @@ class PipxInstallTests(SimpleTestCase):
             self.assertTrue(macos_extra_installed(interpreter=interpreter))
         self.assertEqual(run.call_args.args[0][0], str(interpreter))
 
+    def test_macos_extra_installed_falls_back_to_sys_executable(self) -> None:
+        completed = subprocess.CompletedProcess(["python"], 1, "", "")
+        with (
+            patch("app.pipx_install.pipx_bunnify_venv_python", return_value=None),
+            patch("app.pipx_install.subprocess.run", return_value=completed) as run,
+            patch("app.pipx_install.sys.executable", "/opt/fallback/bin/python"),
+        ):
+            self.assertFalse(macos_extra_installed())
+        self.assertEqual(run.call_args.args[0][0], "/opt/fallback/bin/python")
+
+    def test_macos_extra_installed_returns_false_when_probe_fails(self) -> None:
+        completed = subprocess.CompletedProcess(["python"], 1, "", "")
+        interpreter = Path("/opt/venv/bin/python")
+        with patch("app.pipx_install.subprocess.run", return_value=completed):
+            self.assertFalse(macos_extra_installed(interpreter=interpreter))
+
+    def test_macos_extra_installed_returns_false_on_subprocess_error(self) -> None:
+        interpreter = Path("/opt/venv/bin/python")
+        with patch(
+            "app.pipx_install.subprocess.run",
+            side_effect=OSError("probe failed"),
+        ):
+            self.assertFalse(macos_extra_installed(interpreter=interpreter))
+
     def test_pipx_bunnify_venv_python_uses_pipx_home(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/bookmarks/test_pipx_install.py
+++ b/bookmarks/test_pipx_install.py
@@ -1,0 +1,54 @@
+"""Tests for pipx macOS extra helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from app.pipx_install import (
+    install_macos_extra,
+    macos_extra_installed,
+    pipx_bunnify_path,
+    pipx_bunnify_venv_python,
+)
+
+
+class PipxInstallTests(SimpleTestCase):
+    def test_install_macos_extra_runs_pipx_force(self) -> None:
+        completed = subprocess.CompletedProcess(["pipx"], 0, "", "")
+        with patch("app.pipx_install.subprocess.run", return_value=completed) as run:
+            self.assertTrue(install_macos_extra("/usr/bin/pipx"))
+        self.assertEqual(
+            run.call_args.args[0],
+            ["/usr/bin/pipx", "install", "--force", "bunnify[macos]"],
+        )
+
+    def test_macos_extra_installed_probes_appkit(self) -> None:
+        completed = subprocess.CompletedProcess(["python"], 0, "", "")
+        interpreter = Path("/opt/venv/bin/python")
+        with patch("app.pipx_install.subprocess.run", return_value=completed) as run:
+            self.assertTrue(macos_extra_installed(interpreter=interpreter))
+        self.assertEqual(run.call_args.args[0][0], str(interpreter))
+
+    def test_pipx_bunnify_venv_python_uses_pipx_home(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            python = root / "venvs" / "bunnify" / "bin" / "python"
+            python.parent.mkdir(parents=True)
+            python.write_text("", encoding="utf-8")
+            self.assertEqual(
+                pipx_bunnify_venv_python(pipx_home=root),
+                python,
+            )
+
+    def test_pipx_bunnify_path_honors_pipx_bin_dir(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            binary = root / "bunnify"
+            binary.write_text("#!/bin/sh\n", encoding="utf-8")
+            with patch.dict("os.environ", {"PIPX_BIN_DIR": str(root)}, clear=False):
+                self.assertEqual(pipx_bunnify_path(), binary.resolve())

--- a/bookmarks/test_pipx_install.py
+++ b/bookmarks/test_pipx_install.py
@@ -45,6 +45,15 @@ class PipxInstallTests(SimpleTestCase):
                 python,
             )
 
+    def test_pipx_bunnify_venv_python_checks_local_pipx_home(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".local" / "pipx"
+            python = root / "venvs" / "bunnify" / "bin" / "python"
+            python.parent.mkdir(parents=True)
+            python.write_text("", encoding="utf-8")
+            with patch.object(Path, "home", return_value=Path(tmp)):
+                self.assertEqual(pipx_bunnify_venv_python(), python)
+
     def test_pipx_bunnify_path_honors_pipx_bin_dir(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -664,6 +664,44 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertEqual(tcc.requests, 0)
             self.assertTrue(any(call[1] == "bootstrap" for call in ctl.calls))
 
+    def test_install_skips_chord_prompt_when_not_tty(self) -> None:
+        from unittest.mock import patch
+
+        from app.spotty_bunny_agent import install_agent
+
+        ctl = _FakeLaunchctl()
+        tcc = _FakeTcc(TccStatus(True, True))
+        prompts: list[str] = []
+
+        def ask(message: str) -> str:
+            prompts.append(message)
+            return "y"
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            program = home / "spotty-bunny"
+            _write_executable(program, content="#!/opt/venv/bin/python\n")
+            with (
+                patch("app.spotty_bunny_agent.sys.stdin") as stdin,
+                patch("app.spotty_bunny_agent.sys.stdout") as stdout,
+            ):
+                stdin.isatty.return_value = False
+                stdout.isatty.return_value = False
+                code = install_agent(
+                    home=home,
+                    launchctl=ctl,
+                    platform="darwin",
+                    print_err=lambda _m: None,
+                    probe_tcc=tcc.probe,
+                    program=program,
+                    prompt_fn=ask,
+                    request_tcc=tcc.request,
+                    skip_chord_confirm=False,
+                )
+            self.assertEqual(code, 0)
+            self.assertEqual(prompts, [])
+            self.assertEqual(sum(1 for call in ctl.calls if call[1] == "bootstrap"), 1)
+
     def test_install_does_not_bootstrap_when_tcc_missing(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, install_agent
 

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -798,6 +798,50 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertEqual(tcc.probes, 3)
             self.assertEqual(tcc.requests, 1)
 
+    def test_install_interactive_tcc_recheck_with_prompt_fn(self) -> None:
+        from unittest.mock import patch
+
+        from app.spotty_bunny_agent import (
+            TCC_RECHECK_PROMPT,
+            install_agent,
+        )
+
+        ctl = _FakeLaunchctl()
+        tcc = _FakeTcc(
+            TccStatus(False, False),
+            TccStatus(False, False),
+            TccStatus(True, True),
+        )
+        prompts: list[str] = []
+
+        def ask(message: str) -> str:
+            prompts.append(message)
+            return ""
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            program = home / "spotty-bunny"
+            _write_executable(program, content="#!/opt/venv/bin/python\n")
+            with (
+                patch("app.spotty_bunny_agent.sys.stdin") as stdin,
+                patch("app.spotty_bunny_agent.sys.stdout") as stdout,
+            ):
+                stdin.isatty.return_value = True
+                stdout.isatty.return_value = True
+                code = install_agent(
+                    home=home,
+                    launchctl=ctl,
+                    platform="darwin",
+                    print_err=lambda _m: None,
+                    probe_tcc=tcc.probe,
+                    program=program,
+                    prompt_fn=ask,
+                    request_tcc=tcc.request,
+                    skip_chord_confirm=True,
+                )
+            self.assertEqual(code, 0)
+            self.assertEqual(prompts, [TCC_RECHECK_PROMPT])
+
     def test_install_interactive_chord_retry_bounces_until_confirmed(self) -> None:
         from unittest.mock import patch
 

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -161,7 +161,8 @@ class SpottyBunnyCliTests(SimpleTestCase):
         ):
             self.assertEqual(run_spotty_bunny(), 1)
         self.assertIn("bunnify[macos]", stderr.getvalue())
-        self.assertIn("uv sync --extra macos", stderr.getvalue())
+        self.assertIn("--force", stderr.getvalue())
+        self.assertIn("bunnify onboard", stderr.getvalue())
 
     def test_not_macos_prints_hint(self) -> None:
         stderr = StringIO()
@@ -651,6 +652,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 probe_tcc=tcc.probe,
                 program=program,
                 request_tcc=tcc.request,
+                skip_chord_confirm=True,
             )
             plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
             self.assertEqual(code, 0)
@@ -742,7 +744,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             with (
                 patch("app.spotty_bunny_agent.sys.stdin") as stdin,
                 patch("app.spotty_bunny_agent.sys.stdout") as stdout,
-                patch("builtins.input", return_value=""),
+                patch("builtins.input", side_effect=["", KeyboardInterrupt]),
             ):
                 stdin.isatty.return_value = True
                 stdout.isatty.return_value = True
@@ -756,7 +758,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                     request_tcc=tcc.request,
                 )
             self.assertEqual(code, 1)
-            self.assertEqual(tcc.probes, 3)
+            self.assertGreaterEqual(tcc.probes, 3)
             self.assertFalse(
                 (home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist").exists()
             )
@@ -779,7 +781,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             with (
                 patch("app.spotty_bunny_agent.sys.stdin") as stdin,
                 patch("app.spotty_bunny_agent.sys.stdout") as stdout,
-                patch("builtins.input", return_value=""),
+                patch("builtins.input", side_effect=["", "y"]),
             ):
                 stdin.isatty.return_value = True
                 stdout.isatty.return_value = True
@@ -795,6 +797,42 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertEqual(code, 0)
             self.assertEqual(tcc.probes, 3)
             self.assertEqual(tcc.requests, 1)
+
+    def test_install_interactive_chord_retry_bounces_until_confirmed(self) -> None:
+        from unittest.mock import patch
+
+        from app.spotty_bunny_agent import AGENT_LABEL, install_agent
+
+        ctl = _FakeLaunchctl()
+        tcc = _FakeTcc(TccStatus(True, True))
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            program = home / "spotty-bunny"
+            _write_executable(program, content="#!/opt/venv/bin/python\n")
+            with (
+                patch("app.spotty_bunny_agent.sys.stdin") as stdin,
+                patch("app.spotty_bunny_agent.sys.stdout") as stdout,
+                patch("builtins.input", side_effect=["n", "y"]),
+            ):
+                stdin.isatty.return_value = True
+                stdout.isatty.return_value = True
+                code = install_agent(
+                    home=home,
+                    launchctl=ctl,
+                    platform="darwin",
+                    print_err=lambda _m: None,
+                    probe_tcc=tcc.probe,
+                    program=program,
+                    request_tcc=tcc.request,
+                )
+            self.assertEqual(code, 0)
+            bootouts = sum(1 for call in ctl.calls if call[1] == "bootout")
+            bootstraps = sum(1 for call in ctl.calls if call[1] == "bootstrap")
+            self.assertGreaterEqual(bootouts, 2)
+            self.assertGreaterEqual(bootstraps, 2)
+            self.assertTrue(
+                (home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist").is_file()
+            )
 
     def test_install_rechecks_tcc_after_prompt(self) -> None:
         from app.spotty_bunny_agent import install_agent
@@ -813,6 +851,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 probe_tcc=tcc.probe,
                 program=program,
                 request_tcc=tcc.request,
+                skip_chord_confirm=True,
             )
             self.assertEqual(code, 0)
             self.assertEqual(tcc.requests, 1)
@@ -1144,6 +1183,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
                 probe_tcc=tcc.probe,
                 program=new_program,
                 request_tcc=tcc.request,
+                skip_chord_confirm=True,
             )
             self.assertEqual(code, 0)
             self.assertIn(str(new_program), plist.read_text(encoding="utf-8"))

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -2344,7 +2344,7 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                         spawn=lambda _cmd: self.fail("should not spawn"),
                     )
                 )
-            install.assert_called_once()
+            install.assert_called_once_with(skip_chord_confirm=True)
 
     def test_ensure_spotty_bunny_running_polls_until_launchd_overlay_is_live(
         self,
@@ -2557,6 +2557,13 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 self.assertTrue(stop_spotty_bunny(pid_dir=pid_dir))
             terminate.assert_called_once_with(4242)
             self.assertFalse(pid_path.exists())
+
+    def test_perform_install_skips_chord_confirm(self) -> None:
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("def _perform_install(self) -> None:", source)
+        self.assertIn("install_agent(skip_chord_confirm=True)", source)
 
     def test_placeholder_documents_examples(self) -> None:
         source = (


### PR DESCRIPTION
## Summary

- `bunnify onboard` detects an existing pipx install, shows version/pipx state, offers PyPI upgrade, and on macOS offers `bunnify[macos]` + Spotty Bunny install.
- `spotty-bunny install` / `upgrade` loop on TCC grants (Enter to re-check) and Control-chord verification (bounce launchd until the user confirms the overlay works).
- `bunnify upgrade` restores the macos PyObjC extra after `pipx upgrade` when it was previously installed.
- Error hints now point at `pipx install --force 'bunnify[macos]'` and `bunnify onboard`.

Fixes #347

## Test plan

- [x] `./test_bunnify` (375 tests)
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run pyright --warnings`
- [ ] Manual: `bunnify onboard` on macOS with existing pipx install — upgrade + macos extra + spotty-bunny prompts
- [ ] Manual: grant TCC mid-install, confirm chord loop bounces until CTRL+CTRL works