### PR TITLE
feat: unified version coherence for local and remote installs

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Literal
 
 import click
-from packaging.version import InvalidVersion, Version
 from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.shortcuts import CompleteStyle
 
@@ -27,6 +26,14 @@ from app.client import (
     fetch_suggestions,
     lookup_key_entry,
     resolve_shortcut,
+)
+from app.coherence import (
+    assess_local_coherence,
+    builds_match,
+    cli_is_newer_than,
+    ensure_local_spotty_aligned,
+    format_build_label,
+    offer_remote_build_mismatch,
 )
 from app.config import (
     ENV_VAR,
@@ -128,12 +135,23 @@ def ensure_ready_base_url(
     if preferences.mode == "remote":
         if not preferences.base_url:
             raise ClientError("Remote mode requires BUNNIFY_BASE_URL")
-        return _wait_for_healthy_remote(
+        base_url = _wait_for_healthy_remote(
             preferences.base_url,
             prompt_fn=ask,
             interactive=interactive,
             print_fn=log,
         )
+        if interactive:
+            health = fetch_health(base_url)
+            if health.ok and not offer_remote_build_mismatch(
+                ask,
+                base_url=base_url,
+                health=health,
+                print_fn=log,
+                theme=Theme(enabled=stdout_color_enabled()),
+            ):
+                raise ClientError("Remote server version mismatch")
+        return base_url
 
     bookmarks = ensure_user_bookmarks(
         environ=environ,
@@ -348,7 +366,7 @@ def run_setup(
                     local_port=actual_port,
                 )
                 save_preferences(preferences, env_path=path, environ=environ)
-                build_label = _format_running_build(health)
+                build_label = format_build_label(health)
                 if build_label == "unknown build":
                     local_version, local_commit = get_build_info()
                     log(
@@ -364,6 +382,11 @@ def run_setup(
                 log(colors.header("Browser"))
                 for line in format_browser_setup_text(base_url).splitlines():
                     log(line)
+                _ensure_local_spotty_after_setup(
+                    print_fn=log,
+                    prompt_fn=ask,
+                    theme=colors,
+                )
                 return base_url
             if not _retry_requested(
                 ask,
@@ -413,9 +436,19 @@ def run_setup(
             base_url=base_url,
             local_port=None,
         )
+        if reachable:
+            health = fetch_health(base_url)
+            log(colors.ok(f"✓ Health check passed for {base_url}"))
+            if not offer_remote_build_mismatch(
+                ask,
+                base_url=base_url,
+                health=health,
+                print_fn=log,
+                theme=colors,
+            ):
+                raise ClientError("Setup aborted; settings were not changed")
         save_preferences(preferences, env_path=path, environ=environ)
         if reachable:
-            log(colors.ok(f"✓ Health check passed for {base_url}"))
             log(colors.ok(f"✓ Configured remote Bunnify server at {base_url}"))
         else:
             log(
@@ -471,7 +504,7 @@ def run_stop(
                 log(f"URL: {base_url}")
                 health = fetch_health(base_url)
                 if health.ok:
-                    log(f"Running build: {_format_running_build(health)}")
+                    log(f"Running build: {format_build_label(health)}")
             try:
                 stop_local_server(agent_pid_dir, port=port)
             except (OSError, RuntimeError, ValueError) as exc:
@@ -493,7 +526,7 @@ def run_stop(
     log(f"Runtime directory: {pid_dir}")
     health = fetch_health(base_url)
     if health.ok:
-        log(f"Running build: {_format_running_build(health)}")
+        log(f"Running build: {format_build_label(health)}")
     else:
         log(
             colors.dim(
@@ -600,35 +633,112 @@ def run_upgrade(
             print_fn=log,
             theme=colors,
         )
+    _report_post_upgrade_coherence(
+        print_fn=log,
+        theme=colors,
+        refresh_launch_agents=refresh_launch_agents,
+    )
 
 
-def matching_keys(keys: list[str], prefix: str) -> list[str]:
-    """Return keys that start with ``prefix`` (case-insensitive)."""
-    needle = prefix.lower()
-    return [key for key in keys if key.lower().startswith(needle)]
+def _ensure_local_spotty_after_setup(
+    *,
+    print_fn: Callable[[str], None],
+    prompt_fn: Callable[[str], str],
+    theme: Theme,
+) -> None:
+    """Install or restart Spotty Bunny to match this CLI after local setup."""
+    if sys.platform != "darwin":
+        return
+    from app.spotty_bunny_agent import is_agent_installed
+    from app.spotty_bunny_launch import spotty_bunny_is_running
+
+    if not is_agent_installed() and not spotty_bunny_is_running():
+        print_fn(
+            theme.dim(
+                "Spotty Bunny is not installed. Optional: bunnify spotty-bunny install"
+            )
+        )
+        return
+
+    def offer_restart(recorded: str | None, current: str) -> bool:
+        running = recorded or "unknown"
+        print_fn(
+            theme.warn(
+                f"Spotty Bunny is running commit {running}; this CLI is {current}."
+            )
+        )
+        return _confirm_explicit_yes(
+            prompt_fn,
+            "Restart Spotty Bunny with this CLI? [y/N]: ",
+        )
+
+    print_fn(theme.dim("Ensuring Spotty Bunny matches this install…"))
+    if ensure_local_spotty_aligned(
+        print_fn=print_fn,
+        restart=offer_restart,
+    ):
+        print_fn(theme.ok("✓ Spotty Bunny is running"))
+    else:
+        print_fn(
+            theme.warn(
+                "Spotty Bunny is not running. Install with: "
+                "bunnify spotty-bunny install"
+            )
+        )
 
 
-def build_query_from_args(args: tuple[str, ...]) -> str:
-    return " ".join(args).strip()
+def _report_post_upgrade_coherence(
+    *,
+    print_fn: Callable[[str], None],
+    theme: Theme,
+    refresh_launch_agents: bool | Literal["server"],
+) -> None:
+    """Verify local server and Spotty match the upgraded CLI."""
+    preferences = load_preferences()
+    if preferences is not None and preferences.mode == "remote":
+        if not preferences.base_url:
+            return
+        health = fetch_health(preferences.base_url)
+        if health.ok and not builds_match(health):
+            print_fn(
+                theme.warn(
+                    f"Remote server is {format_build_label(health)}; "
+                    f"this Mac is {build_version()}."
+                )
+            )
+            print_fn(
+                theme.dim(
+                    "Upgrade or redeploy the remote host to match, or continue "
+                    "with client/server version skew."
+                )
+            )
+        return
 
-
-def _builds_match(health: HealthStatus) -> bool:
-    """Return whether a healthy remote build matches this CLI install."""
-    if health.version is None or health.commit is None:
-        return False
-    local_version, local_commit = get_build_info()
-    return health.version == local_version and health.commit == local_commit
-
-
-def _cli_is_newer_than(health: HealthStatus) -> bool:
-    """Return whether this CLI's package version is newer than ``health``."""
-    if health.version is None:
-        return False
-    local_version, _local_commit = get_build_info()
-    try:
-        return Version(health.version) < Version(local_version)
-    except InvalidVersion:
-        return False
+    base_url = resolve_base_url(persist=False, allow_prompt=False)
+    report = assess_local_coherence(base_url=base_url)
+    server = report.server
+    if server is not None and server.ok and not builds_match(server):
+        print_fn(
+            theme.warn(
+                f"Local server is {format_build_label(server)}; "
+                f"this CLI is {build_version()}."
+            )
+        )
+        print_fn(theme.dim("Run: bunnify-server upgrade"))
+    if sys.platform != "darwin":
+        return
+    if refresh_launch_agents is not True:
+        return
+    if report.spotty_running and report.spotty_commit != report.local_commit:
+        print_fn(theme.dim("Restarting Spotty Bunny to match the upgraded CLI…"))
+        if not ensure_local_spotty_aligned(force_restart=True, print_fn=print_fn):
+            print_fn(
+                theme.warn(
+                    "Spotty Bunny did not restart. Run: bunnify spotty-bunny upgrade"
+                )
+            )
+        else:
+            print_fn(theme.ok("✓ Spotty Bunny restarted on the upgraded build"))
 
 
 def _command_banner(action: str) -> str:
@@ -669,7 +779,7 @@ def _ensure_local_server_for_setup(
     ask = prompt_fn or input
     health = fetch_health(base_url)
     if health.ok:
-        if _builds_match(health):
+        if builds_match(health):
             if is_agent_installed():
                 return base_url, chosen
         else:
@@ -722,15 +832,14 @@ def _find_usable_local_port(start: int) -> int:
     raise ClientError(f"No free local port found between {MIN_LOCAL_PORT} and 65535")
 
 
-def _format_running_build(health: HealthStatus) -> str:
-    """Human-readable version/commit from a health probe."""
-    if health.version and health.commit:
-        return f"{health.version} ({health.commit})"
-    if health.version:
-        return health.version
-    if health.commit:
-        return f"commit {health.commit}"
-    return "unknown build"
+def build_query_from_args(args: tuple[str, ...]) -> str:
+    return " ".join(args).strip()
+
+
+def matching_keys(keys: list[str], prefix: str) -> list[str]:
+    """Return keys that start with ``prefix`` (case-insensitive)."""
+    needle = prefix.lower()
+    return [key for key in keys if key.lower().startswith(needle)]
 
 
 def _managed_local_port(pid_dir: Path) -> int | None:
@@ -761,9 +870,9 @@ def _offer_restart_mismatched_server(
     """
     local_version, local_commit = get_build_info()
     local_label = f"{local_version} ({local_commit})"
-    running_label = _format_running_build(health)
+    running_label = format_build_label(health)
     print_fn(theme.ok(f"✓ Port {port} is already serving Bunnify {running_label}"))
-    if _builds_match(health):
+    if builds_match(health):
         return port, False
     if health.version is None or health.commit is None:
         print_fn(
@@ -772,7 +881,7 @@ def _offer_restart_mismatched_server(
             )
         )
         prompt = f"Stop it and start {local_label} on port {port}? [y/N]: "
-    elif _cli_is_newer_than(health):
+    elif cli_is_newer_than(health):
         print_fn(theme.warn(f"That server is older than this CLI ({local_label})."))
         prompt = f"Stop {running_label} and start {local_label} on port {port}? [y/N]: "
     else:
@@ -901,7 +1010,7 @@ def _prompt_local_port(
             log(
                 colors.ok(
                     f"✓ Found healthy Bunnify on port {found} "
-                    f"({_format_running_build(found_health)})"
+                    f"({format_build_label(found_health)})"
                 )
             )
         return found
@@ -999,7 +1108,7 @@ def _restart_local_server_if_build_mismatch(
     """Reuse a healthy local server, or restart it when the CLI commit differs."""
     colors = theme if theme is not None else Theme(enabled=False)
     health = fetch_health(base_url)
-    if not health.ok or _builds_match(health):
+    if not health.ok or builds_match(health):
         return base_url, port
     decided = _offer_restart_mismatched_server(
         prompt_fn,

--- a/app/cli.py
+++ b/app/cli.py
@@ -711,9 +711,16 @@ def _report_post_upgrade_coherence(
 
     parsed = parse_build_label(upgraded_build) if upgraded_build else None
     if parsed is None:
-        local_version, local_commit = get_build_info()
-    else:
-        local_version, local_commit = parsed
+        if upgraded_build is None:
+            print_fn(
+                theme.dim(
+                    "Could not read the upgraded pipx build; skipping version "
+                    "coherence checks. Run ~/.local/bin/bunnify --version to "
+                    "confirm."
+                )
+            )
+        return
+    local_version, local_commit = parsed
     local_label = f"{local_version} ({local_commit})"
     preferences = load_preferences()
     if preferences is not None and preferences.mode == "remote":
@@ -739,7 +746,10 @@ def _report_post_upgrade_coherence(
             )
         return
 
-    base_url = resolve_base_url(persist=False, allow_prompt=False)
+    if preferences is not None and preferences.base_url:
+        base_url = preferences.base_url
+    else:
+        base_url = resolve_base_url(persist=False, allow_prompt=False)
     report = assess_local_coherence(base_url=base_url)
     server = report.server
     if (
@@ -765,14 +775,26 @@ def _report_post_upgrade_coherence(
     spotty_commit = report.spotty_commit
     if report.spotty_running and spotty_commit != local_commit:
         print_fn(theme.dim("Restarting Spotty Bunny to match the upgraded CLI…"))
-        if not ensure_local_spotty_aligned(force_restart=True, print_fn=print_fn):
+        if not ensure_local_spotty_aligned(
+            cli_commit=local_commit,
+            force_restart=True,
+            print_fn=print_fn,
+        ):
             print_fn(
                 theme.warn(
                     "Spotty Bunny did not restart. Run: bunnify spotty-bunny upgrade"
                 )
             )
-        else:
+            return
+        running, aligned_commit = running_spotty_commit()
+        if running and aligned_commit == local_commit:
             print_fn(theme.ok("✓ Spotty Bunny restarted on the upgraded build"))
+        else:
+            print_fn(
+                theme.warn(
+                    "Spotty Bunny did not restart. Run: bunnify spotty-bunny upgrade"
+                )
+            )
 
 
 def _command_banner(action: str) -> str:

--- a/app/cli.py
+++ b/app/cli.py
@@ -711,14 +711,13 @@ def _report_post_upgrade_coherence(
 
     parsed = parse_build_label(upgraded_build) if upgraded_build else None
     if parsed is None:
-        if upgraded_build is None:
-            print_fn(
-                theme.dim(
-                    "Could not read the upgraded pipx build; skipping version "
-                    "coherence checks. Run ~/.local/bin/bunnify --version to "
-                    "confirm."
-                )
+        print_fn(
+            theme.dim(
+                "Could not read the upgraded pipx build; skipping version "
+                "coherence checks. Run ~/.local/bin/bunnify --version to "
+                "confirm."
             )
+        )
         return
     local_version, local_commit = parsed
     local_label = f"{local_version} ({local_commit})"

--- a/app/cli.py
+++ b/app/cli.py
@@ -34,6 +34,7 @@ from app.coherence import (
     ensure_local_spotty_aligned,
     format_build_label,
     offer_remote_build_mismatch,
+    running_spotty_commit,
 )
 from app.config import (
     ENV_VAR,
@@ -637,6 +638,7 @@ def run_upgrade(
         print_fn=log,
         theme=colors,
         refresh_launch_agents=refresh_launch_agents,
+        upgraded_build=after_pipx,
     )
 
 
@@ -673,10 +675,20 @@ def _ensure_local_spotty_after_setup(
         )
 
     print_fn(theme.dim("Ensuring Spotty Bunny matches this install…"))
-    if ensure_local_spotty_aligned(
+    ensure_local_spotty_aligned(
         print_fn=print_fn,
         restart=offer_restart,
-    ):
+    )
+    running, spotty_commit = running_spotty_commit()
+    _local_version, local_commit = get_build_info()
+    if running and spotty_commit is not None and spotty_commit != local_commit:
+        print_fn(
+            theme.warn(
+                "Spotty Bunny is still running an older build. "
+                "Run: bunnify spotty-bunny upgrade"
+            )
+        )
+    elif running:
         print_fn(theme.ok("✓ Spotty Bunny is running"))
     else:
         print_fn(
@@ -692,18 +704,31 @@ def _report_post_upgrade_coherence(
     print_fn: Callable[[str], None],
     theme: Theme,
     refresh_launch_agents: bool | Literal["server"],
+    upgraded_build: str | None = None,
 ) -> None:
-    """Verify local server and Spotty match the upgraded CLI."""
+    """Verify local server and Spotty match the upgraded pipx build."""
+    from app.coherence import builds_match_values, parse_build_label
+
+    parsed = parse_build_label(upgraded_build) if upgraded_build else None
+    if parsed is None:
+        local_version, local_commit = get_build_info()
+    else:
+        local_version, local_commit = parsed
+    local_label = f"{local_version} ({local_commit})"
     preferences = load_preferences()
     if preferences is not None and preferences.mode == "remote":
         if not preferences.base_url:
             return
         health = fetch_health(preferences.base_url)
-        if health.ok and not builds_match(health):
+        if health.ok and not builds_match_values(
+            health,
+            local_commit=local_commit,
+            local_version=local_version,
+        ):
             print_fn(
                 theme.warn(
                     f"Remote server is {format_build_label(health)}; "
-                    f"this Mac is {build_version()}."
+                    f"this Mac is {local_label}."
                 )
             )
             print_fn(
@@ -717,11 +742,19 @@ def _report_post_upgrade_coherence(
     base_url = resolve_base_url(persist=False, allow_prompt=False)
     report = assess_local_coherence(base_url=base_url)
     server = report.server
-    if server is not None and server.ok and not builds_match(server):
+    if (
+        server is not None
+        and server.ok
+        and not builds_match_values(
+            server,
+            local_commit=local_commit,
+            local_version=local_version,
+        )
+    ):
         print_fn(
             theme.warn(
                 f"Local server is {format_build_label(server)}; "
-                f"this CLI is {build_version()}."
+                f"this CLI is {local_label}."
             )
         )
         print_fn(theme.dim("Run: bunnify-server upgrade"))
@@ -729,7 +762,8 @@ def _report_post_upgrade_coherence(
         return
     if refresh_launch_agents is not True:
         return
-    if report.spotty_running and report.spotty_commit != report.local_commit:
+    spotty_commit = report.spotty_commit
+    if report.spotty_running and spotty_commit != local_commit:
         print_fn(theme.dim("Restarting Spotty Bunny to match the upgraded CLI…"))
         if not ensure_local_spotty_aligned(force_restart=True, print_fn=print_fn):
             print_fn(

--- a/app/coherence.py
+++ b/app/coherence.py
@@ -1,0 +1,175 @@
+"""Version coherence between CLI, server /health, and Spotty Bunny."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from packaging.version import InvalidVersion, Version
+
+from app.client import HealthStatus, fetch_health
+from app.theme import Theme
+from app.version import get_build_info
+
+RestartFn = Callable[[str | None, str], bool]
+
+
+@dataclass(frozen=True)
+class LocalCoherenceReport:
+    """Local CLI vs server and Spotty overlay build alignment."""
+
+    local_commit: str
+    local_version: str
+    server: HealthStatus | None
+    spotty_commit: str | None
+    spotty_running: bool
+
+    @property
+    def coherent(self) -> bool:
+        if self.server is not None and self.server.ok and not builds_match(self.server):
+            return False
+        if self.spotty_running and self.spotty_commit != self.local_commit:
+            return False
+        return True
+
+
+def assess_local_coherence(*, base_url: str) -> LocalCoherenceReport:
+    """Compare this process to *base_url* /health and a running Spotty overlay."""
+    local_version, local_commit = get_build_info()
+    server = fetch_health(base_url)
+    spotty_running, spotty_commit = _spotty_runtime_commit()
+    return LocalCoherenceReport(
+        local_commit=local_commit,
+        local_version=local_version,
+        server=server,
+        spotty_commit=spotty_commit,
+        spotty_running=spotty_running,
+    )
+
+
+def builds_match(health: HealthStatus) -> bool:
+    """Return whether *health* matches this CLI install."""
+    if health.version is None or health.commit is None:
+        return False
+    local_version, local_commit = get_build_info()
+    return health.version == local_version and health.commit == local_commit
+
+
+def cli_is_newer_than(health: HealthStatus) -> bool:
+    """Return whether this CLI's package version is newer than *health*."""
+    if health.version is None:
+        return False
+    local_version, _local_commit = get_build_info()
+    try:
+        return Version(health.version) < Version(local_version)
+    except InvalidVersion:
+        return False
+
+
+def ensure_local_spotty_aligned(
+    *,
+    force_restart: bool = False,
+    print_fn: Callable[[str], None] | None = None,
+    restart: RestartFn | None = None,
+) -> bool:
+    """Start or restart Spotty Bunny so its running commit matches this CLI."""
+    if sys.platform != "darwin":
+        return True
+    from app.spotty_bunny_launch import ensure_spotty_bunny_running
+
+    log = print_fn or (lambda _message: None)
+
+    def offer_restart(recorded: str | None, current: str) -> bool:
+        if force_restart:
+            return True
+        if restart is not None:
+            return restart(recorded, current)
+        running = recorded or "unknown"
+        log(f"Spotty Bunny is running commit {running}; this CLI is {current}.")
+        return _confirm_explicit_yes(
+            input,
+            "Restart Spotty Bunny with this CLI? [y/N]: ",
+        )
+
+    return ensure_spotty_bunny_running(
+        force_restart=force_restart,
+        restart=offer_restart,
+    )
+
+
+def format_build_label(health: HealthStatus) -> str:
+    """Human-readable version/commit from a health probe."""
+    if health.version and health.commit:
+        return f"{health.version} ({health.commit})"
+    if health.version:
+        return health.version
+    if health.commit:
+        return f"commit {health.commit}"
+    return "unknown build"
+
+
+def offer_remote_build_mismatch(
+    prompt_fn: Callable[[str], str],
+    *,
+    base_url: str,
+    health: HealthStatus,
+    print_fn: Callable[[str], None],
+    theme: Theme,
+) -> bool:
+    """Warn when *health* differs from this CLI; return True to continue anyway."""
+    if not health.ok or builds_match(health):
+        return True
+    if health.version is None or health.commit is None:
+        return True
+    local_version, local_commit = get_build_info()
+    local_label = f"{local_version} ({local_commit})"
+    remote_label = format_build_label(health)
+    print_fn(
+        theme.warn(
+            f"Remote server at {base_url} is {remote_label}; this Mac is {local_label}."
+        )
+    )
+    if cli_is_newer_than(health):
+        print_fn(
+            theme.dim(
+                "Upgrade the remote host (merge latest release, redeploy, or "
+                "run `bunnify upgrade` there) so both sides match."
+            )
+        )
+    else:
+        print_fn(
+            theme.dim(
+                "Upgrade this Mac with `bunnify upgrade` or align the remote "
+                "host to the same release."
+            )
+        )
+    return _confirm_explicit_yes(
+        prompt_fn,
+        "Continue with this client/server version skew? [y/N]: ",
+    )
+
+
+def _confirm_explicit_yes(prompt_fn: Callable[[str], str], message: str) -> bool:
+    try:
+        answer = prompt_fn(message)
+    except EOFError:
+        return False
+    return answer.strip().lower() in {"y", "yes"}
+
+
+def _spotty_runtime_commit() -> tuple[bool, str | None]:
+    if sys.platform != "darwin":
+        return False, None
+    from app.spotty_bunny_launch import (
+        read_spotty_bunny_runtime,
+        spotty_bunny_is_running,
+    )
+
+    if not spotty_bunny_is_running():
+        return False, None
+    runtime = read_spotty_bunny_runtime()
+    if runtime is None:
+        return True, None
+    _pid, commit = runtime
+    return True, commit

--- a/app/coherence.py
+++ b/app/coherence.py
@@ -50,10 +50,36 @@ def assess_local_coherence(*, base_url: str) -> LocalCoherenceReport:
 
 def builds_match(health: HealthStatus) -> bool:
     """Return whether *health* matches this CLI install."""
+    local_version, local_commit = get_build_info()
+    return builds_match_values(
+        health,
+        local_commit=local_commit,
+        local_version=local_version,
+    )
+
+
+def builds_match_values(
+    health: HealthStatus,
+    *,
+    local_commit: str,
+    local_version: str,
+) -> bool:
+    """Return whether *health* matches explicit local version/commit."""
     if health.version is None or health.commit is None:
         return False
-    local_version, local_commit = get_build_info()
     return health.version == local_version and health.commit == local_commit
+
+
+def parse_build_label(label: str) -> tuple[str, str] | None:
+    """Return ``(version, commit)`` parsed from ``0.10.0 (abc1234)``."""
+    token = label.strip()
+    if not token or " (" not in token or not token.endswith(")"):
+        return None
+    version, _, rest = token.partition(" (")
+    commit = rest.removesuffix(")").strip()
+    if not version or not commit:
+        return None
+    return version, commit
 
 
 def cli_is_newer_than(health: HealthStatus) -> bool:
@@ -156,6 +182,11 @@ def _confirm_explicit_yes(prompt_fn: Callable[[str], str], message: str) -> bool
     except EOFError:
         return False
     return answer.strip().lower() in {"y", "yes"}
+
+
+def running_spotty_commit() -> tuple[bool, str | None]:
+    """Return ``(running, commit)`` for the Spotty Bunny overlay."""
+    return _spotty_runtime_commit()
 
 
 def _spotty_runtime_commit() -> tuple[bool, str | None]:

--- a/app/coherence.py
+++ b/app/coherence.py
@@ -148,30 +148,44 @@ def offer_remote_build_mismatch(
     """Warn when *health* differs from this CLI; return True to continue anyway."""
     if not health.ok or builds_match(health):
         return True
-    if health.version is None or health.commit is None:
-        return True
     local_version, local_commit = get_build_info()
     local_label = f"{local_version} ({local_commit})"
-    remote_label = format_build_label(health)
-    print_fn(
-        theme.warn(
-            f"Remote server at {base_url} is {remote_label}; this Mac is {local_label}."
+    if health.version is None or health.commit is None:
+        remote_label = "unknown build"
+        print_fn(
+            theme.warn(
+                f"Remote server at {base_url} reports {remote_label}; "
+                f"this Mac is {local_label}."
+            )
         )
-    )
-    if cli_is_newer_than(health):
         print_fn(
             theme.dim(
-                "Upgrade the remote host (merge latest release, redeploy, or "
-                "run `bunnify upgrade` there) so both sides match."
+                "The remote server may be an older release without build "
+                "reporting in /health."
             )
         )
     else:
+        remote_label = format_build_label(health)
         print_fn(
-            theme.dim(
-                "Upgrade this Mac with `bunnify upgrade` or align the remote "
-                "host to the same release."
+            theme.warn(
+                f"Remote server at {base_url} is {remote_label}; "
+                f"this Mac is {local_label}."
             )
         )
+        if cli_is_newer_than(health):
+            print_fn(
+                theme.dim(
+                    "Upgrade the remote host (merge latest release, redeploy, or "
+                    "run `bunnify upgrade` there) so both sides match."
+                )
+            )
+        else:
+            print_fn(
+                theme.dim(
+                    "Upgrade this Mac with `bunnify upgrade` or align the remote "
+                    "host to the same release."
+                )
+            )
     return _confirm_explicit_yes(
         prompt_fn,
         "Continue with this client/server version skew? [y/N]: ",

--- a/app/coherence.py
+++ b/app/coherence.py
@@ -95,6 +95,7 @@ def cli_is_newer_than(health: HealthStatus) -> bool:
 
 def ensure_local_spotty_aligned(
     *,
+    cli_commit: str | None = None,
     force_restart: bool = False,
     print_fn: Callable[[str], None] | None = None,
     restart: RestartFn | None = None,
@@ -119,6 +120,7 @@ def ensure_local_spotty_aligned(
         )
 
     return ensure_spotty_bunny_running(
+        cli_commit=cli_commit,
         force_restart=force_restart,
         restart=offer_restart,
     )

--- a/app/server_agent.py
+++ b/app/server_agent.py
@@ -599,11 +599,25 @@ def _wait_for_managed_health(
 ) -> bool:
     """Wait until ``base_url`` is healthy and served from ``pid_dir``."""
     deadline = time.monotonic() + timeout_s
+    port_file = pid_dir / ".bunnify.port"
     while time.monotonic() < deadline:
         if check_health(base_url) and _port_served_by_pid_dir(port, pid_dir):
             return True
+        if check_health(base_url) and _managed_port_file_matches(port_file, port):
+            return True
         time.sleep(0.1)
-    return check_health(base_url) and _port_served_by_pid_dir(port, pid_dir)
+    return check_health(base_url) and (
+        _port_served_by_pid_dir(port, pid_dir)
+        or _managed_port_file_matches(port_file, port)
+    )
+
+
+def _managed_port_file_matches(port_file: Path, port: int) -> bool:
+    try:
+        recorded = int(port_file.read_text(encoding="utf-8").strip())
+    except OSError, ValueError:
+        return False
+    return recorded == port
 
 
 def _write_plist(plist: Path, *, home: Path, program_arguments: Sequence[str]) -> None:

--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -138,6 +138,11 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
         else f"Update available: {status.latest}"
     )
     details_text, details_links = about_details_text_and_links(runtime)
+    skew_text = (
+        "Server build differs from this Mac — align versions."
+        if runtime.server_skewed
+        else None
+    )
     inner_cap = ABOUT_PANEL_MAX_WIDTH - 2.0 * ABOUT_INSET
     needed_width = max(
         _measure_text("Spotty Bunny", title_font, max_width=inner_cap)[0],
@@ -147,6 +152,9 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
         0.0
         if update_text is None
         else _measure_text(update_text, body_font, max_width=inner_cap)[0],
+        0.0
+        if skew_text is None
+        else _measure_text(skew_text, body_font, max_width=inner_cap)[0],
     )
     width = min(
         ABOUT_PANEL_MAX_WIDTH,
@@ -207,8 +215,7 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
                 ),
             )
         )
-    if runtime.server_skewed:
-        skew_text = "Server build differs from this Mac — align versions."
+    if runtime.server_skewed and skew_text is not None:
         rows.append(
             (
                 18.0,
@@ -218,10 +225,6 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
                     color=_srgb_color(ABOUT_WARN_RGB),
                 ),
             )
-        )
-        needed_width = max(
-            needed_width,
-            _measure_text(skew_text, body_font, max_width=inner_cap)[0],
         )
     rows.extend(
         [

--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -207,6 +207,22 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
                 ),
             )
         )
+    if runtime.server_skewed:
+        skew_text = "Server build differs from this Mac — align versions."
+        rows.append(
+            (
+                18.0,
+                lambda y, h: _label(
+                    NSMakeRect(ABOUT_INSET, y, inner, h),
+                    skew_text,
+                    color=_srgb_color(ABOUT_WARN_RGB),
+                ),
+            )
+        )
+        needed_width = max(
+            needed_width,
+            _measure_text(skew_text, body_font, max_width=inner_cap)[0],
+        )
     rows.extend(
         [
             (

--- a/app/spotty_bunny_about_info.py
+++ b/app/spotty_bunny_about_info.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import unquote, urlparse
 
+from app.client import fetch_health
+from app.coherence import builds_match, format_build_label
 from app.config import (
     default_bookmarks_path,
     load_preferences,
@@ -31,7 +33,9 @@ class AboutRuntimeInfo:
     bookmarks_uri: str
     github_display: str | None
     github_url: str | None
+    server_build_label: str | None
     server_display: str
+    server_skewed: bool
     server_url: str
 
 
@@ -57,6 +61,9 @@ def about_details_text_and_links(
         links.append((runtime.github_display, runtime.github_url))
     lines.append(runtime.server_display)
     links.append((runtime.server_url, runtime.server_url))
+    if runtime.server_build_label is not None:
+        lines.append(f"Server build: {runtime.server_build_label}")
+        links.append((runtime.server_build_label, runtime.server_url))
     return "\n".join(lines), tuple(links)
 
 
@@ -190,12 +197,22 @@ def load_about_runtime_info(
     if mode is None:
         mode = "local" if _is_loopback_url(base_url) else "remote"
     label = "Local server" if mode == "local" else "Remote server"
+    health = fetch_health(base_url)
+    server_build_label = format_build_label(health) if health.ok else None
+    server_skewed = bool(
+        health.ok
+        and health.version is not None
+        and health.commit is not None
+        and not builds_match(health)
+    )
     return AboutRuntimeInfo(
         bookmarks_display=display_user_path(path),
         bookmarks_uri=bookmarks_uri,
         github_display=github_display,
         github_url=github_url,
+        server_build_label=server_build_label,
         server_display=f"{label} · {base_url}",
+        server_skewed=server_skewed,
         server_url=base_url,
     )
 

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -42,6 +42,7 @@ def clear_spotty_bunny_pid(
 
 def ensure_spotty_bunny_running(
     *,
+    force_restart: bool = False,
     installed: bool | None = None,
     loaded: bool | None = None,
     pid_dir: Path | None = None,
@@ -75,10 +76,19 @@ def ensure_spotty_bunny_running(
     pid_alive = runtime is not None and _spotty_bunny_process_alive(runtime[0])
     if pid_alive or loaded:
         running_commit = runtime[1] if runtime is not None else None
-        if running_commit is None or running_commit == current:
+        if running_commit == current and not force_restart:
             logger.debug("spotty-bunny already running (pid file %s)", directory)
             return True
-        if restart is None or not restart(running_commit, current):
+        if running_commit is None and not force_restart and restart is None:
+            logger.debug(
+                "spotty-bunny running without recorded commit (pid file %s)",
+                directory,
+            )
+            return True
+        should_restart = force_restart
+        if not should_restart and restart is not None:
+            should_restart = restart(running_commit, current)
+        if not should_restart:
             logger.debug(
                 "spotty-bunny already running with commit %s (cli %s)",
                 running_commit,

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -42,6 +42,7 @@ def clear_spotty_bunny_pid(
 
 def ensure_spotty_bunny_running(
     *,
+    cli_commit: str | None = None,
     force_restart: bool = False,
     installed: bool | None = None,
     loaded: bool | None = None,
@@ -58,7 +59,7 @@ def ensure_spotty_bunny_running(
     if sys.platform != "darwin":
         return False
     directory = pid_dir if pid_dir is not None else run_dir()
-    current = git_commit()
+    current = cli_commit if cli_commit is not None else git_commit()
     if loaded is None or installed is None:
         if pid_dir is None:
             from app.spotty_bunny_agent import is_agent_installed, is_agent_loaded

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -744,6 +744,16 @@ class CliUnitTests(TestCase):
 
 
 class ConfigUnitTests(TestCase):
+    def setUp(self) -> None:
+        self._spotty_setup_patch = patch(
+            "app.cli._ensure_local_spotty_after_setup",
+            return_value=None,
+        )
+        self._spotty_setup_patch.start()
+
+    def tearDown(self) -> None:
+        self._spotty_setup_patch.stop()
+
     def test_config_dir_respects_xdg_config_home(self) -> None:
         import tempfile
         from pathlib import Path
@@ -2413,7 +2423,7 @@ class ConfigUnitTests(TestCase):
             patch("app.cli.sys.platform", "darwin"),
             patch("app.cli.fetch_health", return_value=matching),
             patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
-            patch("app.cli._builds_match", return_value=True),
+            patch("app.cli.builds_match", return_value=True),
             patch("app.server_agent.is_agent_installed", return_value=True),
             patch("app.server_agent.install_agent") as install,
         ):
@@ -2440,7 +2450,7 @@ class ConfigUnitTests(TestCase):
             patch("app.cli.sys.platform", "darwin"),
             patch("app.cli.fetch_health", return_value=matching),
             patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
-            patch("app.cli._builds_match", return_value=True),
+            patch("app.cli.builds_match", return_value=True),
             patch("app.server_agent.is_agent_installed", return_value=False),
             patch("app.server_agent.install_agent", return_value=0) as install,
             patch(
@@ -2507,8 +2517,8 @@ class ConfigUnitTests(TestCase):
             patch("app.cli.sys.platform", "darwin"),
             patch("app.cli.fetch_health", return_value=old),
             patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
-            patch("app.cli._builds_match", return_value=False),
-            patch("app.cli._cli_is_newer_than", return_value=True),
+            patch("app.cli.builds_match", return_value=False),
+            patch("app.cli.cli_is_newer_than", return_value=True),
             patch("app.server_agent.is_agent_installed", return_value=True),
             patch("app.server_agent.bootout_loaded_agent") as bootout,
             patch("app.cli.stop_local_server") as stop,

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1104,6 +1104,46 @@ class ConfigUnitTests(TestCase):
             self.assertIn("unavailable.example", str(raised.exception))
             ensure_server.assert_not_called()
 
+    def test_ensure_ready_base_url_remote_aborts_on_declined_mismatch(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from app.cli import ensure_ready_base_url
+        from app.client import ClientError, HealthStatus
+        from app.config import ServerPreferences, save_preferences
+
+        remote = HealthStatus(ok=True, version="0.9.0", commit="oldoldoldold")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            save_preferences(
+                ServerPreferences(
+                    mode="remote",
+                    base_url="https://remote.example/",
+                    local_port=None,
+                ),
+                env_path=path,
+            )
+            with (
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "newnewnewnew"),
+                ),
+                patch("app.cli.stdout_color_enabled", return_value=False),
+                patch("app.cli.ensure_local_server") as ensure_server,
+            ):
+                with self.assertRaises(ClientError) as raised:
+                    ensure_ready_base_url(
+                        environ={"XDG_CONFIG_HOME": tmp},
+                        env_path=path,
+                        allow_prompt=True,
+                        print_fn=lambda _message: None,
+                        prompt_fn=lambda _message: "",
+                    )
+            self.assertIn("Remote server version mismatch", str(raised.exception))
+            ensure_server.assert_not_called()
+
     def test_ensure_ready_base_url_remote_retry_then_abort(self) -> None:
         import tempfile
         from pathlib import Path
@@ -2165,14 +2205,24 @@ class ConfigUnitTests(TestCase):
     def test_setup_remote_persists_verified_url(self) -> None:
         import tempfile
         from pathlib import Path
+        from unittest.mock import patch
 
         from app.cli import run_setup
+        from app.client import HealthStatus
         from app.config import load_preferences
 
+        matching = HealthStatus(ok=True, version="0.10.0", commit="abc123456789")
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "config.env"
             responses = iter(["remote", "https://remote.example/"])
-            with patch("app.cli.check_health", return_value=True):
+            with (
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=matching),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "abc123456789"),
+                ),
+            ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
                     env_path=path,
@@ -2185,6 +2235,66 @@ class ConfigUnitTests(TestCase):
             assert preferences is not None
             self.assertEqual(preferences.mode, "remote")
             self.assertEqual(preferences.base_url, "https://remote.example")
+
+    def test_setup_remote_aborts_when_mismatch_declined(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.client import ClientError, HealthStatus
+
+        remote = HealthStatus(ok=True, version="0.9.0", commit="oldoldoldold")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            responses = iter(["remote", "https://remote.example/", ""])
+            with (
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "newnewnewnew"),
+                ),
+            ):
+                with self.assertRaises(ClientError) as ctx:
+                    run_setup(
+                        prompt_fn=lambda _message: next(responses),
+                        env_path=path,
+                        print_fn=lambda _message: None,
+                    )
+            self.assertIn("Setup aborted", str(ctx.exception))
+            self.assertFalse(path.exists())
+
+    def test_setup_remote_allows_mismatch_bypass(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.client import HealthStatus
+        from app.config import load_preferences
+
+        remote = HealthStatus(ok=True, version="0.9.0", commit="oldoldoldold")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            responses = iter(["remote", "https://remote.example/", "y"])
+            with (
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=remote),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "newnewnewnew"),
+                ),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    env_path=path,
+                    print_fn=lambda _message: None,
+                )
+            self.assertEqual(result, "https://remote.example")
+            preferences = load_preferences(environ={}, env_path=path)
+            assert preferences is not None
+            self.assertEqual(preferences.mode, "remote")
 
     @patch("app.cli.resolve_shortcut")
     @patch("app.cli.fetch_key_entries")
@@ -2513,6 +2623,54 @@ class ConfigUnitTests(TestCase):
             )
         resolve.assert_not_called()
         assess.assert_called_once_with(base_url="http://127.0.0.1:8765")
+
+    def test_report_post_upgrade_coherence_remote_mismatch(self) -> None:
+        from unittest.mock import patch
+
+        from app.cli import _report_post_upgrade_coherence
+        from app.client import HealthStatus
+        from app.config import ServerPreferences
+        from app.theme import Theme
+
+        remote = HealthStatus(ok=True, version="0.9.0", commit="oldoldoldold")
+        preferences = ServerPreferences(
+            mode="remote",
+            base_url="https://remote.example/",
+            local_port=None,
+        )
+        messages: list[str] = []
+        with (
+            patch("app.cli.load_preferences", return_value=preferences),
+            patch("app.cli.fetch_health", return_value=remote),
+            patch("app.cli.assess_local_coherence") as assess,
+        ):
+            _report_post_upgrade_coherence(
+                print_fn=messages.append,
+                theme=Theme(enabled=False),
+                refresh_launch_agents=True,
+                upgraded_build="0.10.0 (newnewnewnew)",
+            )
+        assess.assert_not_called()
+        joined = "\n".join(messages)
+        self.assertIn("Remote server is 0.9.0 (oldoldoldold)", joined)
+        self.assertIn("this Mac is 0.10.0 (newnewnewnew)", joined)
+
+    def test_report_post_upgrade_coherence_skips_malformed_build_label(self) -> None:
+        from unittest.mock import patch
+
+        from app.cli import _report_post_upgrade_coherence
+        from app.theme import Theme
+
+        messages: list[str] = []
+        with patch("app.cli.assess_local_coherence") as assess:
+            _report_post_upgrade_coherence(
+                print_fn=messages.append,
+                theme=Theme(enabled=False),
+                refresh_launch_agents=True,
+                upgraded_build="0.10.0 without parens",
+            )
+        assess.assert_not_called()
+        self.assertIn("skipping version coherence checks", "\n".join(messages))
 
     def test_ensure_local_spotty_after_setup_warns_when_still_mismatched(self) -> None:
         from unittest.mock import patch

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -2440,6 +2440,10 @@ class ConfigUnitTests(TestCase):
             patch("app.cli.assess_local_coherence", return_value=report),
             patch("app.cli.get_build_info", return_value=("0.9.0", "oldoldoldold")),
             patch("app.cli.ensure_local_spotty_aligned", return_value=True) as spotty,
+            patch(
+                "app.cli.running_spotty_commit",
+                return_value=(True, "newnewnewnew"),
+            ),
         ):
             _report_post_upgrade_coherence(
                 print_fn=messages.append,
@@ -2449,8 +2453,66 @@ class ConfigUnitTests(TestCase):
             )
         joined = "\n".join(messages)
         self.assertNotIn("Local server is", joined)
-        spotty.assert_called_once_with(force_restart=True, print_fn=messages.append)
+        spotty.assert_called_once_with(
+            cli_commit="newnewnewnew",
+            force_restart=True,
+            print_fn=messages.append,
+        )
         self.assertIn("Spotty Bunny restarted", joined)
+
+    def test_report_post_upgrade_coherence_skips_when_build_unreadable(self) -> None:
+        from unittest.mock import patch
+
+        from app.cli import _report_post_upgrade_coherence
+        from app.theme import Theme
+
+        messages: list[str] = []
+        with patch("app.cli.assess_local_coherence") as assess:
+            _report_post_upgrade_coherence(
+                print_fn=messages.append,
+                theme=Theme(enabled=False),
+                refresh_launch_agents=True,
+                upgraded_build=None,
+            )
+        assess.assert_not_called()
+        self.assertIn("skipping version coherence checks", "\n".join(messages))
+
+    def test_report_post_upgrade_coherence_uses_preferences_base_url(self) -> None:
+        from unittest.mock import patch
+
+        from app.cli import _report_post_upgrade_coherence
+        from app.client import HealthStatus
+        from app.coherence import LocalCoherenceReport
+        from app.config import ServerPreferences
+        from app.theme import Theme
+
+        server = HealthStatus(ok=True, version="0.10.0", commit="newnewnewnew")
+        report = LocalCoherenceReport(
+            local_commit="oldoldoldold",
+            local_version="0.9.0",
+            server=server,
+            spotty_commit="newnewnewnew",
+            spotty_running=False,
+        )
+        preferences = ServerPreferences(
+            mode="local",
+            base_url="http://127.0.0.1:8765",
+            local_port=8765,
+        )
+        with (
+            patch("app.cli.sys.platform", "darwin"),
+            patch("app.cli.load_preferences", return_value=preferences),
+            patch("app.cli.resolve_base_url") as resolve,
+            patch("app.cli.assess_local_coherence", return_value=report) as assess,
+        ):
+            _report_post_upgrade_coherence(
+                print_fn=lambda _line: None,
+                theme=Theme(enabled=False),
+                refresh_launch_agents=False,
+                upgraded_build="0.10.0 (newnewnewnew)",
+            )
+        resolve.assert_not_called()
+        assess.assert_called_once_with(base_url="http://127.0.0.1:8765")
 
     def test_ensure_local_spotty_after_setup_warns_when_still_mismatched(self) -> None:
         from unittest.mock import patch

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -745,14 +745,20 @@ class CliUnitTests(TestCase):
 
 class ConfigUnitTests(TestCase):
     def setUp(self) -> None:
-        self._spotty_setup_patch = patch(
-            "app.cli._ensure_local_spotty_after_setup",
-            return_value=None,
+        self._spotty_installed_patch = patch(
+            "app.spotty_bunny_agent.is_agent_installed",
+            return_value=False,
         )
-        self._spotty_setup_patch.start()
+        self._spotty_running_patch = patch(
+            "app.spotty_bunny_launch.spotty_bunny_is_running",
+            return_value=False,
+        )
+        self._spotty_installed_patch.start()
+        self._spotty_running_patch.start()
 
     def tearDown(self) -> None:
-        self._spotty_setup_patch.stop()
+        self._spotty_running_patch.stop()
+        self._spotty_installed_patch.stop()
 
     def test_config_dir_respects_xdg_config_home(self) -> None:
         import tempfile
@@ -2409,6 +2415,91 @@ class ConfigUnitTests(TestCase):
         server_only.assert_called_once()
         spotty_installed.assert_not_called()
         spotty_upgrade.assert_not_called()
+
+    def test_report_post_upgrade_coherence_uses_upgraded_build_label(self) -> None:
+        from unittest.mock import patch
+
+        from app.cli import _report_post_upgrade_coherence
+        from app.client import HealthStatus
+        from app.coherence import LocalCoherenceReport
+        from app.theme import Theme
+
+        server = HealthStatus(ok=True, version="0.10.0", commit="newnewnewnew")
+        report = LocalCoherenceReport(
+            local_commit="oldoldoldold",
+            local_version="0.9.0",
+            server=server,
+            spotty_commit="oldspotty1",
+            spotty_running=True,
+        )
+        messages: list[str] = []
+        with (
+            patch("app.cli.sys.platform", "darwin"),
+            patch("app.cli.load_preferences", return_value=None),
+            patch("app.cli.resolve_base_url", return_value="http://127.0.0.1:8000"),
+            patch("app.cli.assess_local_coherence", return_value=report),
+            patch("app.cli.get_build_info", return_value=("0.9.0", "oldoldoldold")),
+            patch("app.cli.ensure_local_spotty_aligned", return_value=True) as spotty,
+        ):
+            _report_post_upgrade_coherence(
+                print_fn=messages.append,
+                theme=Theme(enabled=False),
+                refresh_launch_agents=True,
+                upgraded_build="0.10.0 (newnewnewnew)",
+            )
+        joined = "\n".join(messages)
+        self.assertNotIn("Local server is", joined)
+        spotty.assert_called_once_with(force_restart=True, print_fn=messages.append)
+        self.assertIn("Spotty Bunny restarted", joined)
+
+    def test_ensure_local_spotty_after_setup_warns_when_still_mismatched(self) -> None:
+        from unittest.mock import patch
+
+        from app.cli import _ensure_local_spotty_after_setup
+        from app.theme import Theme
+
+        messages: list[str] = []
+        with (
+            patch("app.cli.sys.platform", "darwin"),
+            patch("app.spotty_bunny_agent.is_agent_installed", return_value=True),
+            patch("app.spotty_bunny_launch.spotty_bunny_is_running", return_value=True),
+            patch("app.cli.ensure_local_spotty_aligned"),
+            patch("app.cli.running_spotty_commit", return_value=(True, "oldspotty1")),
+            patch("app.cli.get_build_info", return_value=("0.10.0", "newnewnewnew")),
+        ):
+            _ensure_local_spotty_after_setup(
+                print_fn=messages.append,
+                prompt_fn=lambda _message: "n",
+                theme=Theme(enabled=False),
+            )
+        joined = "\n".join(messages)
+        self.assertIn("still running an older build", joined)
+        self.assertNotIn("✓ Spotty Bunny is running", joined)
+
+    def test_ensure_local_spotty_after_setup_ok_when_aligned(self) -> None:
+        from unittest.mock import patch
+
+        from app.cli import _ensure_local_spotty_after_setup
+        from app.theme import Theme
+
+        messages: list[str] = []
+        with (
+            patch("app.cli.sys.platform", "darwin"),
+            patch("app.spotty_bunny_agent.is_agent_installed", return_value=True),
+            patch("app.spotty_bunny_launch.spotty_bunny_is_running", return_value=True),
+            patch("app.cli.ensure_local_spotty_aligned"),
+            patch(
+                "app.cli.running_spotty_commit",
+                return_value=(True, "newnewnewnew"),
+            ),
+            patch("app.cli.get_build_info", return_value=("0.10.0", "newnewnewnew")),
+        ):
+            _ensure_local_spotty_after_setup(
+                print_fn=messages.append,
+                prompt_fn=lambda _message: "y",
+                theme=Theme(enabled=False),
+            )
+        self.assertIn("✓ Spotty Bunny is running", "\n".join(messages))
 
     def test_ensure_local_server_for_setup_reuses_matching_build(self) -> None:
         from pathlib import Path

--- a/bookmarks/test_coherence.py
+++ b/bookmarks/test_coherence.py
@@ -1,0 +1,76 @@
+"""Tests for app.coherence."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from app.client import HealthStatus
+from app.coherence import (
+    LocalCoherenceReport,
+    assess_local_coherence,
+    builds_match,
+    offer_remote_build_mismatch,
+)
+from app.theme import Theme
+
+BUILD_INFO = ("1.0.0", "abc123456789")
+NEW_BUILD = ("0.10.0", "newnewnewnew")
+OLD_BUILD = ("0.9.0", "oldoldoldold")
+
+
+class BuildsMatchTests(unittest.TestCase):
+    def test_builds_match_requires_version_and_commit(self) -> None:
+        health = HealthStatus(ok=True, version="1.0.0", commit="abc123456789")
+        with patch("app.coherence.get_build_info", return_value=BUILD_INFO):
+            self.assertTrue(builds_match(health))
+
+    def test_builds_match_false_when_commit_differs(self) -> None:
+        health = HealthStatus(ok=True, version="0.10.0", commit="oldoldoldold")
+        with patch("app.coherence.get_build_info", return_value=NEW_BUILD):
+            self.assertFalse(builds_match(health))
+
+
+class OfferRemoteBuildMismatchTests(unittest.TestCase):
+    def test_skips_when_builds_match(self) -> None:
+        health = HealthStatus(ok=True, version="1.0.0", commit="abc123456789")
+        with patch("app.coherence.get_build_info", return_value=BUILD_INFO):
+            allowed = offer_remote_build_mismatch(
+                lambda _message: "n",
+                base_url="http://127.0.0.1:8000",
+                health=health,
+                print_fn=lambda _line: None,
+                theme=Theme(enabled=False),
+            )
+        self.assertTrue(allowed)
+
+    def test_decline_mismatch_aborts(self) -> None:
+        health = HealthStatus(ok=True, version="0.9.0", commit="oldoldoldold")
+        with patch("app.coherence.get_build_info", return_value=NEW_BUILD):
+            allowed = offer_remote_build_mismatch(
+                lambda _message: "",
+                base_url="https://remote.example/",
+                health=health,
+                print_fn=lambda _line: None,
+                theme=Theme(enabled=False),
+            )
+        self.assertFalse(allowed)
+
+
+class AssessLocalCoherenceTests(unittest.TestCase):
+    def test_report_marks_spotty_skew(self) -> None:
+        health = HealthStatus(ok=True, version="0.10.0", commit="servercommit1")
+        with (
+            patch("app.coherence.fetch_health", return_value=health),
+            patch(
+                "app.coherence.get_build_info",
+                return_value=("0.10.0", "localcommit1"),
+            ),
+            patch(
+                "app.coherence._spotty_runtime_commit",
+                return_value=(True, "oldspotty1"),
+            ),
+        ):
+            report = assess_local_coherence(base_url="http://127.0.0.1:8000")
+        self.assertIsInstance(report, LocalCoherenceReport)
+        self.assertFalse(report.coherent)

--- a/bookmarks/test_coherence.py
+++ b/bookmarks/test_coherence.py
@@ -73,7 +73,7 @@ class OfferRemoteBuildMismatchTests(unittest.TestCase):
 
 class AssessLocalCoherenceTests(unittest.TestCase):
     def test_report_marks_spotty_skew(self) -> None:
-        health = HealthStatus(ok=True, version="0.10.0", commit="servercommit1")
+        health = HealthStatus(ok=True, version="0.10.0", commit="localcommit1")
         with (
             patch("app.coherence.fetch_health", return_value=health),
             patch(
@@ -88,3 +88,4 @@ class AssessLocalCoherenceTests(unittest.TestCase):
             report = assess_local_coherence(base_url="http://127.0.0.1:8000")
         self.assertIsInstance(report, LocalCoherenceReport)
         self.assertFalse(report.coherent)
+        self.assertEqual(report.spotty_commit, "oldspotty1")

--- a/bookmarks/test_coherence.py
+++ b/bookmarks/test_coherence.py
@@ -70,6 +70,22 @@ class OfferRemoteBuildMismatchTests(unittest.TestCase):
             )
         self.assertFalse(allowed)
 
+    def test_prompts_for_versionless_remote(self) -> None:
+        health = HealthStatus(ok=True, version=None, commit=None)
+        messages: list[str] = []
+        with patch("app.coherence.get_build_info", return_value=NEW_BUILD):
+            allowed = offer_remote_build_mismatch(
+                lambda _message: "y",
+                base_url="https://remote.example/",
+                health=health,
+                print_fn=messages.append,
+                theme=Theme(enabled=False),
+            )
+        self.assertTrue(allowed)
+        joined = "\n".join(messages)
+        self.assertIn("unknown build", joined)
+        self.assertIn("older release without build reporting", joined)
+
 
 class AssessLocalCoherenceTests(unittest.TestCase):
     def test_report_marks_spotty_skew(self) -> None:

--- a/bookmarks/test_coherence.py
+++ b/bookmarks/test_coherence.py
@@ -11,12 +11,26 @@ from app.coherence import (
     assess_local_coherence,
     builds_match,
     offer_remote_build_mismatch,
+    parse_build_label,
 )
 from app.theme import Theme
 
 BUILD_INFO = ("1.0.0", "abc123456789")
 NEW_BUILD = ("0.10.0", "newnewnewnew")
 OLD_BUILD = ("0.9.0", "oldoldoldold")
+
+
+class ParseBuildLabelTests(unittest.TestCase):
+    def test_parse_build_label_extracts_version_and_commit(self) -> None:
+        self.assertEqual(
+            parse_build_label("0.10.0 (abc123456789)"),
+            ("0.10.0", "abc123456789"),
+        )
+
+    def test_parse_build_label_rejects_malformed(self) -> None:
+        self.assertIsNone(parse_build_label("0.10.0"))
+        self.assertIsNone(parse_build_label(""))
+        self.assertIsNone(parse_build_label("0.10.0 (missing paren"))
 
 
 class BuildsMatchTests(unittest.TestCase):

--- a/bookmarks/test_server_agent.py
+++ b/bookmarks/test_server_agent.py
@@ -413,6 +413,35 @@ class ServerAgentTests(SimpleTestCase):
         self.assertEqual(code, 0)
         run.assert_called_once_with("install", ["--port", "8000"])
 
+    def test_wait_for_managed_health_accepts_port_file_match(self) -> None:
+        from app.server_agent import _wait_for_managed_health
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            port_file = pid_dir / ".bunnify.port"
+            port_file.write_text("8123", encoding="utf-8")
+            with (
+                patch("app.server_agent.check_health", return_value=True),
+                patch("app.server_agent._port_served_by_pid_dir", return_value=False),
+                patch("app.server_agent.time.sleep"),
+            ):
+                healthy = _wait_for_managed_health(
+                    "http://127.0.0.1:8123",
+                    pid_dir=pid_dir,
+                    port=8123,
+                    timeout_s=1.0,
+                )
+        self.assertTrue(healthy)
+
+    def test_managed_port_file_matches_reads_recorded_port(self) -> None:
+        from app.server_agent import _managed_port_file_matches
+
+        with TemporaryDirectory() as tmp:
+            port_file = Path(tmp) / ".bunnify.port"
+            port_file.write_text("8123\n", encoding="utf-8")
+            self.assertTrue(_managed_port_file_matches(port_file, 8123))
+            self.assertFalse(_managed_port_file_matches(port_file, 9000))
+
 
 class _FakeLaunchctl:
     def __init__(self) -> None:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -434,7 +434,10 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             }
             with (
                 patch("app.spotty_bunny_about_info.fetch_health", return_value=health),
-                patch("app.spotty_bunny_about_info.builds_match", return_value=False),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "newnewnewnew"),
+                ),
             ):
                 info = load_about_runtime_info(
                     environ=env,
@@ -442,6 +445,36 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
                 )
             self.assertTrue(info.server_skewed)
             self.assertEqual(info.server_build_label, "0.9.0 (oldoldoldold)")
+
+    def test_load_about_runtime_info_no_skew_when_builds_match(self) -> None:
+        from unittest.mock import patch
+
+        from app.client import HealthStatus
+        from app.spotty_bunny_about_info import load_about_runtime_info
+
+        health = HealthStatus(ok=True, version="0.10.0", commit="newnewnewnew")
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bookmarks = root / "bookmarks.json"
+            bookmarks.write_text("{}", encoding="utf-8")
+            env = {
+                "BUNNIFY_BASE_URL": "http://127.0.0.1:8000",
+                "BUNNIFY_BOOKMARKS": str(bookmarks),
+                "BUNNIFY_MODE": "local",
+                "XDG_CONFIG_HOME": str(root / "cfg"),
+            }
+            with (
+                patch("app.spotty_bunny_about_info.fetch_health", return_value=health),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "newnewnewnew"),
+                ),
+            ):
+                info = load_about_runtime_info(
+                    environ=env,
+                    origin_url_for=lambda _workdir: None,
+                )
+            self.assertFalse(info.server_skewed)
 
     def test_load_about_runtime_info_remote_server_and_github(self) -> None:
         from app.spotty_bunny_about_info import load_about_runtime_info

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -2488,6 +2488,52 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 "4242\nnewcommit9\n",
             )
 
+    def test_ensure_spotty_bunny_running_force_restart_matching_commit(
+        self,
+    ) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        spawned: list[int] = []
+
+        def spawn(_cmd: object) -> int:
+            spawned.append(5151)
+            return 5151
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            (pid_dir / SPOTTY_BUNNY_PID_FILE).write_text(
+                "4242\nsamecommit\n",
+                encoding="utf-8",
+            )
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch.git_commit",
+                    return_value="samecommit",
+                ),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+                patch("app.spotty_bunny_launch.stop_spotty_bunny") as stop,
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        force_restart=True,
+                        pid_dir=pid_dir,
+                        spawn=spawn,
+                    )
+                )
+            stop.assert_called_once_with(pid_dir=pid_dir)
+            self.assertEqual(spawned, [5151])
+            self.assertEqual(
+                (pid_dir / SPOTTY_BUNNY_PID_FILE).read_text(encoding="utf-8"),
+                "5151\nsamecommit\n",
+            )
+
     def test_ensure_spotty_bunny_running_keeps_mismatch_when_declined(
         self,
     ) -> None:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -415,6 +415,34 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             )
             self.assertEqual(info.server_url, "http://127.0.0.1:9000")
 
+    def test_load_about_runtime_info_marks_server_skew(self) -> None:
+        from unittest.mock import patch
+
+        from app.client import HealthStatus
+        from app.spotty_bunny_about_info import load_about_runtime_info
+
+        health = HealthStatus(ok=True, version="0.9.0", commit="oldoldoldold")
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bookmarks = root / "bookmarks.json"
+            bookmarks.write_text("{}", encoding="utf-8")
+            env = {
+                "BUNNIFY_BASE_URL": "http://127.0.0.1:8000",
+                "BUNNIFY_BOOKMARKS": str(bookmarks),
+                "BUNNIFY_MODE": "local",
+                "XDG_CONFIG_HOME": str(root / "cfg"),
+            }
+            with (
+                patch("app.spotty_bunny_about_info.fetch_health", return_value=health),
+                patch("app.spotty_bunny_about_info.builds_match", return_value=False),
+            ):
+                info = load_about_runtime_info(
+                    environ=env,
+                    origin_url_for=lambda _workdir: None,
+                )
+            self.assertTrue(info.server_skewed)
+            self.assertEqual(info.server_build_label, "0.9.0 (oldoldoldold)")
+
     def test_load_about_runtime_info_remote_server_and_github(self) -> None:
         from app.spotty_bunny_about_info import load_about_runtime_info
 

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -2457,6 +2457,37 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
                 "4242\nabc1234\n",
             )
 
+    def test_ensure_spotty_bunny_running_honors_cli_commit_override(self) -> None:
+        from app.spotty_bunny_launch import (
+            SPOTTY_BUNNY_PID_FILE,
+            ensure_spotty_bunny_running,
+        )
+
+        with TemporaryDirectory() as tmp:
+            pid_dir = Path(tmp)
+            with (
+                patch("app.spotty_bunny_launch.sys.platform", "darwin"),
+                patch(
+                    "app.spotty_bunny_launch.git_commit",
+                    return_value="stalecommit",
+                ),
+                patch(
+                    "app.spotty_bunny_launch._spotty_bunny_process_alive",
+                    return_value=True,
+                ),
+            ):
+                self.assertTrue(
+                    ensure_spotty_bunny_running(
+                        cli_commit="newcommit9",
+                        pid_dir=pid_dir,
+                        spawn=lambda _cmd: 4242,
+                    )
+                )
+            self.assertEqual(
+                (pid_dir / SPOTTY_BUNNY_PID_FILE).read_text(encoding="utf-8"),
+                "4242\nnewcommit9\n",
+            )
+
     def test_ensure_spotty_bunny_running_keeps_mismatch_when_declined(
         self,
     ) -> None:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -452,7 +452,9 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             bookmarks_uri="file:///Users/me/.config/bunnify/bookmarks.json",
             github_display="github.com/acme/repo",
             github_url="https://github.com/acme/repo",
+            server_build_label="0.10.0 (abc123456789)",
             server_display="Local server · http://127.0.0.1:8000",
+            server_skewed=False,
             server_url="http://127.0.0.1:8000",
         )
         text, links = about_details_text_and_links(runtime)
@@ -462,7 +464,8 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             "License: MIT License\n"
             "Bookmarks: ~/.config/bunnify/bookmarks.json\n"
             "GitHub: github.com/acme/repo\n"
-            "Local server · http://127.0.0.1:8000",
+            "Local server · http://127.0.0.1:8000\n"
+            "Server build: 0.10.0 (abc123456789)",
         )
         self.assertEqual(
             links,
@@ -481,6 +484,7 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
                 ),
                 ("github.com/acme/repo", "https://github.com/acme/repo"),
                 ("http://127.0.0.1:8000", "http://127.0.0.1:8000"),
+                ("0.10.0 (abc123456789)", "http://127.0.0.1:8000"),
             ),
         )
 


### PR DESCRIPTION
## Summary
- Add `app/coherence` for build comparison, local coherence reports, remote mismatch prompts, and forced Spotty restart after upgrade
- `bunnify upgrade` now verifies local server/Spotty alignment and restarts stale Spotty processes; remote mode warns when `/health` differs from this Mac
- Local `bunnify setup` checks Spotty when installed; Spotty About shows server build and skew warning; `bunnify-server install` accepts healthy launchd servers via port file

Closes #365

## Test plan
- [x] `./test_bunnify`
- [x] `uv run ruff check .` / `uv run pyright --warnings`
- [ ] CI green
- [ ] Manual: `bunnify upgrade` restarts Spotty without a second command
- [ ] Manual: remote setup prompts on version skew with bypass option