### PR TITLE
fix: reliably identify Bunnify's own processes (LaunchAgent detection + build marker)

### DIFF
--- a/app/process_marker.py
+++ b/app/process_marker.py
@@ -1,0 +1,97 @@
+"""Self-identifying argv marker for Bunnify's own background processes.
+
+Bunnify repeatedly has to decide whether some process it found — a port
+listener, a recorded pid — is one of its own. Inferring that from the
+executable name is fragile: launchd runs the console script behind an
+interpreter, uv and pipx install it under different paths, and unrelated
+commands can mention ``bunnify-server`` in their arguments.
+
+Every process Bunnify spawns therefore carries an explicit
+``--bunnify-build <component>:<version>+<commit>`` token, which ``ps`` reports
+verbatim. Recording the build alongside the component means the marker also
+answers *which* build a process is running, without an HTTP probe.
+
+Marker detection is an additional signal, never a replacement for the
+name-based heuristics: during an upgrade the process holding the port was
+started by an older build that predates the marker, so unmarked processes must
+still be recognized.
+"""
+
+from __future__ import annotations
+
+import shlex
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from app.version import get_build_info
+
+BUILD_MARKER_FLAG = "--bunnify-build"
+SERVER_COMPONENT = "bunnify-server"
+SPOTTY_BUNNY_COMPONENT = "spotty-bunny"
+
+
+@dataclass(frozen=True)
+class BuildMarker:
+    """A parsed ``--bunnify-build`` token."""
+
+    commit: str
+    component: str
+    version: str
+
+
+def build_marker_arguments(
+    component: str,
+    *,
+    commit: str | None = None,
+    version: str | None = None,
+) -> list[str]:
+    """Return the argv pair stamping *component* with the running build."""
+    return [
+        BUILD_MARKER_FLAG,
+        build_marker_value(component, commit=commit, version=version),
+    ]
+
+
+def build_marker_value(
+    component: str,
+    *,
+    commit: str | None = None,
+    version: str | None = None,
+) -> str:
+    """Return the ``component:version+commit`` marker value."""
+    default_version, default_commit = get_build_info()
+    resolved_version = version if version is not None else default_version
+    resolved_commit = commit if commit is not None else default_commit
+    return f"{component}:{resolved_version}+{resolved_commit}"
+
+
+def marker_from_arguments(arguments: Sequence[str]) -> BuildMarker | None:
+    """Return the build marker carried by *arguments*, if any."""
+    for index, argument in enumerate(arguments):
+        if argument == BUILD_MARKER_FLAG:
+            if index + 1 < len(arguments):
+                return parse_marker_value(arguments[index + 1])
+            return None
+        if argument.startswith(f"{BUILD_MARKER_FLAG}="):
+            return parse_marker_value(argument.split("=", 1)[1])
+    return None
+
+
+def marker_from_command(command: str) -> BuildMarker | None:
+    """Return the build marker in a ``ps`` command line, if any."""
+    try:
+        arguments = shlex.split(command)
+    except ValueError:
+        return None
+    return marker_from_arguments(arguments)
+
+
+def parse_marker_value(value: str) -> BuildMarker | None:
+    """Parse ``component:version+commit``; ``None`` when malformed."""
+    component, separator, build = value.partition(":")
+    if not separator or not component or not build:
+        return None
+    version, separator, commit = build.rpartition("+")
+    if not separator or not version or not commit:
+        return None
+    return BuildMarker(commit=commit, component=component, version=version)

--- a/app/server_agent.py
+++ b/app/server_agent.py
@@ -17,6 +17,7 @@ from xml.sax.saxutils import escape
 from app.client import check_health
 from app.config import run_dir
 from app.local_server import port_is_free, stop_local_server
+from app.process_marker import SERVER_COMPONENT, build_marker_arguments
 from app.version import build_version
 
 AGENT_COMMANDS = frozenset({"install", "status", "uninstall", "upgrade"})
