### PR TITLE
fix: retry GitHub token for Spotty Bunny Tab completion

### DIFF
--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -174,10 +174,6 @@ def entries_need_github_completion(entries: Iterable[Any]) -> bool:
         complete = getattr(entry, "complete", None)
         if complete:
             return True
-        params = getattr(entry, "params", ()) or ()
-        for name in params:
-            if isinstance(name, str) and param_needs_github_auth(name, None):
-                return True
     return False
 
 
@@ -305,11 +301,14 @@ def param_needs_github_auth(
     param_name: str,
     complete: Mapping[str, ParamCompleteSpec] | None = None,
 ) -> bool:
-    """True when *param_name* is completed via the GitHub REST API."""
+    """True when *param_name* is completed via the GitHub REST API.
+
+    When a ``complete`` map is attached (including an empty one), only declared
+    specs count — generic names like ``number`` / ``repo`` alone must not light
+    up GitHub auth UX. Name heuristics apply only when *complete* is omitted.
+    """
     if complete is not None:
-        spec = complete.get(param_name)
-        if spec is not None:
-            return True
+        return complete.get(param_name) is not None
     name = param_name.lower()
     return (
         name in _REPO_PARAM_NAMES

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -168,6 +168,19 @@ def clear_github_completion_cache() -> None:
     _token_cache_expires_at = 0.0
 
 
+def entries_need_github_completion(entries: Iterable[Any]) -> bool:
+    """True when any bookmark declares GitHub-backed Tab completion."""
+    for entry in entries:
+        complete = getattr(entry, "complete", None)
+        if complete:
+            return True
+        params = getattr(entry, "params", ()) or ()
+        for name in params:
+            if isinstance(name, str) and param_needs_github_auth(name, None):
+                return True
+    return False
+
+
 def gh_install_guidance() -> str:
     """User-facing text when ``gh`` is missing and no env token is set."""
     parts = [

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -29,6 +29,7 @@ _DEFAULT_TIMEOUT_SECONDS = 8.0
 _GH_BREW_INSTALL_TIMEOUT_SECONDS = 600.0
 _GH_TOKEN_TIMEOUT_SECONDS = 8.0
 _GH_LOGIN_TIMEOUT_SECONDS = 600.0
+_NEGATIVE_TOKEN_TTL_SECONDS = 60.0
 _PERSIST_VERSION = 1
 _REPO_PARAM_NAMES = frozenset({"org_repo", "repo", "repository"})
 _PR_PARAM_NAMES = frozenset(
@@ -37,11 +38,16 @@ _PR_PARAM_NAMES = frozenset(
 _ISSUE_PARAM_NAMES = frozenset({"issue", "issue_id", "issue_num", "issue_number"})
 _API_ROOT = "https://api.github.com"
 _UNSET = object()
+_WARN_THROTTLE_SECONDS = 60.0
+
+GITHUB_AUTH_NEEDED_MESSAGE = "GitHub auth needed — run: gh auth login"
 
 _cache: dict[str, tuple[float, list[str]]] = {}
 _cache_lock = threading.RLock()
 _token_cache: Any = _UNSET
+_token_cache_expires_at: float = 0.0
 _refresh_thread: threading.Thread | None = None
+_warn_throttle: dict[str, float] = {}
 
 _GITHUB_ORG_REPO = re.compile(
     r"(?:github\.com|graphite\.com/github/pr)/([^/#{}]+)/#\{repo\}",
@@ -79,6 +85,17 @@ def _cache_get(key: str) -> list[str] | None:
 def _cache_set(key: str, values: list[str]) -> None:
     with _cache_lock:
         _cache[key] = (time.monotonic() + _CACHE_TTL_SECONDS, list(values))
+
+
+def _warn_throttled(key: str, message: str, *args: object) -> None:
+    """Emit ``logger.warning`` at most once per key within the throttle window."""
+    now = time.monotonic()
+    with _cache_lock:
+        expires_at = _warn_throttle.get(key)
+        if expires_at is not None and now < expires_at:
+            return
+        _warn_throttle[key] = now + _WARN_THROTTLE_SECONDS
+    logger.warning(message, *args)
 
 
 _NAME_SPLIT = re.compile(r"[/_\-.]+")
@@ -143,10 +160,12 @@ def can_offer_gh_install() -> bool:
 
 def clear_github_completion_cache() -> None:
     """Test helper: drop in-process completion + token caches."""
-    global _token_cache
+    global _token_cache, _token_cache_expires_at
     with _cache_lock:
         _cache.clear()
+        _warn_throttle.clear()
     _token_cache = _UNSET
+    _token_cache_expires_at = 0.0
 
 
 def gh_install_guidance() -> str:
@@ -245,6 +264,18 @@ def save_github_completion_cache(
     return cache_path
 
 
+def github_completion_unavailable_message(
+    *,
+    environ: dict[str, str] | None = None,
+) -> str:
+    """User-facing text when GitHub Tab completion cannot authenticate."""
+    if github_token_from_environ(environ):
+        return GITHUB_AUTH_NEEDED_MESSAGE
+    if not gh_is_available():
+        return gh_install_guidance()
+    return GITHUB_AUTH_NEEDED_MESSAGE
+
+
 def github_token_from_environ(
     environ: dict[str, str] | None = None,
 ) -> str | None:
@@ -255,6 +286,23 @@ def github_token_from_environ(
         if value:
             return value
     return None
+
+
+def param_needs_github_auth(
+    param_name: str,
+    complete: Mapping[str, ParamCompleteSpec] | None = None,
+) -> bool:
+    """True when *param_name* is completed via the GitHub REST API."""
+    if complete is not None:
+        spec = complete.get(param_name)
+        if spec is not None:
+            return True
+    name = param_name.lower()
+    return (
+        name in _REPO_PARAM_NAMES
+        or name in _PR_PARAM_NAMES
+        or name in _ISSUE_PARAM_NAMES
+    )
 
 
 def _run_gh(
@@ -290,10 +338,21 @@ def github_token_from_gh(
             capture_output=True,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
+        _warn_throttled(
+            "gh-auth-token-exc",
+            "gh auth token failed: %s",
+            exc,
+        )
         logger.debug("gh auth token failed: %s", exc, exc_info=True)
         return None
     if completed.returncode != 0:
         stderr = (completed.stderr or "").strip()
+        _warn_throttled(
+            "gh-auth-token-exit",
+            "gh auth token exited %s%s",
+            completed.returncode,
+            f": {stderr}" if stderr else "",
+        )
         logger.debug("gh auth token exited %s: %s", completed.returncode, stderr)
         return None
     token = (completed.stdout or "").strip()
@@ -352,21 +411,41 @@ def resolve_github_token(
     environ: dict[str, str] | None = None,
     runner: GhRunner | None = None,
     use_cache: bool = True,
+    monotonic: Callable[[], float] | None = None,
+    negative_ttl_seconds: float = _NEGATIVE_TOKEN_TTL_SECONDS,
 ) -> str | None:
     """
     Resolve a GitHub token for completion API calls.
 
     Precedence: ``GITHUB_TOKEN`` / ``GH_TOKEN`` → ``gh auth token``.
+
+    Successful tokens are cached for the process lifetime. A missing token is
+    cached only for ``negative_ttl_seconds`` so a later ``gh auth login`` is
+    picked up without restarting the process.
     """
-    global _token_cache
+    global _token_cache, _token_cache_expires_at
     env_token = github_token_from_environ(environ)
     if env_token:
         return env_token
+    now = (monotonic or time.monotonic)()
     if use_cache and _token_cache is not _UNSET:
-        return _token_cache if isinstance(_token_cache, str) else None
+        if isinstance(_token_cache, str):
+            return _token_cache
+        if now < _token_cache_expires_at:
+            return None
     token = github_token_from_gh(runner=runner)
     if use_cache:
-        _token_cache = token
+        if token:
+            _token_cache = token
+            _token_cache_expires_at = 0.0
+        else:
+            _token_cache = None
+            _token_cache_expires_at = now + negative_ttl_seconds
+            _warn_throttled(
+                "github-token-missing",
+                "GitHub Tab completion has no token — set GITHUB_TOKEN / "
+                "GH_TOKEN or run: gh auth login",
+            )
     return token
 
 
@@ -387,7 +466,7 @@ def ensure_github_authenticated(
       offer ``brew install gh`` (via ``confirm_install``).
     - Then launch the browser-oriented ``gh auth login`` flow.
     """
-    global _token_cache
+    global _token_cache, _token_cache_expires_at
     token = resolve_github_token(environ=environ, runner=runner)
     if token:
         return token
@@ -429,6 +508,7 @@ def ensure_github_authenticated(
         logger.debug("gh auth login exited %s", completed.returncode)
         return None
     _token_cache = _UNSET
+    _token_cache_expires_at = 0.0
     return resolve_github_token(environ=environ, runner=runner, use_cache=True)
 
 
@@ -487,6 +567,13 @@ def _github_get_json(
         json.JSONDecodeError,
         OSError,
     ) as exc:
+        status = getattr(exc, "code", None)
+        _warn_throttled(
+            f"github-get:{path}:{status}",
+            "GitHub REST GET %s failed: %s",
+            path,
+            exc,
+        )
         logger.debug("GitHub REST GET %s failed: %s", path, exc, exc_info=True)
         return None
 
@@ -526,6 +613,12 @@ def _github_get_owner_repos_json(
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             return None, True
+        _warn_throttled(
+            f"github-owner-repos:{path}:{exc.code}",
+            "GitHub REST GET %s failed: %s",
+            path,
+            exc,
+        )
         logger.debug("GitHub REST GET %s failed: %s", path, exc, exc_info=True)
         return None, False
     except (
@@ -534,6 +627,12 @@ def _github_get_owner_repos_json(
         json.JSONDecodeError,
         OSError,
     ) as exc:
+        _warn_throttled(
+            f"github-owner-repos:{path}",
+            "GitHub REST GET %s failed: %s",
+            path,
+            exc,
+        )
         logger.debug("GitHub REST GET %s failed: %s", path, exc, exc_info=True)
         return None, False
 

--- a/app/github_complete.py
+++ b/app/github_complete.py
@@ -528,6 +528,11 @@ def user_is_admin() -> bool:
         return False
 
 
+def warn_github_completion(key: str, message: str, *args: object) -> None:
+    """Emit a throttled WARNING for GitHub completion UX (no token material)."""
+    _warn_throttled(key, message, *args)
+
+
 def _github_get_json(
     path: str,
     *,

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -114,6 +114,7 @@ from app.github_complete import (
     github_token_from_environ,
     install_gh_via_homebrew,
     resolve_github_token,
+    warn_github_completion,
 )
 from app.spotty_bunny_about import (
     apply_spotty_chrome,
@@ -142,6 +143,7 @@ from app.spotty_bunny_complete import (
     is_tab_completion_selector,
     make_spotty_completer,
     should_auto_insert_completion,
+    surface_blocked_github_completion,
 )
 from app.spotty_bunny_edit import (
     edit_action_for_key,
@@ -793,7 +795,8 @@ class SpottyBunnyController(NSObject):
                 token=token,
             )
         else:
-            logger.warning(
+            warn_github_completion(
+                "github-startup-unavailable",
                 "GitHub Tab completion unavailable at startup: %s",
                 github_completion_unavailable_message(),
             )
@@ -1018,13 +1021,11 @@ class SpottyBunnyController(NSObject):
         if not rows:
             prefix = self._completion_prefix
             self._hide_completions()
-            if blocked_message is not None:
-                logger.warning(
-                    "GitHub Tab completion blocked for %r: %s",
-                    prefix,
-                    blocked_message,
-                )
-                self._set_status(blocked_message)
+            surface_blocked_github_completion(
+                prefix,
+                blocked_message,
+                set_status=self._set_status,
+            )
             return
         self._set_status("")
         if self.field is not None and should_auto_insert_completion(

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -108,6 +108,7 @@ from app.config import resolve_base_url
 from app.github_complete import (
     bootstrap_github_completion_cache,
     can_offer_gh_install,
+    entries_need_github_completion,
     gh_install_guidance,
     gh_is_available,
     github_completion_unavailable_message,
@@ -414,7 +415,6 @@ class SpottyBunnyController(NSObject):
             self.panel.makeFirstResponder_(self.field)
             self._paint_search_editor()
         self._io.submit(self._load_completer, self._completer_loaded)
-        self._maybe_offer_gh_install()
         if cache_is_stale(self._update_status.checked_at):
             self._schedule_update_check()
 
@@ -681,6 +681,7 @@ class SpottyBunnyController(NSObject):
             self._shortcuts_load_failed = False
             self._set_status("")
             logger.info("shortcut completer ready")
+            self._maybe_offer_gh_install()
 
         _run_on_main(apply)
 
@@ -788,18 +789,19 @@ class SpottyBunnyController(NSObject):
     def _load_completer(self) -> object:
         base_url = resolve_base_url(persist=False, allow_prompt=False)
         entries = fetch_key_entries(base_url=base_url)
-        token = resolve_github_token()
-        if token:
-            bootstrap_github_completion_cache(
-                url_templates=[entry.url for entry in entries],
-                token=token,
-            )
-        else:
-            warn_github_completion(
-                "github-startup-unavailable",
-                "GitHub Tab completion unavailable at startup: %s",
-                github_completion_unavailable_message(),
-            )
+        if entries_need_github_completion(entries):
+            token = resolve_github_token()
+            if token:
+                bootstrap_github_completion_cache(
+                    url_templates=[entry.url for entry in entries],
+                    token=token,
+                )
+            else:
+                warn_github_completion(
+                    "github-startup-unavailable",
+                    "GitHub Tab completion unavailable at startup: %s",
+                    github_completion_unavailable_message(),
+                )
         completer = make_spotty_completer(
             entries=entries,
             suggestions_fn=lambda query: fetch_suggestions(query, base_url=base_url),
@@ -808,6 +810,8 @@ class SpottyBunnyController(NSObject):
 
     def _maybe_offer_gh_install(self) -> None:
         """Surface missing ``gh``; admins with Homebrew may install in-place."""
+        if not entries_need_github_completion(self._entries):
+            return
         if github_token_from_environ() or gh_is_available():
             return
         guidance = gh_install_guidance()

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -106,11 +106,14 @@ from app.cli import open_url
 from app.client import fetch_key_entries, fetch_suggestions
 from app.config import resolve_base_url
 from app.github_complete import (
+    bootstrap_github_completion_cache,
     can_offer_gh_install,
     gh_install_guidance,
     gh_is_available,
+    github_completion_unavailable_message,
     github_token_from_environ,
     install_gh_via_homebrew,
+    resolve_github_token,
 )
 from app.spotty_bunny_about import (
     apply_spotty_chrome,
@@ -135,6 +138,7 @@ from app.spotty_bunny_complete import (
     completion_table_should_show,
     completions_for,
     field_editor_selector_name,
+    github_param_completion_blocked_message,
     is_tab_completion_selector,
     make_spotty_completer,
     should_auto_insert_completion,
@@ -334,6 +338,7 @@ class SpottyBunnyController(NSObject):
         self._completion_prefix = ""
         self._completion_rows: list[CompletionRow] = []
         self._completion_seq = 0
+        self._entries: list = []
         self._escape_held = False
         self._history = HistoryNavigator()
         self._io = ThreadIo()
@@ -667,9 +672,10 @@ class SpottyBunnyController(NSObject):
                 self._shortcuts_load_failed = True
                 self._set_status(format_spotty_bunny_status(result))
                 return
-            completer, base_url = result  # type: ignore[misc]
+            completer, base_url, entries = result  # type: ignore[misc]
             self._completer = completer
             self._base_url = base_url
+            self._entries = entries
             self._shortcuts_load_failed = False
             self._set_status("")
             logger.info("shortcut completer ready")
@@ -779,11 +785,22 @@ class SpottyBunnyController(NSObject):
     def _load_completer(self) -> object:
         base_url = resolve_base_url(persist=False, allow_prompt=False)
         entries = fetch_key_entries(base_url=base_url)
+        token = resolve_github_token()
+        if token:
+            bootstrap_github_completion_cache(
+                url_templates=[entry.url for entry in entries],
+                token=token,
+            )
+        else:
+            logger.warning(
+                "GitHub Tab completion unavailable at startup: %s",
+                github_completion_unavailable_message(),
+            )
         completer = make_spotty_completer(
             entries=entries,
             suggestions_fn=lambda query: fetch_suggestions(query, base_url=base_url),
         )
-        return completer, base_url
+        return completer, base_url, entries
 
     def _maybe_offer_gh_install(self) -> None:
         """Surface missing ``gh``; admins with Homebrew may install in-place."""
@@ -984,7 +1001,19 @@ class SpottyBunnyController(NSObject):
         self._completion_rows = rows
         if not rows:
             self._hide_completions()
+            message = github_param_completion_blocked_message(
+                self._completion_prefix,
+                self._entries,
+            )
+            if message is not None:
+                logger.warning(
+                    "GitHub Tab completion blocked for %r: %s",
+                    self._completion_prefix,
+                    message,
+                )
+                self._set_status(message)
             return
+        self._set_status("")
         if self.field is not None and should_auto_insert_completion(
             self._completion_prefix, rows
         ):

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -700,7 +700,8 @@ class SpottyBunnyController(NSObject):
             if isinstance(result, Exception):
                 logger.warning("completion failed: %s", result)
                 return
-            self._show_completions(result)  # type: ignore[arg-type]
+            rows, blocked_message = result  # type: ignore[misc]
+            self._show_completions(rows, blocked_message=blocked_message)
 
         _run_on_main(apply)
 
@@ -910,8 +911,18 @@ class SpottyBunnyController(NSObject):
         self._completion_seq += 1
         seq = self._completion_seq
         completer = self._completer
+        entries = list(self._entries)
+
+        def fetch() -> object:
+            rows = completions_for(text, completer)
+            blocked: str | None = None
+            if not rows:
+                # Resolve token off the AppKit thread (gh auth token / keychain).
+                blocked = github_param_completion_blocked_message(text, entries)
+            return rows, blocked
+
         self._io.submit(
-            lambda: completions_for(text, completer),
+            fetch,
             lambda result: self._completions_ready(result, seq=seq),
         )
 
@@ -997,22 +1008,23 @@ class SpottyBunnyController(NSObject):
         self._update_check_pending = True
         self._io.submit(refresh_update_status, self._update_check_ready)
 
-    def _show_completions(self, rows: list[CompletionRow]) -> None:
+    def _show_completions(
+        self,
+        rows: list[CompletionRow],
+        *,
+        blocked_message: str | None = None,
+    ) -> None:
         self._completion_rows = rows
         if not rows:
             prefix = self._completion_prefix
             self._hide_completions()
-            message = github_param_completion_blocked_message(
-                prefix,
-                self._entries,
-            )
-            if message is not None:
+            if blocked_message is not None:
                 logger.warning(
                     "GitHub Tab completion blocked for %r: %s",
                     prefix,
-                    message,
+                    blocked_message,
                 )
-                self._set_status(message)
+                self._set_status(blocked_message)
             return
         self._set_status("")
         if self.field is not None and should_auto_insert_completion(

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -1000,15 +1000,16 @@ class SpottyBunnyController(NSObject):
     def _show_completions(self, rows: list[CompletionRow]) -> None:
         self._completion_rows = rows
         if not rows:
+            prefix = self._completion_prefix
             self._hide_completions()
             message = github_param_completion_blocked_message(
-                self._completion_prefix,
+                prefix,
                 self._entries,
             )
             if message is not None:
                 logger.warning(
                     "GitHub Tab completion blocked for %r: %s",
-                    self._completion_prefix,
+                    prefix,
                     message,
                 )
                 self._set_status(message)

--- a/app/spotty_bunny_complete.py
+++ b/app/spotty_bunny_complete.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 
 from prompt_toolkit.completion import CompleteEvent, Completer
@@ -10,7 +10,18 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.formatted_text import to_formatted_text, to_plain_text
 
 from app.client import KeyEntry
-from app.interactive import FirstTokenFuzzyCompleter, ShortcutCompleter
+from app.completion_spec import ParamCompleteSpec
+from app.github_complete import (
+    GhRunner,
+    github_completion_unavailable_message,
+    param_needs_github_auth,
+    resolve_github_token,
+)
+from app.interactive import (
+    FirstTokenFuzzyCompleter,
+    ShortcutCompleter,
+    completion_token_state,
+)
 from app.theme import Theme
 
 
@@ -169,6 +180,30 @@ def field_editor_selector_name(selector: object) -> str:
     return text
 
 
+def github_param_completion_blocked_message(
+    text: str,
+    entries: Sequence[KeyEntry] | Mapping[str, KeyEntry],
+    *,
+    environ: dict[str, str] | None = None,
+    runner: GhRunner | None = None,
+) -> str | None:
+    """
+    Return status text when *text* is on a GitHub param and auth is missing.
+
+    ``None`` when the field is not a GitHub-backed param slot, or a token is
+    available (including after negative-cache TTL expiry / re-probe).
+    """
+    entry, param_name = _github_param_slot(text, entries)
+    if entry is None or param_name is None:
+        return None
+    complete: Mapping[str, ParamCompleteSpec] | None = entry.complete
+    if not param_needs_github_auth(param_name, complete):
+        return None
+    if resolve_github_token(environ=environ, runner=runner):
+        return None
+    return github_completion_unavailable_message(environ=environ)
+
+
 def is_completion_navigation_selector(selector: object) -> bool:
     """True when *selector* should move the Tab completion selection."""
     return field_editor_selector_name(selector) in COMPLETION_NAVIGATION_SELECTORS
@@ -215,6 +250,36 @@ def normalize_completion_navigation_selector(selector: str) -> str:
 def should_auto_insert_completion(prefix: str, rows: list[CompletionRow]) -> bool:
     """True when the first Tab candidate should replace the field text."""
     return bool(rows) and not completion_browse_all(prefix)
+
+
+def _github_param_slot(
+    text: str,
+    entries: Sequence[KeyEntry] | Mapping[str, KeyEntry],
+) -> tuple[KeyEntry | None, str | None]:
+    """Return ``(entry, param_name)`` for the active Tab param slot, if any."""
+    stripped = text.strip()
+    if not stripped:
+        return None, None
+    by_key: Mapping[str, KeyEntry]
+    if isinstance(entries, Mapping):
+        by_key = entries
+    else:
+        by_key = {entry.key: entry for entry in entries}
+    insert_key_prefix = not any(ch.isspace() for ch in text)
+    effective = f"{text.rstrip()} " if insert_key_prefix else text
+    key, _filled_args, _prefix, arg_index = completion_token_state(effective)
+    entry = by_key.get(key)
+    if entry is None:
+        lowered = key.lower()
+        for candidate_key, candidate in by_key.items():
+            if candidate_key.lower() == lowered:
+                entry = candidate
+                break
+    if entry is None or not entry.params:
+        return None, None
+    if arg_index < 0 or arg_index >= len(entry.params):
+        return None, None
+    return entry, entry.params[arg_index]
 
 
 def _plain(value: object) -> str:

--- a/app/spotty_bunny_complete.py
+++ b/app/spotty_bunny_complete.py
@@ -16,6 +16,7 @@ from app.github_complete import (
     github_completion_unavailable_message,
     param_needs_github_auth,
     resolve_github_token,
+    warn_github_completion,
 )
 from app.interactive import (
     FirstTokenFuzzyCompleter,
@@ -250,6 +251,25 @@ def normalize_completion_navigation_selector(selector: str) -> str:
 def should_auto_insert_completion(prefix: str, rows: list[CompletionRow]) -> bool:
     """True when the first Tab candidate should replace the field text."""
     return bool(rows) and not completion_browse_all(prefix)
+
+
+def surface_blocked_github_completion(
+    prefix: str,
+    blocked_message: str | None,
+    *,
+    set_status: Callable[[str], None],
+) -> bool:
+    """Log (throttled) and set status when Tab was blocked by missing GitHub auth."""
+    if blocked_message is None:
+        return False
+    warn_github_completion(
+        "github-tab-blocked",
+        "GitHub Tab completion blocked for %r: %s",
+        prefix,
+        blocked_message,
+    )
+    set_status(blocked_message)
+    return True
 
 
 def _github_param_slot(

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -3514,6 +3514,38 @@ class KeyUsageAndCompletionTests(TestCase):
         self.assertIn("gh auth login", joined)
         clear_github_completion_cache()
 
+    def test_entries_need_github_completion_detects_specs_and_heuristics(
+        self,
+    ) -> None:
+        from types import SimpleNamespace
+
+        from app.completion_spec import ParamCompleteSpec
+        from app.github_complete import entries_need_github_completion
+
+        self.assertFalse(entries_need_github_completion([]))
+        self.assertFalse(
+            entries_need_github_completion(
+                [SimpleNamespace(params=("query",), complete={})]
+            )
+        )
+        self.assertTrue(
+            entries_need_github_completion(
+                [SimpleNamespace(params=("repo",), complete={})]
+            )
+        )
+        self.assertTrue(
+            entries_need_github_completion(
+                [
+                    SimpleNamespace(
+                        params=("name",),
+                        complete={
+                            "name": ParamCompleteSpec(kind="github_repo", org="o"),
+                        },
+                    )
+                ]
+            )
+        )
+
     def test_ensure_github_authenticated_offers_brew_install_when_admin(
         self,
     ) -> None:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -3520,7 +3520,10 @@ class KeyUsageAndCompletionTests(TestCase):
         from types import SimpleNamespace
 
         from app.completion_spec import ParamCompleteSpec
-        from app.github_complete import entries_need_github_completion
+        from app.github_complete import (
+            entries_need_github_completion,
+            param_needs_github_auth,
+        )
 
         self.assertFalse(entries_need_github_completion([]))
         self.assertFalse(
@@ -3528,11 +3531,14 @@ class KeyUsageAndCompletionTests(TestCase):
                 [SimpleNamespace(params=("query",), complete={})]
             )
         )
-        self.assertTrue(
+        # Param-name heuristics alone must not drive GitHub auth UX.
+        self.assertFalse(
             entries_need_github_completion(
-                [SimpleNamespace(params=("repo",), complete={})]
+                [SimpleNamespace(params=("number",), complete={})]
             )
         )
+        self.assertFalse(param_needs_github_auth("number", {}))
+        self.assertTrue(param_needs_github_auth("number", None))
         self.assertTrue(
             entries_need_github_completion(
                 [
@@ -3543,6 +3549,12 @@ class KeyUsageAndCompletionTests(TestCase):
                         },
                     )
                 ]
+            )
+        )
+        self.assertTrue(
+            param_needs_github_auth(
+                "name",
+                {"name": ParamCompleteSpec(kind="github_repo", org="o")},
             )
         )
 

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -3436,6 +3436,84 @@ class KeyUsageAndCompletionTests(TestCase):
         )
         self.assertEqual(token, "gh-token")
 
+    def test_resolve_github_token_retries_after_negative_ttl(self) -> None:
+        import subprocess
+
+        from app.github_complete import (
+            clear_github_completion_cache,
+            resolve_github_token,
+        )
+
+        clear_github_completion_cache()
+        calls = {"n": 0}
+        clock = {"t": 100.0}
+
+        def gh_runner(*, args, **_kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return subprocess.CompletedProcess(
+                    args=list(args), returncode=1, stdout="", stderr="not logged in"
+                )
+            return subprocess.CompletedProcess(
+                args=list(args), returncode=0, stdout="fresh-token\n", stderr=""
+            )
+
+        first = resolve_github_token(
+            environ={"PATH": "/usr/bin"},
+            runner=gh_runner,
+            monotonic=lambda: clock["t"],
+            negative_ttl_seconds=30.0,
+        )
+        self.assertIsNone(first)
+        self.assertEqual(calls["n"], 1)
+
+        cached = resolve_github_token(
+            environ={"PATH": "/usr/bin"},
+            runner=gh_runner,
+            monotonic=lambda: clock["t"] + 10.0,
+            negative_ttl_seconds=30.0,
+        )
+        self.assertIsNone(cached)
+        self.assertEqual(calls["n"], 1)
+
+        clock["t"] += 31.0
+        second = resolve_github_token(
+            environ={"PATH": "/usr/bin"},
+            runner=gh_runner,
+            monotonic=lambda: clock["t"],
+            negative_ttl_seconds=30.0,
+        )
+        self.assertEqual(second, "fresh-token")
+        self.assertEqual(calls["n"], 2)
+        clear_github_completion_cache()
+
+    def test_resolve_github_token_logs_warning_on_miss(self) -> None:
+        import logging
+        import subprocess
+
+        from app.github_complete import (
+            clear_github_completion_cache,
+            resolve_github_token,
+        )
+
+        clear_github_completion_cache()
+
+        def gh_runner(*, args, **_kwargs):
+            return subprocess.CompletedProcess(
+                args=list(args), returncode=1, stdout="", stderr=""
+            )
+
+        with self.assertLogs("app.github_complete", level=logging.WARNING) as logged:
+            token = resolve_github_token(
+                environ={"PATH": "/usr/bin"},
+                runner=gh_runner,
+            )
+        self.assertIsNone(token)
+        joined = "\n".join(logged.output)
+        self.assertIn("no token", joined.lower())
+        self.assertIn("gh auth login", joined)
+        clear_github_completion_cache()
+
     def test_ensure_github_authenticated_offers_brew_install_when_admin(
         self,
     ) -> None:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1430,6 +1430,7 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
     ) -> None:
         import logging
         import subprocess
+        from unittest.mock import patch
 
         from app.client import KeyEntry
         from app.completion_spec import ParamCompleteSpec
@@ -1457,7 +1458,10 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
                 args=list(args), returncode=1, stdout="", stderr=""
             )
 
-        with self.assertLogs("app.github_complete", level=logging.WARNING):
+        with (
+            patch("app.github_complete.gh_is_available", return_value=True),
+            self.assertLogs("app.github_complete", level=logging.WARNING),
+        ):
             message = github_param_completion_blocked_message(
                 "prh dom",
                 entries,
@@ -1511,17 +1515,16 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
         ).read_text(encoding="utf-8")
-        marker = "def _show_completions(self, rows: list[CompletionRow]) -> None:"
+        marker = "def _show_completions("
         start = source.index(marker)
-        chunk = source[start : start + 900]
+        chunk = source[start : start + 1100]
         prefix_idx = chunk.index("prefix = self._completion_prefix")
         hide_idx = chunk.index("self._hide_completions()")
-        blocked_idx = chunk.index("github_param_completion_blocked_message(")
         self.assertLess(prefix_idx, hide_idx)
-        self.assertLess(hide_idx, blocked_idx)
+        self.assertIn("blocked_message is not None", chunk)
         self.assertIn(
-            "github_param_completion_blocked_message(\n                prefix,",
-            chunk,
+            "github_param_completion_blocked_message(text, entries)",
+            source,
         )
 
     def test_completion_still_current_requires_matching_seq_and_field(self) -> None:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1521,11 +1521,58 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         prefix_idx = chunk.index("prefix = self._completion_prefix")
         hide_idx = chunk.index("self._hide_completions()")
         self.assertLess(prefix_idx, hide_idx)
-        self.assertIn("blocked_message is not None", chunk)
+        self.assertIn("surface_blocked_github_completion(", chunk)
         self.assertIn(
             "github_param_completion_blocked_message(text, entries)",
             source,
         )
+
+    def test_surface_blocked_github_completion_sets_status_and_warns(self) -> None:
+        import logging
+
+        from app.github_complete import (
+            GITHUB_AUTH_NEEDED_MESSAGE,
+            clear_github_completion_cache,
+        )
+        from app.spotty_bunny_complete import surface_blocked_github_completion
+
+        clear_github_completion_cache()
+        statuses: list[str] = []
+        with self.assertLogs("app.github_complete", level=logging.WARNING) as logged:
+            surfaced = surface_blocked_github_completion(
+                "prh dom",
+                GITHUB_AUTH_NEEDED_MESSAGE,
+                set_status=statuses.append,
+            )
+        self.assertTrue(surfaced)
+        self.assertEqual(statuses, [GITHUB_AUTH_NEEDED_MESSAGE])
+        self.assertTrue(any("blocked" in line.lower() for line in logged.output))
+        # Second call within throttle window should not add another WARNING.
+        with self.assertRaises(AssertionError):
+            with self.assertLogs("app.github_complete", level=logging.WARNING):
+                surface_blocked_github_completion(
+                    "prh bun",
+                    GITHUB_AUTH_NEEDED_MESSAGE,
+                    set_status=statuses.append,
+                )
+        self.assertEqual(
+            statuses,
+            [GITHUB_AUTH_NEEDED_MESSAGE, GITHUB_AUTH_NEEDED_MESSAGE],
+        )
+        clear_github_completion_cache()
+
+    def test_surface_blocked_github_completion_noop_without_message(self) -> None:
+        from app.spotty_bunny_complete import surface_blocked_github_completion
+
+        statuses: list[str] = []
+        self.assertFalse(
+            surface_blocked_github_completion(
+                "prh dom",
+                None,
+                set_status=statuses.append,
+            )
+        )
+        self.assertEqual(statuses, [])
 
     def test_completion_still_current_requires_matching_seq_and_field(self) -> None:
         from app.spotty_bunny_complete import completion_still_current

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1425,6 +1425,85 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         row = CompletionRow(insert="gh", meta="GitHub", start_position=-1)
         self.assertEqual(apply_completion("g", row), "gh")
 
+    def test_github_param_completion_blocked_message_when_unauthenticated(
+        self,
+    ) -> None:
+        import logging
+        import subprocess
+
+        from app.client import KeyEntry
+        from app.completion_spec import ParamCompleteSpec
+        from app.github_complete import (
+            GITHUB_AUTH_NEEDED_MESSAGE,
+            clear_github_completion_cache,
+        )
+        from app.spotty_bunny_complete import github_param_completion_blocked_message
+
+        clear_github_completion_cache()
+        entries = [
+            KeyEntry(
+                key="prh",
+                description="pulls",
+                url="https://github.com/the-hcma/#{repo}/pulls",
+                params=("repo",),
+                complete={
+                    "repo": ParamCompleteSpec(kind="github_repo", org="the-hcma"),
+                },
+            )
+        ]
+
+        def gh_runner(*, args, **_kwargs):
+            return subprocess.CompletedProcess(
+                args=list(args), returncode=1, stdout="", stderr=""
+            )
+
+        with self.assertLogs("app.github_complete", level=logging.WARNING):
+            message = github_param_completion_blocked_message(
+                "prh dom",
+                entries,
+                environ={"PATH": "/usr/bin"},
+                runner=gh_runner,
+            )
+        self.assertEqual(message, GITHUB_AUTH_NEEDED_MESSAGE)
+        clear_github_completion_cache()
+
+    def test_github_param_completion_blocked_message_none_when_authed(
+        self,
+    ) -> None:
+        import subprocess
+
+        from app.client import KeyEntry
+        from app.completion_spec import ParamCompleteSpec
+        from app.github_complete import clear_github_completion_cache
+        from app.spotty_bunny_complete import github_param_completion_blocked_message
+
+        clear_github_completion_cache()
+        entries = [
+            KeyEntry(
+                key="prh",
+                description="pulls",
+                url="https://github.com/the-hcma/#{repo}/pulls",
+                params=("repo",),
+                complete={
+                    "repo": ParamCompleteSpec(kind="github_repo", org="the-hcma"),
+                },
+            )
+        ]
+
+        def gh_runner(*, args, **_kwargs):
+            return subprocess.CompletedProcess(
+                args=list(args), returncode=0, stdout="tok\n", stderr=""
+            )
+
+        message = github_param_completion_blocked_message(
+            "prh dom",
+            entries,
+            environ={"PATH": "/usr/bin"},
+            runner=gh_runner,
+        )
+        self.assertIsNone(message)
+        clear_github_completion_cache()
+
     def test_completion_still_current_requires_matching_seq_and_field(self) -> None:
         from app.spotty_bunny_complete import completion_still_current
 

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1504,6 +1504,26 @@ class SpottyBunnyCompleteTests(SimpleTestCase):
         self.assertIsNone(message)
         clear_github_completion_cache()
 
+    def test_show_completions_captures_prefix_before_hide(self) -> None:
+        """Regression: hide clears _completion_prefix; blocked message needs a copy."""
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_app.py"
+        ).read_text(encoding="utf-8")
+        marker = "def _show_completions(self, rows: list[CompletionRow]) -> None:"
+        start = source.index(marker)
+        chunk = source[start : start + 900]
+        prefix_idx = chunk.index("prefix = self._completion_prefix")
+        hide_idx = chunk.index("self._hide_completions()")
+        blocked_idx = chunk.index("github_param_completion_blocked_message(")
+        self.assertLess(prefix_idx, hide_idx)
+        self.assertLess(hide_idx, blocked_idx)
+        self.assertIn(
+            "github_param_completion_blocked_message(\n                prefix,",
+            chunk,
+        )
+
     def test_completion_still_current_requires_matching_seq_and_field(self) -> None:
         from app.spotty_bunny_complete import completion_still_current
 


### PR DESCRIPTION
## Summary
- Expire negative `gh auth token` cache (~60s TTL) so Spotty Bunny picks up a later `gh auth login` without restart
- Surface missing GitHub auth in the search status line when Tab hits a GitHub-backed param
- Log auth/API completion failures at WARNING (throttled, no token material) and bootstrap the completion cache on panel show
- Closes #356

## Test plan
- [x] `uv run ruff check .` / `ruff format --check .` / `pyright --warnings`
- [x] `./test_bunnify` (includes new negative-TTL and blocked-message tests)
- [x] `./test_integration`
- [ ] After install/restart: with no auth, Tab on `prh ` shows status + WARNING in `spotty-bunny.log`
- [ ] `gh auth login`, wait ≤60s (or Tab again after TTL), completions work without agent restart