### PR TITLE
fix: qualify the About panel server build-skew warning by mode

### DIFF
--- a/app/spotty_bunny_about.py
+++ b/app/spotty_bunny_about.py
@@ -43,6 +43,7 @@ from app.spotty_bunny_about_info import (
     about_version_text_and_links,
     handle_about_link_click,
     load_about_runtime_info,
+    server_skew_message,
 )
 from app.spotty_bunny_hotkey import ESCAPE_KEYCODE
 from app.spotty_bunny_update import UpdateStatus, read_cached_update_status
@@ -138,11 +139,7 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
         else f"Update available: {status.latest}"
     )
     details_text, details_links = about_details_text_and_links(runtime)
-    skew_text = (
-        "Server build differs from this Mac — align versions."
-        if runtime.server_skewed
-        else None
-    )
+    skew_text = server_skew_message(runtime)
     inner_cap = ABOUT_PANEL_MAX_WIDTH - 2.0 * ABOUT_INSET
     needed_width = max(
         _measure_text("Spotty Bunny", title_font, max_width=inner_cap)[0],
@@ -215,14 +212,20 @@ def build_about_panel(*, update: UpdateStatus | None = None) -> NSPanel:
                 ),
             )
         )
-    if runtime.server_skewed and skew_text is not None:
+    if skew_text is not None:
+        warning = skew_text
         rows.append(
             (
-                18.0,
+                max(
+                    18.0,
+                    _measure_text(warning, body_font, max_width=inner)[1]
+                    + ABOUT_CELL_PAD,
+                ),
                 lambda y, h: _label(
                     NSMakeRect(ABOUT_INSET, y, inner, h),
-                    skew_text,
+                    warning,
                     color=_srgb_color(ABOUT_WARN_RGB),
+                    wrap=True,
                 ),
             )
         )

--- a/app/spotty_bunny_about_info.py
+++ b/app/spotty_bunny_about_info.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,8 +34,10 @@ class AboutRuntimeInfo:
     bookmarks_uri: str
     github_display: str | None
     github_url: str | None
+    server_agent_installed: bool
     server_build_label: str | None
     server_display: str
+    server_mode: Literal["local", "remote"]
     server_skewed: bool
     server_url: str
 
@@ -210,8 +213,10 @@ def load_about_runtime_info(
         bookmarks_uri=bookmarks_uri,
         github_display=github_display,
         github_url=github_url,
+        server_agent_installed=_server_agent_installed(),
         server_build_label=server_build_label,
         server_display=f"{label} · {base_url}",
+        server_mode=mode,
         server_skewed=server_skewed,
         server_url=base_url,
     )
@@ -245,6 +250,28 @@ def path_from_file_uri(uri: str) -> Path | None:
     return Path(unquote(parsed.path))
 
 
+def server_skew_message(runtime: AboutRuntimeInfo) -> str | None:
+    """Return the About-panel build-skew warning, or None when aligned.
+
+    A remote server is deployed independently of this Mac, so skew there is
+    advisory. A local server is expected to track this install, so name the
+    command that realigns it.
+    """
+    if not runtime.server_skewed:
+        return None
+    if runtime.server_mode == "remote":
+        return (
+            "Remote server build differs from this Mac. Upgrading here cannot "
+            "change it; redeploy the server if features look out of date."
+        )
+    if runtime.server_agent_installed:
+        return "Local server build differs from this Mac. Run: bunnify-server upgrade"
+    return (
+        "Local server build differs from this Mac. Run: bunnify-server --stop "
+        "(the next bunnify command starts this build)."
+    )
+
+
 _GIT_REMOTE_TIMEOUT_S = 2
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
 
@@ -268,6 +295,14 @@ def _git_origin_url(workdir: Path) -> str | None:
 def _is_loopback_url(url: str) -> bool:
     host = (urlparse(url).hostname or "").lower()
     return host in _LOOPBACK_HOSTS
+
+
+def _server_agent_installed() -> bool:
+    if sys.platform != "darwin":
+        return False
+    from app.server_agent import is_agent_installed
+
+    return is_agent_installed()
 
 
 def _workdir_containing_git(path: Path) -> Path | None:

--- a/app/spotty_bunny_about_info.py
+++ b/app/spotty_bunny_about_info.py
@@ -18,6 +18,7 @@ from app.config import (
     load_preferences,
     resolve_base_url,
 )
+from app.version import get_build_info
 
 ABOUT_LICENSE = "MIT License"
 ABOUT_LICENSE_URL = "https://github.com/the-hcma/bunnify/blob/main/LICENSE"
@@ -34,6 +35,7 @@ class AboutRuntimeInfo:
     bookmarks_uri: str
     github_display: str | None
     github_url: str | None
+    local_build_label: str
     server_agent_installed: bool
     server_build_label: str | None
     server_display: str
