### PR TITLE
fix: Spotty Bunny Home/End and empty-Tab browse

### DIFF
--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -46,6 +46,7 @@ from Cocoa import (
     NSParagraphStyleAttributeName,
     NSScreen,
     NSScrollView,
+    NSSelectionAffinityUpstream,
     NSStringDrawingUsesFontLeading,
     NSStringDrawingUsesLineFragmentOrigin,
     NSTableColumn,
@@ -127,6 +128,7 @@ from app.spotty_bunny_cli import SpottyBunnyEventTapError
 from app.spotty_bunny_complete import (
     CompletionRow,
     apply_completion,
+    completion_browse_all,
     completion_navigation_disposition,
     completion_row_after_selector,
     completion_still_current,
@@ -140,10 +142,10 @@ from app.spotty_bunny_complete import (
 from app.spotty_bunny_edit import (
     edit_action_for_key,
     edit_command_modifiers_ok,
-    is_line_end_selector,
     is_line_navigation_selector,
     is_line_start_selector,
     line_navigation_modifies_selection,
+    line_navigation_selected_range,
 )
 from app.spotty_bunny_history import (
     HistoryNavigator,
@@ -464,20 +466,17 @@ class SpottyBunnyController(NSObject):
         """Move or extend the caret for Home/End (and Cocoa document aliases)."""
         length = int(text_view.string().length())
         selected = text_view.selectedRange()
-        location = int(selected.location)
-        if is_line_start_selector(selector):
-            if line_navigation_modifies_selection(selector):
-                text_view.setSelectedRange_(NSMakeRange(0, location))
-            else:
-                text_view.setSelectedRange_(NSMakeRange(0, 0))
-            return
-        if is_line_end_selector(selector):
-            if line_navigation_modifies_selection(selector):
-                text_view.setSelectedRange_(
-                    NSMakeRange(location, max(0, length - location))
-                )
-            else:
-                text_view.setSelectedRange_(NSMakeRange(length, 0))
+        location, sel_length = line_navigation_selected_range(
+            text_length=length,
+            selected_location=int(selected.location),
+            selected_length=int(selected.length),
+            to_start=is_line_start_selector(selector),
+            modify=line_navigation_modifies_selection(selector),
+            affinity_upstream=(
+                int(text_view.selectionAffinity()) == int(NSSelectionAffinityUpstream)
+            ),
+        )
+        text_view.setSelectedRange_(NSMakeRange(location, sel_length))
 
     def _apply_update_status(self) -> None:
         outdated = self._update_status.outdated
@@ -815,6 +814,8 @@ class SpottyBunnyController(NSObject):
             False,
         )
         self.table.scrollRowToVisible_(idx)
+        if completion_browse_all(self._completion_prefix):
+            return
         row = self._completion_rows[idx]
         self._set_field_text(apply_completion(self._completion_prefix, row))
 

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -130,12 +130,21 @@ from app.spotty_bunny_complete import (
     completion_navigation_disposition,
     completion_row_after_selector,
     completion_still_current,
+    completion_table_should_show,
     completions_for,
     field_editor_selector_name,
     is_tab_completion_selector,
     make_spotty_completer,
+    should_auto_insert_completion,
 )
-from app.spotty_bunny_edit import edit_action_for_key, edit_command_modifiers_ok
+from app.spotty_bunny_edit import (
+    edit_action_for_key,
+    edit_command_modifiers_ok,
+    is_line_end_selector,
+    is_line_navigation_selector,
+    is_line_start_selector,
+    line_navigation_modifies_selection,
+)
 from app.spotty_bunny_history import (
     HistoryNavigator,
     append_history_line,
@@ -236,11 +245,14 @@ class SpottyBunnyController(NSObject):
             return
         self._hide_completions()
 
-    def control_textView_doCommandBySelector_(self, _control, _text_view, selector):
-        """Tab completions, history up/down, dismiss on Esc/Return."""
+    def control_textView_doCommandBySelector_(self, _control, text_view, selector):
+        """Tab completions, history up/down, Home/End, dismiss on Esc/Return."""
         name = field_editor_selector_name(selector)
         if is_tab_completion_selector(name):
             self.completeWithTab_(None)
+            return True
+        if is_line_navigation_selector(name):
+            self._apply_line_navigation(text_view, name)
             return True
         disposition = completion_navigation_disposition(
             name,
@@ -447,6 +459,25 @@ class SpottyBunnyController(NSObject):
         resigning = notification.object()
         if resigning is self.panel and self._became_key:
             self.hide()
+
+    def _apply_line_navigation(self, text_view, selector: str) -> None:
+        """Move or extend the caret for Home/End (and Cocoa document aliases)."""
+        length = int(text_view.string().length())
+        selected = text_view.selectedRange()
+        location = int(selected.location)
+        if is_line_start_selector(selector):
+            if line_navigation_modifies_selection(selector):
+                text_view.setSelectedRange_(NSMakeRange(0, location))
+            else:
+                text_view.setSelectedRange_(NSMakeRange(0, 0))
+            return
+        if is_line_end_selector(selector):
+            if line_navigation_modifies_selection(selector):
+                text_view.setSelectedRange_(
+                    NSMakeRange(location, max(0, length - location))
+                )
+            else:
+                text_view.setSelectedRange_(NSMakeRange(length, 0))
 
     def _apply_update_status(self) -> None:
         outdated = self._update_status.outdated
@@ -953,7 +984,9 @@ class SpottyBunnyController(NSObject):
         if not rows:
             self._hide_completions()
             return
-        if self.field is not None:
+        if self.field is not None and should_auto_insert_completion(
+            self._completion_prefix, rows
+        ):
             self._set_field_text(apply_completion(self._completion_prefix, rows[0]))
         if self.table is not None:
             self.table.reloadData()
@@ -962,7 +995,9 @@ class SpottyBunnyController(NSObject):
                 False,
             )
             self.table.scrollRowToVisible_(0)
-        self._set_table_visible(len(rows) > 1)
+        self._set_table_visible(
+            completion_table_should_show(self._completion_prefix, rows)
+        )
 
     def _status_attributed(self, message: str, *, color):
         """Build wrapping, centered status copy with Courier command spans."""
@@ -1047,6 +1082,20 @@ class SpottyBunnyController(NSObject):
         if self.field is None or self._resolving:
             return
         query = str(self.field.stringValue()).strip()
+        if (
+            not query
+            and self._completion_table_visible()
+            and self._completion_rows
+            and self.table is not None
+        ):
+            idx = int(self.table.selectedRow())
+            if idx < 0:
+                idx = 0
+            if idx < len(self._completion_rows):
+                query = apply_completion(
+                    self._completion_prefix, self._completion_rows[idx]
+                ).strip()
+                self._set_field_text(query)
         if not query:
             self.hide()
             return

--- a/app/spotty_bunny_complete.py
+++ b/app/spotty_bunny_complete.py
@@ -63,6 +63,11 @@ def apply_completion(current: str, row: CompletionRow) -> str:
     return current[:begin] + row.insert
 
 
+def completion_browse_all(prefix: str) -> bool:
+    """True when Tab should list every shortcut without inserting the first."""
+    return not prefix.strip()
+
+
 def completion_navigation_disposition(
     selector: str,
     *,
@@ -114,6 +119,15 @@ def completion_still_current(
 ) -> bool:
     """True when an async Tab result still matches the field that requested it."""
     return seq == expected_seq and field == prefix
+
+
+def completion_table_should_show(prefix: str, rows: list[CompletionRow]) -> bool:
+    """Whether the completion table should appear for *rows* under *prefix*."""
+    if not rows:
+        return False
+    if completion_browse_all(prefix):
+        return True
+    return len(rows) > 1
 
 
 def completions_for(text: str, completer: Completer) -> list[CompletionRow]:
@@ -192,6 +206,11 @@ def normalize_completion_navigation_selector(selector: str) -> str:
     if selector == "scrollPageDown:":
         return "pageDown:"
     return selector
+
+
+def should_auto_insert_completion(prefix: str, rows: list[CompletionRow]) -> bool:
+    """True when the first Tab candidate should replace the field text."""
+    return bool(rows) and not completion_browse_all(prefix)
 
 
 def _plain(value: object) -> str:

--- a/app/spotty_bunny_complete.py
+++ b/app/spotty_bunny_complete.py
@@ -64,8 +64,12 @@ def apply_completion(current: str, row: CompletionRow) -> str:
 
 
 def completion_browse_all(prefix: str) -> bool:
-    """True when Tab should list every shortcut without inserting the first."""
-    return not prefix.strip()
+    """True when Tab should list every shortcut without inserting the first.
+
+    Only the empty field qualifies. Whitespace-only input is handed to the
+    suggestion path (separator present), so it must not claim browse-all.
+    """
+    return prefix == ""
 
 
 def completion_navigation_disposition(

--- a/app/spotty_bunny_edit.py
+++ b/app/spotty_bunny_edit.py
@@ -87,3 +87,32 @@ def is_line_start_selector(selector: str) -> bool:
 def line_navigation_modifies_selection(selector: str) -> bool:
     """True when *selector* extends the selection (Shift+Home/End variants)."""
     return selector.endswith("AndModifySelection:")
+
+
+def line_navigation_selected_range(
+    *,
+    text_length: int,
+    selected_location: int,
+    selected_length: int,
+    to_start: bool,
+    modify: bool,
+    affinity_upstream: bool,
+) -> tuple[int, int]:
+    """Return ``(location, length)`` for a Home/End (optionally Shift) move.
+
+    Non-modify collapses the caret to the start or end of the field. Modify
+    keeps AppKit's selection anchor fixed and moves the active end: upstream
+    affinity means the anchor is at ``location + length`` (backward selection);
+    otherwise the anchor is at ``location``.
+    """
+    if not modify:
+        if to_start:
+            return (0, 0)
+        return (text_length, 0)
+    if selected_length > 0 and affinity_upstream:
+        anchor = selected_location + selected_length
+    else:
+        anchor = selected_location
+    if to_start:
+        return (0, max(0, anchor))
+    return (anchor, max(0, text_length - anchor))

--- a/app/spotty_bunny_edit.py
+++ b/app/spotty_bunny_edit.py
@@ -16,6 +16,33 @@ EDIT_COMMAND_SHIFT_ACTIONS: dict[str, str] = {
     "z": "redo:",
 }
 
+# Home/End (and document-scroll aliases) → caret begin/end of the field.
+# On macOS, dedicated Home/End keys historically map to document scroll, which
+# is a no-op in a single-line NSTextField — remap them to line begin/end.
+LINE_END_SELECTORS = frozenset(
+    {
+        "moveToEndOfDocument:",
+        "moveToEndOfDocumentAndModifySelection:",
+        "moveToEndOfLine:",
+        "moveToEndOfLineAndModifySelection:",
+        "moveToRightEndOfLine:",
+        "moveToRightEndOfLineAndModifySelection:",
+        "scrollToEndOfDocument:",
+    }
+)
+
+LINE_START_SELECTORS = frozenset(
+    {
+        "moveToBeginningOfDocument:",
+        "moveToBeginningOfDocumentAndModifySelection:",
+        "moveToBeginningOfLine:",
+        "moveToBeginningOfLineAndModifySelection:",
+        "moveToLeftEndOfLine:",
+        "moveToLeftEndOfLineAndModifySelection:",
+        "scrollToBeginningOfDocument:",
+    }
+)
+
 
 def edit_action_for_key(
     characters: str,
@@ -40,3 +67,23 @@ def edit_command_modifiers_ok(
 ) -> bool:
     """True when modifiers are a Command edit chord (Caps Lock / Fn ignored)."""
     return command and not control and not option
+
+
+def is_line_end_selector(selector: str) -> bool:
+    """True when *selector* should place the caret (or selection) at line end."""
+    return selector in LINE_END_SELECTORS
+
+
+def is_line_navigation_selector(selector: str) -> bool:
+    """True when *selector* is Home/End / line / document begin-or-end."""
+    return selector in LINE_START_SELECTORS or selector in LINE_END_SELECTORS
+
+
+def is_line_start_selector(selector: str) -> bool:
+    """True when *selector* should place the caret (or selection) at line start."""
+    return selector in LINE_START_SELECTORS
+
+
+def line_navigation_modifies_selection(selector: str) -> bool:
+    """True when *selector* extends the selection (Shift+Home/End variants)."""
+    return selector.endswith("AndModifySelection:")

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1508,6 +1508,7 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
             is_line_navigation_selector,
             is_line_start_selector,
             line_navigation_modifies_selection,
+            line_navigation_selected_range,
         )
 
         self.assertEqual(
@@ -1560,6 +1561,72 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
             )
         )
         self.assertFalse(line_navigation_modifies_selection("moveToBeginningOfLine:"))
+        self.assertEqual(
+            line_navigation_selected_range(
+                text_length=8,
+                selected_location=6,
+                selected_length=2,
+                to_start=True,
+                modify=True,
+                affinity_upstream=True,
+            ),
+            (0, 8),
+        )
+        self.assertEqual(
+            line_navigation_selected_range(
+                text_length=8,
+                selected_location=6,
+                selected_length=2,
+                to_start=False,
+                modify=True,
+                affinity_upstream=True,
+            ),
+            (8, 0),
+        )
+        self.assertEqual(
+            line_navigation_selected_range(
+                text_length=8,
+                selected_location=0,
+                selected_length=2,
+                to_start=True,
+                modify=True,
+                affinity_upstream=False,
+            ),
+            (0, 0),
+        )
+        self.assertEqual(
+            line_navigation_selected_range(
+                text_length=8,
+                selected_location=0,
+                selected_length=2,
+                to_start=False,
+                modify=True,
+                affinity_upstream=False,
+            ),
+            (0, 8),
+        )
+        self.assertEqual(
+            line_navigation_selected_range(
+                text_length=8,
+                selected_location=5,
+                selected_length=0,
+                to_start=True,
+                modify=False,
+                affinity_upstream=False,
+            ),
+            (0, 0),
+        )
+        self.assertEqual(
+            line_navigation_selected_range(
+                text_length=8,
+                selected_location=5,
+                selected_length=0,
+                to_start=False,
+                modify=False,
+                affinity_upstream=False,
+            ),
+            (8, 0),
+        )
 
     def test_empty_prefix_tab_lists_without_auto_insert(self) -> None:
         from app.spotty_bunny_complete import (

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1641,7 +1641,7 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
             CompletionRow(insert="gm", meta="Gmail", start_position=0),
         ]
         self.assertTrue(completion_browse_all(""))
-        self.assertTrue(completion_browse_all("   "))
+        self.assertFalse(completion_browse_all("   "))
         self.assertFalse(completion_browse_all("g"))
         self.assertFalse(should_auto_insert_completion("", rows))
         self.assertTrue(should_auto_insert_completion("g", rows))

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1504,6 +1504,10 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         from app.spotty_bunny_edit import (
             edit_action_for_key,
             edit_command_modifiers_ok,
+            is_line_end_selector,
+            is_line_navigation_selector,
+            is_line_start_selector,
+            line_navigation_modifies_selection,
         )
 
         self.assertEqual(
@@ -1544,6 +1548,40 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         self.assertFalse(
             edit_command_modifiers_ok(command=False, control=False, option=False)
         )
+        self.assertTrue(is_line_start_selector("scrollToBeginningOfDocument:"))
+        self.assertTrue(is_line_start_selector("moveToBeginningOfLine:"))
+        self.assertTrue(is_line_end_selector("scrollToEndOfDocument:"))
+        self.assertTrue(is_line_end_selector("moveToEndOfLine:"))
+        self.assertTrue(is_line_navigation_selector("moveToBeginningOfLine:"))
+        self.assertFalse(is_line_navigation_selector("moveUp:"))
+        self.assertTrue(
+            line_navigation_modifies_selection(
+                "moveToBeginningOfLineAndModifySelection:"
+            )
+        )
+        self.assertFalse(line_navigation_modifies_selection("moveToBeginningOfLine:"))
+
+    def test_empty_prefix_tab_lists_without_auto_insert(self) -> None:
+        from app.spotty_bunny_complete import (
+            CompletionRow,
+            completion_browse_all,
+            completion_table_should_show,
+            should_auto_insert_completion,
+        )
+
+        rows = [
+            CompletionRow(insert="gh", meta="GitHub", start_position=0),
+            CompletionRow(insert="gm", meta="Gmail", start_position=0),
+        ]
+        self.assertTrue(completion_browse_all(""))
+        self.assertTrue(completion_browse_all("   "))
+        self.assertFalse(completion_browse_all("g"))
+        self.assertFalse(should_auto_insert_completion("", rows))
+        self.assertTrue(should_auto_insert_completion("g", rows))
+        self.assertTrue(completion_table_should_show("", rows))
+        self.assertTrue(completion_table_should_show("", rows[:1]))
+        self.assertFalse(completion_table_should_show("g", rows[:1]))
+        self.assertTrue(completion_table_should_show("g", rows))
 
     def test_field_editor_selector_name_normalizes_forms(self) -> None:
         from app.spotty_bunny_complete import field_editor_selector_name


### PR DESCRIPTION
## Summary
- Remap Home/End (and Cocoa document-scroll aliases) to line begin/end in Spotty Bunny's search field (#347 follow-up bugs).
- Empty Tab lists all shortcuts without auto-inserting the first candidate; Return accepts the selected row when the field is empty.

## Test plan
- [x] Unit coverage for line-nav selectors and empty-Tab browse helpers
- [ ] Manual: Home/End move caret in the search field
- [ ] Manual: empty field + Tab shows full shortcut list; Enter inserts selected row

Depends on #351.

---
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>