@@ -103,6 +104,7 @@ def install_agent(
     agent_pid_dir.mkdir(parents=True, exist_ok=True)
     argv = [
         *program_argv,
+        *build_marker_arguments(SERVER_COMPONENT),
         "--foreground",
         "--noninteractive",
         "--port",

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -160,7 +160,11 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
 
-_PYTHON_EXECUTABLE_RE = re.compile(r"^(?:python|pypy)[0-9.]*(?:\.exe)?$", re.IGNORECASE)
+# Trailing ``[dt]`` covers ABI-flagged builds (``python3.14t`` free-threaded,
+# ``python3.14d`` debug), which uv and python.org ship for the versions we target.
+_PYTHON_EXECUTABLE_RE = re.compile(
+    r"^(?:python|pypy)[0-9.]*[dt]*(?:\.exe)?$", re.IGNORECASE
+)
 
 _PYTHON_OPTIONS_WITH_VALUE = frozenset({"--check-hash-based-pycs", "-W", "-X"})
 

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -269,20 +270,27 @@ def _initialize_database(*, bookmarks: Path, noninteractive: bool) -> None:
 def _is_bunnify_command(command: str) -> bool:
     """Return whether a ``ps`` command line belongs to a Bunnify server.
 
-    A build marker is authoritative when present. Processes started by builds
-    that predate the marker are still matched on their argv shape.
+    The executable has to look like ours before anything else is considered:
+    a mismatch here is how unrelated command lines that merely mention our
+    names or flags are rejected, and callers act on a match by signalling the
+    process. A build marker then refines that decision, ruling out a sibling
+    component. Processes started by builds that predate the marker are
+    accepted on their argv shape alone.
     """
     try:
         arguments = shlex.split(command)
     except ValueError:
         return False
+    if not _is_bunnify_executable(arguments):
+        return False
+    marker = marker_from_arguments(arguments)
+    return marker is None or marker.component == SERVER_COMPONENT
+
+
+def _is_bunnify_executable(arguments: Sequence[str]) -> bool:
+    """Return whether *arguments* launch the Bunnify server program."""
     if not arguments:
         return False
-
-    marker = marker_from_arguments(arguments)
-    if marker is not None:
-        return marker.component == SERVER_COMPONENT
-
     if Path(arguments[0]).name == "bunnify-server":
         return True
     target = _python_invocation_target(arguments)
@@ -476,7 +484,7 @@ def _process_managed_by_pid_dir(pid: int, pid_dir: Path) -> bool:
         return recorded.expanduser() == pid_dir.expanduser()
 
 
-def _python_invocation_target(arguments: list[str]) -> str | None:
+def _python_invocation_target(arguments: Sequence[str]) -> str | None:
     """Return the script path or ``-m`` module a Python command line runs.
 
     macOS LaunchAgents start the console script through the interpreter

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import re
 import shlex
 import signal
 import socket
@@ -159,6 +160,11 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
 
+_PYTHON_EXECUTABLE_RE = re.compile(r"^(?:python|pypy)[0-9.]*(?:\.exe)?$", re.IGNORECASE)
+
+_PYTHON_OPTIONS_WITH_VALUE = frozenset({"--check-hash-based-pycs", "-W", "-X"})
+
+
 def _background_command(
     options: ServerOptions,
     bookmarks: Path,
@@ -243,6 +249,7 @@ def _initialize_database(*, bookmarks: Path, noninteractive: bool) -> None:
 
 
 def _is_bunnify_command(command: str) -> bool:
+    """Return whether a ``ps`` command line belongs to a Bunnify server."""
     try:
         arguments = shlex.split(command)
     except ValueError:
@@ -250,10 +257,12 @@ def _is_bunnify_command(command: str) -> bool:
     if not arguments:
         return False
 
-    if len(arguments) >= 3 and arguments[1:3] == ["-m", "app.server_cli"]:
+    if Path(arguments[0]).name == "bunnify-server":
         return True
-    executable_names = {Path(argument).name for argument in arguments[:2]}
-    return "bunnify-server" in executable_names
+    target = _python_invocation_target(arguments)
+    if target is None:
+        return False
+    return target == "app.server_cli" or Path(target).name == "bunnify-server"
 
 
 def _is_bunnify_process(pid: int) -> bool:
@@ -439,6 +448,30 @@ def _process_managed_by_pid_dir(pid: int, pid_dir: Path) -> bool:
         return recorded.resolve() == pid_dir.expanduser().resolve()
     except OSError:
         return recorded.expanduser() == pid_dir.expanduser()
+
+
+def _python_invocation_target(arguments: list[str]) -> str | None:
+    """Return the script path or ``-m`` module a Python command line runs.
+
+    macOS LaunchAgents start the console script through the interpreter
+    (``<python> -E /path/to/bunnify-server --foreground ...``), so interpreter
+    options have to be skipped before the target becomes visible. Returns
+    ``None`` when ``arguments`` is not a Python invocation, or when it runs code
+    from ``-c`` or stdin rather than a named script or module.
+    """
+    if not arguments or not _PYTHON_EXECUTABLE_RE.match(Path(arguments[0]).name):
+        return None
+    index = 1
+    while index < len(arguments):
+        argument = arguments[index]
+        if not argument.startswith("-"):
+            return argument
+        if argument in {"-", "-c"}:
+            return None
+        if argument == "-m":
+            return arguments[index + 1] if index + 1 < len(arguments) else None
+        index += 2 if argument in _PYTHON_OPTIONS_WITH_VALUE else 1
+    return None
 
 
 def _read_pid(path: Path) -> int | None:

--- a/app/server_cli.py
+++ b/app/server_cli.py
@@ -18,6 +18,12 @@ from pathlib import Path
 
 from app.client import check_health
 from app.config import data_dir, ensure_user_bookmarks, run_dir
+from app.process_marker import (
+    BUILD_MARKER_FLAG,
+    SERVER_COMPONENT,
+    build_marker_arguments,
+    marker_from_arguments,
+)
 from app.version import build_version
 
 LOG_LEVELS = ("CRITICAL", "DEBUG", "ERROR", "INFO", "WARNING")
@@ -54,6 +60,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--bookmarks",
         type=Path,
         help="Bookmarks JSON file (default: XDG config bookmarks.json).",
+    )
+    # Stamped by the launcher so `ps` identifies this process and its build.
+    # Carries no behaviour, so it stays out of --help.
+    parser.add_argument(
+        BUILD_MARKER_FLAG,
+        default=None,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--console",
@@ -178,6 +191,7 @@ def _background_command(
         sys.executable,
         "-m",
         "app.server_cli",
+        *build_marker_arguments(SERVER_COMPONENT),
         "--bookmarks",
         str(bookmarks),
         "--foreground",
@@ -253,13 +267,21 @@ def _initialize_database(*, bookmarks: Path, noninteractive: bool) -> None:
 
 
 def _is_bunnify_command(command: str) -> bool:
-    """Return whether a ``ps`` command line belongs to a Bunnify server."""
+    """Return whether a ``ps`` command line belongs to a Bunnify server.
+
+    A build marker is authoritative when present. Processes started by builds
+    that predate the marker are still matched on their argv shape.
+    """
     try:
         arguments = shlex.split(command)
     except ValueError:
         return False
     if not arguments:
         return False
+
+    marker = marker_from_arguments(arguments)
+    if marker is not None:
+        return marker.component == SERVER_COMPONENT
 
     if Path(arguments[0]).name == "bunnify-server":
         return True

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from xml.sax.saxutils import escape
 
+from app.process_marker import SPOTTY_BUNNY_COMPONENT, build_marker_arguments
 from app.spotty_bunny_cli import (
     COMMAND_NAME,
     MACOS_EXTRA_HINT,
@@ -331,6 +332,7 @@ def spotty_bunny_program_arguments() -> list[str] | None:
             resolved.append(found if found else str(path.resolve()))
             continue
         resolved.append(part)
+    resolved.extend(build_marker_arguments(SPOTTY_BUNNY_COMPONENT))
     return resolved
 
 

--- a/app/spotty_bunny_cli.py
+++ b/app/spotty_bunny_cli.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from app.config import data_dir
+from app.process_marker import BUILD_MARKER_FLAG
 from app.spotty_bunny_launch import clear_spotty_bunny_pid, write_spotty_bunny_pid
 from app.version import build_version
 
@@ -58,6 +59,13 @@ def build_parser() -> argparse.ArgumentParser:
             "press the other to show it. Subcommands: install, uninstall, "
             "status, upgrade (login LaunchAgent). Bare invocation is foreground."
         ),
+    )
+    # Stamped by the launcher so `ps` identifies this process and its build.
+    # Carries no behaviour, so it stays out of --help.
+    parser.add_argument(
+        BUILD_MARKER_FLAG,
+        default=None,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--log-file",

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -13,6 +13,11 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from app.config import run_dir
+from app.process_marker import (
+    SPOTTY_BUNNY_COMPONENT,
+    build_marker_arguments,
+    marker_from_command,
+)
 from app.version import git_commit
 
 logger = logging.getLogger(__name__)
@@ -121,7 +126,7 @@ def ensure_spotty_bunny_running(
             )
             return False
         logger.warning("LaunchAgent install failed; falling back to spawn")
-    command = spotty_bunny_command()
+    command = spotty_bunny_launch_arguments(commit=current)
     spawn_fn = spawn or _spawn_detached
     try:
         pid = spawn_fn(command)
@@ -178,6 +183,14 @@ def spotty_bunny_is_running(*, pid_dir: Path | None = None) -> bool:
     return True
 
 
+def spotty_bunny_launch_arguments(*, commit: str | None = None) -> list[str]:
+    """Return the argv used to spawn Spotty Bunny, stamped with its build."""
+    return [
+        *spotty_bunny_command(),
+        *build_marker_arguments(SPOTTY_BUNNY_COMPONENT, commit=commit),
+    ]
+
+
 def spotty_bunny_pid_path(*, pid_dir: Path | None = None) -> Path:
     """Path to the Spotty Bunny PID file under the runtime directory."""
     directory = pid_dir if pid_dir is not None else run_dir()
@@ -214,6 +227,10 @@ def write_spotty_bunny_pid(
 
 
 def _is_spotty_bunny_command(command: str) -> bool:
+    """A build marker is authoritative; unmarked (older) builds match by name."""
+    marker = marker_from_command(command)
+    if marker is not None:
+        return marker.component == SPOTTY_BUNNY_COMPONENT
     return "spotty-bunny" in command or "spotty_bunny_cli" in command
 
 

--- a/app/spotty_bunny_launch.py
+++ b/app/spotty_bunny_launch.py
@@ -227,11 +227,11 @@ def write_spotty_bunny_pid(
 
 
 def _is_spotty_bunny_command(command: str) -> bool:
-    """A build marker is authoritative; unmarked (older) builds match by name."""
+    """Match the overlay by name, then let a build marker rule out a sibling."""
+    if "spotty-bunny" not in command and "spotty_bunny_cli" not in command:
+        return False
     marker = marker_from_command(command)
-    if marker is not None:
-        return marker.component == SPOTTY_BUNNY_COMPONENT
-    return "spotty-bunny" in command or "spotty_bunny_cli" in command
+    return marker is None or marker.component == SPOTTY_BUNNY_COMPONENT
 
 
 def _process_command(pid: int) -> str | None:

--- a/app/tests.py
+++ b/app/tests.py
@@ -593,6 +593,16 @@ LAUNCHAGENT_COMMAND = (
 
 
 class ServerProcessTests(SimpleTestCase):
+    def test_accepts_abi_flagged_interpreters(self) -> None:
+        for interpreter in ("python3.14t", "python3.14d", "python3.14td", "pypy3"):
+            with self.subTest(interpreter=interpreter):
+                self.assertTrue(
+                    _is_bunnify_command(
+                        f"/tmp/venv/bin/{interpreter} -E "
+                        "/tmp/venv/bin/bunnify-server --port 8000"
+                    )
+                )
+
     def test_accepts_bare_console_script(self) -> None:
         self.assertTrue(_is_bunnify_command("bunnify-server --port 8000"))
 

--- a/app/tests.py
+++ b/app/tests.py
@@ -584,7 +584,18 @@ class ServerStopTests(SimpleTestCase):
             wait_for_port.assert_called_once_with(8123, timeout_s=15)
 
 
+LAUNCHAGENT_COMMAND = (
+    "/opt/homebrew/Cellar/python@3.14/3.14.7/Frameworks/Python.framework/Versions/"
+    "3.14/Resources/Python.app/Contents/MacOS/Python -E "
+    "/Users/tester/.local/bin/bunnify-server --foreground --noninteractive "
+    "--port 8000 --pid-dir /Users/tester/.local/share/bunnify/run/launchd"
+)
+
+
 class ServerProcessTests(SimpleTestCase):
+    def test_accepts_bare_console_script(self) -> None:
+        self.assertTrue(_is_bunnify_command("bunnify-server --port 8000"))
+
     def test_accepts_bunnify_console_script(self) -> None:
         self.assertTrue(
             _is_bunnify_command(
@@ -597,8 +608,42 @@ class ServerProcessTests(SimpleTestCase):
             _is_bunnify_command("/tmp/venv/bin/python -m app.server_cli --port 8000")
         )
 
+    def test_accepts_interpreter_option_taking_a_value(self) -> None:
+        self.assertTrue(
+            _is_bunnify_command(
+                "/usr/bin/python3 -X importtime -W ignore "
+                "/tmp/venv/bin/bunnify-server --port 8000"
+            )
+        )
+
+    def test_accepts_launchagent_interpreter_invocation(self) -> None:
+        self.assertTrue(_is_bunnify_command(LAUNCHAGENT_COMMAND))
+
+    def test_launchagent_process_is_managed_by_its_pid_dir(self) -> None:
+        from app.server_cli import _process_managed_by_pid_dir
+
+        launchd_dir = Path("/Users/tester/.local/share/bunnify/run/launchd")
+        with mock.patch(
+            "app.server_cli._process_command",
+            return_value=LAUNCHAGENT_COMMAND,
+        ):
+            self.assertTrue(_process_managed_by_pid_dir(1, launchd_dir))
+            self.assertFalse(
+                _process_managed_by_pid_dir(1, Path("/Users/tester/other-run"))
+            )
+
     def test_rejects_command_containing_bunnify_name(self) -> None:
         self.assertFalse(_is_bunnify_command("grep -r bunnify-server ."))
+
+    def test_rejects_interpreter_inline_code(self) -> None:
+        self.assertFalse(
+            _is_bunnify_command("/usr/bin/python3 -c 'print(\"bunnify-server\")'")
+        )
+
+    def test_rejects_unrelated_python_script(self) -> None:
+        self.assertFalse(
+            _is_bunnify_command("/usr/bin/python3 -E /tmp/venv/bin/other-script")
+        )
 
 
 class SettingsDataDirTests(SimpleTestCase):

--- a/bookmarks/test_process_marker.py
+++ b/bookmarks/test_process_marker.py
@@ -1,0 +1,193 @@
+"""Tests for the self-identifying argv build marker."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from app.process_marker import (
+    BUILD_MARKER_FLAG,
+    SERVER_COMPONENT,
+    SPOTTY_BUNNY_COMPONENT,
+    build_marker_arguments,
+    build_marker_value,
+    marker_from_arguments,
+    marker_from_command,
+    parse_marker_value,
+)
+
+
+class BuildMarkerValueTests(SimpleTestCase):
+    def test_arguments_pair_flag_with_value(self) -> None:
+        self.assertEqual(
+            build_marker_arguments(SERVER_COMPONENT, commit="abc123", version="1.2.3"),
+            [BUILD_MARKER_FLAG, "bunnify-server:1.2.3+abc123"],
+        )
+
+    def test_defaults_come_from_running_build(self) -> None:
+        with mock.patch(
+            "app.process_marker.get_build_info",
+            return_value=("0.11.0", "2959c24e2afc"),
+        ):
+            self.assertEqual(
+                build_marker_value(SPOTTY_BUNNY_COMPONENT),
+                "spotty-bunny:0.11.0+2959c24e2afc",
+            )
+
+    def test_local_version_segment_keeps_commit_last(self) -> None:
+        marker = parse_marker_value("bunnify-server:1.2.3+local+abc123")
+        assert marker is not None
+        self.assertEqual(marker.version, "1.2.3+local")
+        self.assertEqual(marker.commit, "abc123")
+
+
+class MarkerParsingTests(SimpleTestCase):
+    def test_parses_attached_value_form(self) -> None:
+        marker = marker_from_arguments(
+            ["bunnify-server", f"{BUILD_MARKER_FLAG}=bunnify-server:1.2.3+abc123"]
+        )
+        assert marker is not None
+        self.assertEqual(marker.component, SERVER_COMPONENT)
+        self.assertEqual(marker.version, "1.2.3")
+
+    def test_parses_separate_value_form(self) -> None:
+        marker = marker_from_command(
+            "/usr/bin/python3 -E /opt/bin/bunnify-server "
+            f"{BUILD_MARKER_FLAG} bunnify-server:1.2.3+abc123 --port 8000"
+        )
+        assert marker is not None
+        self.assertEqual(marker.commit, "abc123")
+        self.assertEqual(marker.component, SERVER_COMPONENT)
+
+    def test_returns_none_for_absent_or_malformed_markers(self) -> None:
+        cases = (
+            "bunnify-server --port 8000",
+            f"bunnify-server {BUILD_MARKER_FLAG}",
+            f"bunnify-server {BUILD_MARKER_FLAG} nocolon",
+            f"bunnify-server {BUILD_MARKER_FLAG} missing-build:",
+            f"bunnify-server {BUILD_MARKER_FLAG} bunnify-server:1.2.3",
+            f"bunnify-server {BUILD_MARKER_FLAG} :1.2.3+abc123",
+        )
+        for command in cases:
+            with self.subTest(command=command):
+                self.assertIsNone(marker_from_command(command))
+
+    def test_returns_none_for_unparsable_command(self) -> None:
+        self.assertIsNone(marker_from_command("bunnify-server --bookmarks 'unclosed"))
+
+
+class MarkerDetectionTests(SimpleTestCase):
+    def test_marked_server_is_detected_behind_an_opaque_launcher(self) -> None:
+        from app.server_cli import _is_bunnify_command
+
+        self.assertTrue(
+            _is_bunnify_command(
+                "/opt/some-wrapper --exec "
+                f"{BUILD_MARKER_FLAG} bunnify-server:1.2.3+abc123"
+            )
+        )
+
+    def test_marker_distinguishes_components(self) -> None:
+        from app.server_cli import _is_bunnify_command
+        from app.spotty_bunny_launch import _is_spotty_bunny_command
+
+        server = f"/opt/bin/bunnify-server {BUILD_MARKER_FLAG} bunnify-server:1+abc123"
+        spotty = f"/opt/bin/spotty-bunny {BUILD_MARKER_FLAG} spotty-bunny:1+abc123"
+
+        self.assertTrue(_is_bunnify_command(server))
+        self.assertFalse(_is_bunnify_command(spotty))
+        self.assertTrue(_is_spotty_bunny_command(spotty))
+        self.assertFalse(_is_spotty_bunny_command(server))
+
+    def test_unmarked_legacy_processes_still_match_by_shape(self) -> None:
+        from app.server_cli import _is_bunnify_command
+        from app.spotty_bunny_launch import _is_spotty_bunny_command
+
+        self.assertTrue(
+            _is_bunnify_command("/usr/bin/python3 -E /opt/bin/bunnify-server --port 1")
+        )
+        self.assertTrue(_is_spotty_bunny_command("/opt/bin/spotty-bunny"))
+
+
+class MarkerStampingTests(SimpleTestCase):
+    def test_background_server_command_is_stamped(self) -> None:
+        from pathlib import Path
+
+        from app.server_cli import ServerOptions, _background_command
+
+        options = ServerOptions(
+            bookmarks=None,
+            console=False,
+            foreground=False,
+            listen_all=False,
+            log_file=Path("/tmp/bunnify.log"),
+            log_level="INFO",
+            noninteractive=True,
+            pid_dir=Path("/tmp/run"),
+            port=8000,
+            port_timeout_s=5.0,
+            replace_on_port=None,
+            stop=False,
+        )
+        command = _background_command(options, Path("/tmp/bookmarks.json"), 8000)
+
+        self.assertIn(BUILD_MARKER_FLAG, command)
+        marker = marker_from_arguments(command)
+        assert marker is not None
+        self.assertEqual(marker.component, SERVER_COMPONENT)
+
+    def test_background_server_command_parses_back_into_the_server_cli(self) -> None:
+        from pathlib import Path
+
+        from app.server_cli import ServerOptions, _background_command, build_parser
+
+        options = ServerOptions(
+            bookmarks=None,
+            console=False,
+            foreground=False,
+            listen_all=False,
+            log_file=Path("/tmp/bunnify.log"),
+            log_level="INFO",
+            noninteractive=True,
+            pid_dir=Path("/tmp/run"),
+            port=8000,
+            port_timeout_s=5.0,
+            replace_on_port=None,
+            stop=False,
+        )
+        command = _background_command(options, Path("/tmp/bookmarks.json"), 8000)
+
+        namespace = build_parser().parse_args(command[3:])
+        self.assertEqual(namespace.port, 8000)
+
+    def test_spotty_bunny_launch_arguments_are_stamped(self) -> None:
+        from app.spotty_bunny_launch import spotty_bunny_launch_arguments
+
+        arguments = spotty_bunny_launch_arguments(commit="abc123")
+        marker = marker_from_arguments(arguments)
+        assert marker is not None
+        self.assertEqual(marker.commit, "abc123")
+        self.assertEqual(marker.component, SPOTTY_BUNNY_COMPONENT)
+
+    def test_spotty_bunny_launch_arguments_parse_back_into_the_cli(self) -> None:
+        from app.spotty_bunny_cli import build_parser
+        from app.spotty_bunny_launch import spotty_bunny_launch_arguments
+
+        arguments = spotty_bunny_launch_arguments(commit="abc123")
+        namespace = build_parser().parse_args(arguments[1:])
+        self.assertEqual(namespace.log_level, "INFO")
+
+    def test_spotty_bunny_plist_arguments_are_stamped(self) -> None:
+        from app.spotty_bunny_agent import spotty_bunny_program_arguments
+
+        with mock.patch(
+            "app.spotty_bunny_agent.spotty_bunny_command",
+            return_value=["/opt/bin/spotty-bunny"],
+        ):
+            arguments = spotty_bunny_program_arguments()
+
+        assert arguments is not None
+        marker = marker_from_arguments(arguments)
+        assert marker is not None
+        self.assertEqual(marker.component, SPOTTY_BUNNY_COMPONENT)

--- a/bookmarks/test_process_marker.py
+++ b/bookmarks/test_process_marker.py
@@ -177,18 +177,41 @@ class MarkerStampingTests(SimpleTestCase):
     def test_spotty_bunny_launch_arguments_are_stamped(self) -> None:
         from app.spotty_bunny_launch import spotty_bunny_launch_arguments
 
-        arguments = spotty_bunny_launch_arguments(commit="abc123")
+        with mock.patch(
+            "app.spotty_bunny_launch.spotty_bunny_command",
+            return_value=["/opt/bin/spotty-bunny"],
+        ):
+            arguments = spotty_bunny_launch_arguments(commit="abc123")
         marker = marker_from_arguments(arguments)
         assert marker is not None
         self.assertEqual(marker.commit, "abc123")
         self.assertEqual(marker.component, SPOTTY_BUNNY_COMPONENT)
 
     def test_spotty_bunny_launch_arguments_parse_back_into_the_cli(self) -> None:
+        """Pin the console-script form; the fallback prepends ``-m <module>``."""
         from app.spotty_bunny_cli import build_parser
         from app.spotty_bunny_launch import spotty_bunny_launch_arguments
 
-        arguments = spotty_bunny_launch_arguments(commit="abc123")
+        with mock.patch(
+            "app.spotty_bunny_launch.spotty_bunny_command",
+            return_value=["/opt/bin/spotty-bunny"],
+        ):
+            arguments = spotty_bunny_launch_arguments(commit="abc123")
         namespace = build_parser().parse_args(arguments[1:])
+        self.assertEqual(namespace.log_level, "INFO")
+
+    def test_spotty_bunny_module_fallback_arguments_parse_back_into_the_cli(
+        self,
+    ) -> None:
+        from app.spotty_bunny_cli import build_parser
+        from app.spotty_bunny_launch import spotty_bunny_launch_arguments
+
+        with mock.patch(
+            "app.spotty_bunny_launch.spotty_bunny_command",
+            return_value=["/usr/bin/python3", "-m", "app.spotty_bunny_cli"],
+        ):
+            arguments = spotty_bunny_launch_arguments(commit="abc123")
+        namespace = build_parser().parse_args(arguments[3:])
         self.assertEqual(namespace.log_level, "INFO")
 
     def test_spotty_bunny_plist_arguments_are_stamped(self) -> None:

--- a/bookmarks/test_process_marker.py
+++ b/bookmarks/test_process_marker.py
@@ -78,15 +78,18 @@ class MarkerParsingTests(SimpleTestCase):
 
 
 class MarkerDetectionTests(SimpleTestCase):
-    def test_marked_server_is_detected_behind_an_opaque_launcher(self) -> None:
+    def test_marker_alone_cannot_promote_an_unrelated_command(self) -> None:
+        """A match authorizes signalling the process, so the executable gates it."""
         from app.server_cli import _is_bunnify_command
 
-        self.assertTrue(
-            _is_bunnify_command(
-                "/opt/some-wrapper --exec "
-                f"{BUILD_MARKER_FLAG} bunnify-server:1.2.3+abc123"
-            )
+        cases = (
+            f"grep -r {BUILD_MARKER_FLAG} bunnify-server:1.0+abc123 .",
+            f"/opt/some-wrapper --exec {BUILD_MARKER_FLAG} bunnify-server:1.0+abc123",
+            f"sh -c 'echo {BUILD_MARKER_FLAG} bunnify-server:1.0+abc123'",
         )
+        for command in cases:
+            with self.subTest(command=command):
+                self.assertFalse(_is_bunnify_command(command))
 
     def test_marker_distinguishes_components(self) -> None:
         from app.server_cli import _is_bunnify_command
@@ -99,6 +102,16 @@ class MarkerDetectionTests(SimpleTestCase):
         self.assertFalse(_is_bunnify_command(spotty))
         self.assertTrue(_is_spotty_bunny_command(spotty))
         self.assertFalse(_is_spotty_bunny_command(server))
+
+    def test_marker_rules_out_a_sibling_component_on_a_matching_shape(self) -> None:
+        from app.server_cli import _is_bunnify_command
+
+        self.assertFalse(
+            _is_bunnify_command(
+                "/usr/bin/python3 -E /opt/bin/bunnify-server "
+                f"{BUILD_MARKER_FLAG} spotty-bunny:1.0+abc123"
+            )
+        )
 
     def test_unmarked_legacy_processes_still_match_by_shape(self) -> None:
         from app.server_cli import _is_bunnify_command

--- a/bookmarks/test_server_agent.py
+++ b/bookmarks/test_server_agent.py
@@ -130,6 +130,49 @@ class ServerAgentTests(SimpleTestCase):
             self.assertIn("--bookmarks", text)
             self.assertIn(str(bookmarks.resolve()), text)
 
+    def test_install_stamps_build_marker_into_plist(self) -> None:
+        from app.process_marker import BUILD_MARKER_FLAG, marker_from_arguments
+        from app.server_agent import (
+            AGENT_LABEL,
+            _plist_program_arguments,
+            install_agent,
+        )
+
+        ctl = _FakeLaunchctl()
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            program = home / "bin" / "bunnify-server"
+            _write_executable(program)
+            pid_dir = home / "run" / "launchd"
+            with (
+                patch("app.server_agent.stop_local_server"),
+                patch("app.server_agent.port_is_free", return_value=False),
+                patch("app.server_agent.check_health", return_value=True),
+                patch(
+                    "app.server_agent._port_served_by_pid_dir",
+                    side_effect=lambda port, pid_dir: pid_dir.name == "launchd",
+                ),
+            ):
+                code = install_agent(
+                    home=home,
+                    launchctl=ctl,
+                    pid_dir=pid_dir,
+                    platform="darwin",
+                    port=8123,
+                    print_err=lambda _m: None,
+                    program=program,
+                    timeout_s=1,
+                )
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            self.assertEqual(code, 0)
+            self.assertIn(BUILD_MARKER_FLAG, plist.read_text(encoding="utf-8"))
+
+            argv = _plist_program_arguments(plist)
+            assert argv is not None
+            marker = marker_from_arguments(argv)
+            assert marker is not None
+            self.assertEqual(marker.component, "bunnify-server")
+
     def test_install_rejects_non_darwin(self) -> None:
         from app.server_agent import install_agent
 


### PR DESCRIPTION
Fixes #368

## Summary

`bunnify-server upgrade` (and the LaunchAgent refresh inside `bunnify upgrade`) aborted on macOS with:

```
bunnify-server: port 8000 is held by another Bunnify server (not managed under
~/.local/share/bunnify/run or ~/.local/share/bunnify/run/launchd).
```

…even though the listener *was* the Bunnify LaunchAgent that command manages. The upgrade bailed out, leaving the server on the old build while the CLI and Spotty Bunny advanced — exactly the skew #365 set out to eliminate.

`_is_bunnify_command` only inspected the first two argv entries:

```python
executable_names = {Path(argument).name for argument in arguments[:2]}
return "bunnify-server" in executable_names
```

The LaunchAgent starts the console script through the interpreter with `-E`, so `bunnify-server` lands at index 2 and never matched. `_process_managed_by_pid_dir` then reported the agent's own listener as foreign, and `_port_served_by_pid_dir` failed the port check in `install_agent`.

## Part 1 — parse the interpreter invocation

`_python_invocation_target` skips Python options (including `-W` / `-X` / `--check-hash-based-pycs`, which consume a following value) and returns the script path or `-m` module actually executed. `_is_bunnify_executable` matches a `bunnify-server` basename or the `app.server_cli` module.

Requiring a Python-looking `argv[0]` keeps unrelated command lines out — `grep -r bunnify-server .` still returns `False`, as do `python -c ...` and unrelated scripts. The interpreter pattern accepts ABI-flagged builds (`python3.14t` free-threaded, `python3.14d` debug).

## Part 2 — self-identifying build marker

Per review discussion, name-based inference is inherently fragile. Every process Bunnify spawns now carries an explicit token that `ps` reports verbatim:

```
--bunnify-build bunnify-server:0.11.0+e60221cc67f8
```

`app/process_marker.py` owns the format and parsing. The marker is stamped at all four spawn sites — the background server (`_background_command`), the server LaunchAgent (`install_agent`), the Spotty Bunny spawn path (`spotty_bunny_launch_arguments`), and the Spotty Bunny LaunchAgent (`spotty_bunny_program_arguments`) — and both CLIs accept the flag as a no-op, hidden from `--help`.

Recording the build next to the component means the marker also answers *which* build a listener is running with no HTTP probe.

### The marker refines, it never promotes

A match authorizes signalling the process (`--replace-on-port` will SIGTERM then SIGKILL it), so the executable check gates the decision and the marker only narrows it:

```python
if not _is_bunnify_executable(arguments):
    return False
marker = marker_from_arguments(arguments)
return marker is None or marker.component == SERVER_COMPONENT
```

A command line carrying the token therefore cannot be promoted into a match — `grep -r --bunnify-build bunnify-server:1.0+x .` stays `False` — while a server-shaped argv marked `spotty-bunny` is correctly rejected. `_is_spotty_bunny_command` follows the same shape, leaving unmarked behavior identical to before this PR.

### Still additive, not a replacement

The failure in #368 happens during an upgrade, when the process holding the port was started by an *older* build that predates the marker. Unmarked processes must therefore still be recognized by argv shape, so Part 1 remains load-bearing for the current installed base.

One consequence worth recording: downgrading to a pre-marker binary without re-running install leaves a plist whose flag the older parser rejects. Both `bunnify-server install` and `bunnify-server upgrade` rewrite the plist, so recovery is a single command.

## Verification

Checked against the live LaunchAgent listener on port 8000, which returned `False` for both predicates before this change:

```
command        : /opt/homebrew/.../MacOS/Python -E ~/.local/bin/bunnify-server \
                 --foreground --noninteractive --port 8000 --pid-dir ~/.local/share/bunnify/run/launchd
is_bunnify     : True
managed launchd: True
managed rundir : False
```

The last line matters too: the process is attributed to the LaunchAgent pid dir specifically, not to any pid dir. Marker paths were checked the same way:

```
legacy launchd shape  : True
marked server         : True
marked spotty (not us): False
```

## Test plan

- [x] `bookmarks/test_process_marker.py` covers marker formatting, both `--flag value` and `--flag=value` forms, malformed and absent markers, local-version segments, component disambiguation, and the guarantee that a marker cannot promote an unrelated command line.
- [x] Round-trip tests assert the stamped argv still parses in `bunnify-server` and `spotty-bunny`, including the `-m app.spotty_bunny_cli` fallback, so the marker cannot break a real launch and the tests do not depend on console scripts being on PATH.
- [x] `app/tests.py::ServerProcessTests` covers the real LaunchAgent command shape, ABI-flagged interpreters, options taking a value, a bare console script, `-c` inline code, and an unrelated script.
- [x] `test_launchagent_process_is_managed_by_its_pid_dir` and `test_install_stamps_build_marker_into_plist` exercise the actual failing path and the plist contents.
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright --warnings` (0 errors, 0 warnings)
- [x] `./test_bunnify` (466 tests) and `./test_integration` via `scripts/checks`