### PR TITLE
fix: decouple onboard upgrade test from release version bumps

### DIFF
--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -21,14 +21,14 @@ from app.onboard import (
 class OnboardTests(SimpleTestCase):
     def test_detect_install_state_marks_upgrade_when_pypi_is_newer(self) -> None:
         with (
-            patch("app.onboard.get_build_info", return_value=("0.8.0", "abc12345")),
-            patch("app.onboard.pypi_latest_version", return_value="0.9.0"),
+            patch("app.onboard.get_build_info", return_value=("1.0.0", "abc12345")),
+            patch("app.onboard.pypi_latest_version", return_value="2.0.0"),
         ):
             state = detect_install_state(
-                read_executable_build=lambda _path: "0.8.0 (abc12345)",
+                read_executable_build=lambda _path: "1.0.0 (abc12345)",
             )
         self.assertTrue(state.upgrade_available)
-        self.assertEqual(state.pypi_latest, "0.9.0")
+        self.assertEqual(state.pypi_latest, "2.0.0")
 
     def test_format_onboarding_text_includes_install_summary(self) -> None:
         state = InstallState(

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -20,7 +20,10 @@ from app.onboard import (
 
 class OnboardTests(SimpleTestCase):
     def test_detect_install_state_marks_upgrade_when_pypi_is_newer(self) -> None:
-        with patch("app.onboard.pypi_latest_version", return_value="0.9.0"):
+        with (
+            patch("app.onboard.get_build_info", return_value=("0.8.0", "abc12345")),
+            patch("app.onboard.pypi_latest_version", return_value="0.9.0"),
+        ):
             state = detect_install_state(
                 read_executable_build=lambda _path: "0.8.0 (abc12345)",
             )

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -17,18 +17,30 @@ from app.onboard import (
     run_onboard,
 )
 
+_FIXTURE_COMMIT = "test-fixture-commit"
+_FIXTURE_INSTALLED_VERSION = "0.0.0+test-fixture-installed"
+_FIXTURE_PYPI_LATEST_VERSION = "0.0.0+test-fixture-pypi-latest"
+
 
 class OnboardTests(SimpleTestCase):
     def test_detect_install_state_marks_upgrade_when_pypi_is_newer(self) -> None:
         with (
-            patch("app.onboard.get_build_info", return_value=("1.0.0", "abc12345")),
-            patch("app.onboard.pypi_latest_version", return_value="2.0.0"),
+            patch(
+                "app.onboard.get_build_info",
+                return_value=(_FIXTURE_INSTALLED_VERSION, _FIXTURE_COMMIT),
+            ),
+            patch(
+                "app.onboard.pypi_latest_version",
+                return_value=_FIXTURE_PYPI_LATEST_VERSION,
+            ),
         ):
             state = detect_install_state(
-                read_executable_build=lambda _path: "1.0.0 (abc12345)",
+                read_executable_build=lambda _path: (
+                    f"{_FIXTURE_INSTALLED_VERSION} ({_FIXTURE_COMMIT})"
+                ),
             )
         self.assertTrue(state.upgrade_available)
-        self.assertEqual(state.pypi_latest, "2.0.0")
+        self.assertEqual(state.pypi_latest, _FIXTURE_PYPI_LATEST_VERSION)
 
     def test_format_onboarding_text_includes_install_summary(self) -> None:
         state = InstallState(


### PR DESCRIPTION
## Summary

- Pin `get_build_info` in the onboard upgrade-detection unit test so it stays valid after release-please bumps the package version.
- Use named `0.0.0+test-fixture-*` version strings so test data is unmistakably decoupled from real PyPI releases.

## Test plan

- [x] `./test_bunnify bookmarks.test_onboard.OnboardTests.test_detect_install_state_marks_upgrade_when_pypi_is_newer`
