### PR TITLE
docs: align README and quick reference with server LaunchAgent

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -23,8 +23,8 @@ curl -fsSL https://raw.githubusercontent.com/the-hcma/bunnify/main/bunnify.json.
 bunnify                         # interactive REPL
 bunnify onboard                 # post-install / upgrade checklist
 bunnify setup                   # configure local or remote server
-bunnify stop                    # stop the managed local server
-bunnify upgrade                 # preferred: pipx upgrade; prints from/to versions
+bunnify stop                    # stop server (macOS: boot out server LaunchAgent)
+bunnify upgrade                 # pipx upgrade; macOS refreshes LaunchAgents
 bunnify --version               # package version, commit, and install path
 bunnify gh                      # open a shortcut (example key from bunnify.json.example)
 bunnify bun                     # Bunnify source on GitHub
@@ -36,7 +36,7 @@ bunnify spotty-bunny            # macOS search box (requires extra macos)
 bunnify spotty-bunny --verbose  # DEBUG logs on stderr and log file
 bunnify spotty-bunny install    # login LaunchAgent (TCC + KeepAlive)
 bunnify spotty-bunny status     # process, launchd, logs, TCC
-bunnify spotty-bunny upgrade    # refresh agent after `bunnify upgrade`
+bunnify spotty-bunny upgrade    # manual Spotty plist bounce (optional on macOS)
 bunnify spotty-bunny uninstall
 ```
 
@@ -47,7 +47,7 @@ Requires `pipx install 'bunnify[macos]'`. Hold one Control, tap the other.
 ```bash
 bunnify spotty-bunny install     # login LaunchAgent (TCC + KeepAlive)
 bunnify spotty-bunny status
-bunnify upgrade && bunnify spotty-bunny upgrade
+bunnify upgrade                  # refreshes both LaunchAgents on macOS
 bunnify spotty-bunny uninstall
 spotty-bunny                     # foreground (debug)
 ```
@@ -62,13 +62,21 @@ Details: [docs/LOCAL.md](docs/LOCAL.md)
 ## Server
 
 ```bash
-bunnify stop                    # stop the managed local server (local mode)
+bunnify stop                         # local mode; macOS boots out server agent
+bunnify-server install --port 8000   # macOS: server LaunchAgent only
+bunnify-server status
+bunnify-server upgrade
+bunnify-server uninstall
 bunnify-server --help
-bunnify-server --foreground --noninteractive --port 8000   # foreground (systemd/debug)
+bunnify-server --foreground --noninteractive --port 8000   # foreground (debug)
 bunnify-server --port 8000 --noninteractive --pid-dir ~/.local/share/bunnify/run
 bunnify-server --stop --pid-dir ~/.local/share/bunnify/run
 curl -sf "$(grep '^BUNNIFY_BASE_URL=' ~/.config/bunnify/config.env | cut -d= -f2-)/health"
 ```
+
+On macOS, **local** `bunnify setup` installs the server LaunchAgent; Linux and
+manual installs use the managed `--pid-dir` path above. Details:
+[docs/LOCAL.md](docs/LOCAL.md).
 
 Development checkout: prefix with `./scripts/` (e.g. `./scripts/bunnify-server`).
 
@@ -96,7 +104,7 @@ Full guide: [CHROME_SETUP.md](CHROME_SETUP.md)
 |------|---------|
 | `~/.config/bunnify/bookmarks.json` | Shortcuts |
 | `~/.config/bunnify/config.env` | Mode, base URL, port |
-| `~/.local/share/bunnify/` | DB, logs, managed run state |
+| `~/.local/share/bunnify/` | DB, logs, managed run state (`run/`, `run/launchd/` on macOS LaunchAgent) |
 
 More: [docs/CONFIG.md](docs/CONFIG.md), [docs/LOCAL.md](docs/LOCAL.md)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ That prints the version/commit you are running **from**, the PyPI target, then
 the pipx app version/commit **to** after `pipx upgrade`. Use this instead of
 bare `pipx upgrade bunnify` so you can see when PATH is still a git checkout.
 
+On **macOS**, `bunnify upgrade` also refreshes installed server and Spotty Bunny
+LaunchAgents when their plists are present (or run `bunnify-server upgrade` /
+`bunnify spotty-bunny upgrade` manually).
+
 `pipx upgrade` only updates `~/.local/bin/bunnify`. If `bunnify --version` still
 shows a checkout SHA, PATH is hitting `./scripts/bunnify` or a repo `.venv`.
 After `pipx ensurepath`, `command -v bunnify` should be `~/.local/bin/bunnify`.
@@ -108,15 +112,18 @@ for overrides (`BUNNIFY_BOOKMARKS`, `XDG_CONFIG_HOME`).
 bunnify setup
 ```
 
-**Laptop / daily machine:** choose **local** (default). Setup starts a managed
-server, verifies `/health`, records the port, and saves settings to
-`~/.config/bunnify/config.env`. Point Chrome or Edge at the same
-`BUNNIFY_BASE_URL`
+**Laptop / daily machine:** choose **local** (default). On **macOS**, setup
+installs the **server LaunchAgent** (`com.thehcma.bunnify`), verifies
+`/health`, records the port, and saves settings to `~/.config/bunnify/config.env`.
+Elsewhere it starts a managed background server the same way as before. Point
+Chrome or Edge at the same `BUNNIFY_BASE_URL`
 ([Chrome / Edge setup](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md)).
 
 **Home server / always-on host:** choose **remote** on client devices and enter