@@ -213,6 +215,7 @@ def load_about_runtime_info(
         bookmarks_uri=bookmarks_uri,
         github_display=github_display,
         github_url=github_url,
+        local_build_label=_local_build_label(),
         server_agent_installed=_server_agent_installed(),
         server_build_label=server_build_label,
         server_display=f"{label} · {base_url}",
@@ -259,16 +262,21 @@ def server_skew_message(runtime: AboutRuntimeInfo) -> str | None:
     """
     if not runtime.server_skewed:
         return None
+    server_build = f"Server build {runtime.server_build_label or 'unknown build'}"
+    local_build = f"this Mac's {runtime.local_build_label}"
     if runtime.server_mode == "remote":
         return (
-            "Remote server build differs from this Mac. Upgrading here cannot "
-            "change it; redeploy the server if features look out of date."
+            f"{server_build} (remote) differs from {local_build}. Upgrading here "
+            "cannot change it; redeploy the server if features look out of date."
         )
     if runtime.server_agent_installed:
-        return "Local server build differs from this Mac. Run: bunnify-server upgrade"
+        return (
+            f"{server_build} (local) differs from {local_build}. "
+            "Run: bunnify-server upgrade"
+        )
     return (
-        "Local server build differs from this Mac. Run: bunnify-server --stop "
-        "(the next bunnify command starts this build)."
+        f"{server_build} (local) differs from {local_build}. "
+        "Run: bunnify-server --stop (the next bunnify command starts this build)."
     )
 
 
@@ -295,6 +303,11 @@ def _git_origin_url(workdir: Path) -> str | None:
 def _is_loopback_url(url: str) -> bool:
     host = (urlparse(url).hostname or "").lower()
     return host in _LOOPBACK_HOSTS
+
+
+def _local_build_label() -> str:
+    version, commit = get_build_info()
+    return f"{version} ({commit})"
 
 
 def _server_agent_installed() -> bool:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -441,6 +441,10 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
                     return_value=True,
                 ),
                 patch(
+                    "app.spotty_bunny_about_info.get_build_info",
+                    return_value=("0.10.0", "newnewnewnew"),
+                ),
+                patch(
                     "app.coherence.get_build_info",
                     return_value=("0.10.0", "newnewnewnew"),
                 ),
@@ -450,6 +454,7 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
                     origin_url_for=lambda _workdir: None,
                 )
             self.assertTrue(info.server_skewed)
+            self.assertEqual(info.local_build_label, "0.10.0 (newnewnewnew)")
             self.assertEqual(info.server_mode, "local")
             self.assertTrue(info.server_agent_installed)
             self.assertEqual(info.server_build_label, "0.9.0 (oldoldoldold)")
@@ -522,6 +527,7 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             bookmarks_uri="file:///Users/me/.config/bunnify/bookmarks.json",
             github_display="github.com/acme/repo",
             github_url="https://github.com/acme/repo",
+            local_build_label="0.10.0 (abc123456789)",
             server_agent_installed=False,
             server_build_label="0.10.0 (abc123456789)",
             server_display="Local server · http://127.0.0.1:8000",
@@ -612,7 +618,8 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
         )
         self.assertIsNotNone(message)
         assert message is not None
-        self.assertIn("Local server", message)
+        self.assertIn("Server build 0.9.0 (oldoldoldold) (local)", message)
+        self.assertIn("this Mac's 0.10.0 (newnewnewnew)", message)
         self.assertIn("bunnify-server --stop", message)
 
     def test_server_skew_message_local_names_upgrade_with_agent(self) -> None:
@@ -627,7 +634,8 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
         )
         self.assertEqual(
             message,
-            "Local server build differs from this Mac. Run: bunnify-server upgrade",
+            "Server build 0.9.0 (oldoldoldold) (local) differs from this Mac's "
+            "0.10.0 (newnewnewnew). Run: bunnify-server upgrade",
         )
 
     def test_server_skew_message_none_when_aligned(self) -> None:
@@ -644,7 +652,8 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
         )
         self.assertIsNotNone(message)
         assert message is not None
-        self.assertIn("Remote server", message)
+        self.assertIn("Server build 0.9.0 (oldoldoldold) (remote)", message)
+        self.assertIn("this Mac's 0.10.0 (newnewnewnew)", message)
         self.assertIn("redeploy", message)
         self.assertNotIn("bunnify-server", message)
 
@@ -3676,6 +3685,7 @@ def _about_runtime(
         bookmarks_uri="file:///Users/me/.config/bunnify/bookmarks.json",
         github_display=None,
         github_url=None,
+        local_build_label="0.10.0 (newnewnewnew)",
         server_agent_installed=server_agent_installed,
         server_build_label="0.9.0 (oldoldoldold)",
         server_display="Local server · http://127.0.0.1:8000",

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -6,11 +6,13 @@ import subprocess
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Literal
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 from django.test import SimpleTestCase
 
+from app.spotty_bunny_about_info import AboutRuntimeInfo
 from app.spotty_bunny_agent import TccStatus
 from app.spotty_bunny_cli import (
     LOG_ENV_VAR,
@@ -435,6 +437,10 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             with (
                 patch("app.spotty_bunny_about_info.fetch_health", return_value=health),
                 patch(
+                    "app.spotty_bunny_about_info._server_agent_installed",
+                    return_value=True,
+                ),
+                patch(
                     "app.coherence.get_build_info",
                     return_value=("0.10.0", "newnewnewnew"),
                 ),
@@ -444,6 +450,8 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
                     origin_url_for=lambda _workdir: None,
                 )
             self.assertTrue(info.server_skewed)
+            self.assertEqual(info.server_mode, "local")
+            self.assertTrue(info.server_agent_installed)
             self.assertEqual(info.server_build_label, "0.9.0 (oldoldoldold)")
 
     def test_load_about_runtime_info_no_skew_when_builds_match(self) -> None:
@@ -500,6 +508,7 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
                 info.server_display,
                 "Remote server · https://bun.example.com",
             )
+            self.assertEqual(info.server_mode, "remote")
             self.assertEqual(info.server_url, "https://bun.example.com")
 
     def test_about_details_text_and_links(self) -> None:
@@ -513,8 +522,10 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             bookmarks_uri="file:///Users/me/.config/bunnify/bookmarks.json",
             github_display="github.com/acme/repo",
             github_url="https://github.com/acme/repo",
+            server_agent_installed=False,
             server_build_label="0.10.0 (abc123456789)",
             server_display="Local server · http://127.0.0.1:8000",
+            server_mode="local",
             server_skewed=False,
             server_url="http://127.0.0.1:8000",
         )
@@ -592,6 +603,50 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             Path("/tmp/bookmarks.json"),
         )
         self.assertIsNone(path_from_file_uri("https://example.com/x"))
+
+    def test_server_skew_message_local_names_restart_without_agent(self) -> None:
+        from app.spotty_bunny_about_info import server_skew_message
+
+        message = server_skew_message(
+            _about_runtime(server_mode="local", server_skewed=True)
+        )
+        self.assertIsNotNone(message)
+        assert message is not None
+        self.assertIn("Local server", message)
+        self.assertIn("bunnify-server --stop", message)
+
+    def test_server_skew_message_local_names_upgrade_with_agent(self) -> None:
+        from app.spotty_bunny_about_info import server_skew_message
+
+        message = server_skew_message(
+            _about_runtime(
+                server_agent_installed=True,
+                server_mode="local",
+                server_skewed=True,
+            )
+        )
+        self.assertEqual(
+            message,
+            "Local server build differs from this Mac. Run: bunnify-server upgrade",
+        )
+
+    def test_server_skew_message_none_when_aligned(self) -> None:
+        from app.spotty_bunny_about_info import server_skew_message
+
+        self.assertIsNone(server_skew_message(_about_runtime(server_mode="local")))
+        self.assertIsNone(server_skew_message(_about_runtime(server_mode="remote")))
+
+    def test_server_skew_message_remote_is_advisory(self) -> None:
+        from app.spotty_bunny_about_info import server_skew_message
+
+        message = server_skew_message(
+            _about_runtime(server_mode="remote", server_skewed=True)
+        )
+        self.assertIsNotNone(message)
+        assert message is not None
+        self.assertIn("Remote server", message)
+        self.assertIn("redeploy", message)
+        self.assertNotIn("bunnify-server", message)
 
 
 class SpottyBunnyAgentTests(SimpleTestCase):
@@ -3608,3 +3663,23 @@ class _FakeClock:
 
     def advance(self, seconds: float) -> None:
         self.t += seconds
+
+
+def _about_runtime(
+    *,
+    server_agent_installed: bool = False,
+    server_mode: Literal["local", "remote"],
+    server_skewed: bool = False,
+) -> AboutRuntimeInfo:
+    return AboutRuntimeInfo(
+        bookmarks_display="~/.config/bunnify/bookmarks.json",
+        bookmarks_uri="file:///Users/me/.config/bunnify/bookmarks.json",
+        github_display=None,
+        github_url=None,
+        server_agent_installed=server_agent_installed,
+        server_build_label="0.9.0 (oldoldoldold)",
+        server_display="Local server · http://127.0.0.1:8000",
+        server_mode=server_mode,
+        server_skewed=server_skewed,
+        server_url="http://127.0.0.1:8000",
+    )


### PR DESCRIPTION
## Summary

- The About panel warned `Server build differs from this Mac — align versions.` for any `/health` version/commit mismatch, without distinguishing a local server from a remote deployment. Remote skew cannot be fixed from this Mac, and local skew never named the remedy.
- `server_skew_message` now derives the warning from the new `AboutRuntimeInfo.server_mode`: remote skew is advisory and points at a redeploy, local skew names the realigning command, choosing `bunnify-server upgrade` when the server LaunchAgent is installed and a `bunnify-server --stop` restart otherwise (`upgrade_agent` fails without a plist).
- The warning row wraps and is measured like the other wrapped rows, so the longer prescriptive text is not clipped.

Fixes #377

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright --warnings`
- [x] `./test_bunnify` (471 tests)
- [x] `./scripts/checks` (includes shellcheck, packaging smoke, and `./test_integration`)
- [x] New unit tests cover all four message branches (aligned, local with agent, local without agent, remote) plus `server_mode` on `load_about_runtime_info`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>