### PR TITLE
chore: sync cve-check.yml to hardened canonical template

### DIFF
--- a/.github/workflows/cve-check.yml
+++ b/.github/workflows/cve-check.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "latest"
 
@@ -95,10 +95,11 @@ jobs:
           close_resolved_cve_issues() {
             local numbers
 
+            # Fail loud on gh list errors — do not treat API failures as "no issues".
             numbers="$(gh issue list --repo "${REPOSITORY}" \
               --label security/cve --state open \
               --search "in:title ${issue_title}" \
-              --json number --jq '.[].number' || true)"
+              --json number --jq '.[].number')" || return 1
             if [[ -z "$numbers" ]]; then
               return 0
             fi
@@ -115,10 +116,11 @@ jobs:
 
             ensure_cve_label
             body="$(format_cve_issue_body "$audit_json")"
+            # Fail loud on gh list errors — empty only means no match when list succeeds.
             existing_number="$(gh issue list --repo "${REPOSITORY}" \
               --label security/cve --state open \
               --search "in:title ${issue_title}" \
-              --json number --jq '.[0].number // empty' || true)"
+              --json number --jq '.[0].number // empty')" || return 1
             if [[ -n "$existing_number" ]]; then
               if ! gh issue comment "${existing_number}" --repo "${REPOSITORY}" --body "$body"; then
                 echo "ERROR: pip-audit found CVEs but failed to comment on security/cve issue #${existing_number}" >&2
@@ -138,15 +140,27 @@ jobs:
           }
 
           while (( attempt <= max_attempts )); do
+            # Drop stale output so a failed attempt cannot reuse a prior clean JSON.
+            rm -f "${audit_json}"
             set +e
-            uv run --no-progress --with pip-audit pip-audit --skip-editable \
+            # --with pip: pip-audit default env mode needs pip/pip-api in the uv ephemeral env.
+            uv run --no-progress --with pip --with pip-audit pip-audit --skip-editable \
               --format=json -o "${audit_json}"
+            audit_rc=$?
             set -e
 
-            outcome="$(classify_audit_json "${audit_json}")"
+            # pip-audit: 0 clean, 1 CVEs found, other = tool/db failure (do not treat as clean).
+            if (( audit_rc != 0 && audit_rc != 1 )); then
+              outcome=transient
+            else
+              outcome="$(classify_audit_json "${audit_json}")"
+            fi
             case "$outcome" in
               clean)
-                close_resolved_cve_issues
+                if ! close_resolved_cve_issues; then
+                  echo "ERROR: pip-audit clean but failed to list/close security/cve issues" >&2
+                  exit 1
+                fi
                 echo 'No vulnerabilities found'
                 exit 0
                 ;;
@@ -159,11 +173,11 @@ jobs:
                 ;;
               transient)
                 if (( attempt < max_attempts )); then
-                  echo "Transient pip-audit failure (attempt ${attempt}/${max_attempts}); retrying..."
+                  echo "Transient pip-audit failure (rc=${audit_rc:-?}, attempt ${attempt}/${max_attempts}); retrying..."
                   sleep "${retry_wait}"
                   attempt=$((attempt + 1))
                 else
-                  echo "ERROR: pip-audit failed after ${max_attempts} attempts (transient/tool error)"
+                  echo "ERROR: pip-audit failed after ${max_attempts} attempts (transient/tool error, rc=${audit_rc:-?})"
                   if [[ -f "${audit_json}" ]]; then
                     cat "${audit_json}" || true
                   fi


### PR DESCRIPTION
## Summary
Sync `.github/workflows/cve-check.yml` to the hardened org canonical template from [repository-helpers#524](https://github.com/the-hcma/repository-helpers/pull/524):
- Fail loud on `gh issue list` failures
- `uv run --with pip --with pip-audit`
- Treat non-0/1 pip-audit exits as transient; clear `audit.json` before retries

## Test plan
- [ ] CI green
- [ ] After merge, `github-repo-lint --repo the-hcma/bunnify --strict-onboarding` no longer fails on cve-check canonicity