-that host’s URL. Prefer a centralized remote install when several machines share
-one server — not as a laptop’s only dependency if you often go offline.
+that host’s URL. Setup probes `/health`; if the host is unreachable it warns
+and asks before saving. Prefer a centralized remote install when several
+machines share one server — not as a laptop’s only dependency if you often go
+offline.
 
 One-time override without saving: `bunnify --base-url https://… shortcut`.
 
@@ -141,6 +148,8 @@ Unknown keys exit non-zero in direct mode (no search-engine fallback).
 - **CLI / REPL** — fuzzy Tab completion, fzf mode, Vim/Emacs edit keys
 - **Spotty Bunny** — dual-Control search box (`spotty-bunny`; extra `macos`;
   login LaunchAgent via `install` / `upgrade` / `uninstall`)
+- **macOS server LaunchAgent** — local setup installs `bunnify-server` under
+  launchd (`bunnify-server install|status|upgrade|uninstall`)
 - **Web** — `/cmd/` command palette, `/list/` browser, smart `/search/`
 - **Chrome / Edge** — OpenSearch at `/opensearch.xml`
   ([setup guide](https://github.com/the-hcma/bunnify/blob/main/CHROME_SETUP.md))
@@ -170,12 +179,13 @@ runs in the **foreground** for debugging.
 ### Upgrade
 
 ```bash
-bunnify upgrade                 # pipx package
-bunnify spotty-bunny upgrade    # refresh the LaunchAgent binary path
+bunnify upgrade                 # pipx package; on macOS refreshes LaunchAgents
+bunnify spotty-bunny upgrade    # manual plist bounce when needed
 ```
 
-Run `upgrade` after `bunnify upgrade` so launchd does not keep a stale
-`ProgramArguments` path.
+On macOS, `bunnify upgrade` rewrites both LaunchAgents when installed. Use
+`bunnify spotty-bunny upgrade` only when you need to refresh Spotty without
+upgrading the pipx package.
 
 ### Uninstall
 
@@ -204,18 +214,22 @@ Installed users manage the server with **`bunnify-server`**:
 
 ```bash
 bunnify-server --help
-# Foreground (systemd, LaunchAgent, debugging):
+bunnify-server install --port 8000   # macOS: server LaunchAgent only
+bunnify-server status
+bunnify-server upgrade               # rewrite plist for current binary
+# Foreground (systemd, debugging):
 bunnify-server --foreground --noninteractive --port 8000
-# Background managed daemon (returns after fork):
+# Background managed daemon (non-macOS or manual):
 bunnify-server --port 8000 --noninteractive --pid-dir ~/.local/share/bunnify/run
 bunnify-server --stop --pid-dir ~/.local/share/bunnify/run
 curl --max-time 2 http://127.0.0.1:8000/health
 ```
 
-`bunnify setup` starts a managed local server for daily CLI use. Stop it with:
+**Local setup:** `bunnify setup` (macOS installs the server LaunchAgent; other
+platforms start a managed background server). Stop with:
 
 ```bash
-bunnify stop
+bunnify stop    # macOS: boot out server LaunchAgent; else stop managed server
 ```
 
 That prints the URL and runtime directory before stopping. Details:
@@ -226,8 +240,10 @@ That prints the URL and runtime directory before stopping. Details:
 via `setup-service` from
 [repository-helpers](https://github.com/the-hcma/repository-helpers).
 
-**macOS:**
-[LaunchAgent example](https://github.com/the-hcma/bunnify/blob/main/etc/launchd/com.thehcma.bunnify.plist.example).
+**macOS:** prefer `bunnify setup` (local) or the commands above. Manual plist
+copy is optional — see
+[LaunchAgent example](https://github.com/the-hcma/bunnify/blob/main/etc/launchd/com.thehcma.bunnify.plist.example)
+and [LOCAL.md](https://github.com/the-hcma/bunnify/blob/main/docs/LOCAL.md).
 
 ## Web usage
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -13,7 +13,8 @@ to `~/.config/bunnify` when `XDG_CONFIG_HOME` is unset:
 - `bookmarks.json` contains personal shortcuts (required before server start).
 - `config.env` contains persistent CLI server preferences:
   `BUNNIFY_MODE`, `BUNNIFY_BASE_URL`, and `BUNNIFY_LOCAL_PORT`.
-- `run/` contains PID and selected-port files for the CLI-managed local server.
+- `run/` contains PID and port files for CLI-managed servers. On macOS the
+  server LaunchAgent uses `run/launchd/` (see [LOCAL.md](LOCAL.md)).
 
 Writable data (logs, SQLite, Spotty Bunny’s daily PyPI check cache
 `pypi-latest.json`) lives under `$XDG_DATA_HOME/bunnify` or `BUNNIFY_DATA_DIR`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -58,6 +58,8 @@ bunnify upgrade
 
 That prints the version/commit you are running from and the pipx app you
 upgraded to. Bare `pipx upgrade bunnify` also works but does not compare builds.
+On macOS, `bunnify upgrade` refreshes installed server and Spotty Bunny
+LaunchAgents when their plists are present.
 
 For runtime configuration and server setup, see
 [Configuration](CONFIG.md) and [Local and remote setup](LOCAL.md).


### PR DESCRIPTION
## Summary
- Update README quick start, features, Spotty upgrade, and server lifecycle for the merged server LaunchAgent (#360).
- Refresh QUICK_REFERENCE with `bunnify-server install|status|upgrade`, macOS `bunnify stop`, and `bunnify upgrade` refreshing both agents.
- Note `run/launchd/` in CONFIG and LaunchAgent refresh on upgrade in RELEASING.

## Test plan
- [x] Docs-only change; pre-pr-checks passed locally via submit-stack.
- [ ] CI markdown/lint jobs green.