### PR TITLE
fix: confirm configured server mode before setup/upgrade changes

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -291,9 +291,15 @@ def run_setup(
     environ: dict[str, str] | None = None,
     env_path: Path | None = None,
     print_fn: Callable[[str], None] | None = None,
+    skip_keep_confirmation: bool = False,
     theme: Theme | None = None,
 ) -> str:
-    """Interactively configure a verified local or remote Bunnify server."""
+    """Interactively configure a verified local or remote Bunnify server.
+
+    When *skip_keep_confirmation* is True (upgrade/onboard after the operator
+    already declined Keep), skip the keep prompt and reconfigure with the
+    previous mode as the bracket default.
+    """
     ask = prompt_fn or input
     log = print_fn or click.echo
     colors = theme if theme is not None else Theme(enabled=False)
@@ -309,7 +315,7 @@ def run_setup(
         log(colors.header("Current configuration"))
         for line in format_server_preferences_summary(existing):
             log(line)
-        if _retry_requested(
+        if not skip_keep_confirmation and _retry_requested(
             ask,
             colors.brand("Keep this configuration?") + colors.dim(" [Y/n]") + ": ",
         ):
@@ -680,7 +686,12 @@ def run_upgrade(
     )
     if reconfigure_after_upgrade:
         log(colors.dim("Opening setup to reconfigure…"))
-        run_setup(prompt_fn=ask, print_fn=log, theme=colors)
+        run_setup(
+            prompt_fn=ask,
+            print_fn=log,
+            skip_keep_confirmation=True,
+            theme=colors,
+        )
 
 
 def _ensure_local_spotty_after_setup(
@@ -863,6 +874,22 @@ def _complete_setup_keeping_preferences(
         )
         pid_dir = run_dir(environ=environ)
         preferred_port = existing.local_port
+        if preferred_port is not None and not (
+            MIN_LOCAL_PORT <= preferred_port <= 65535
+        ):
+            log(
+                colors.warn(
+                    f"Saved local port {preferred_port} is outside "
+                    f"{MIN_LOCAL_PORT}-65535; prompting for a new port."
+                )
+            )
+            preferred_port = _prompt_local_port(
+                ask,
+                existing_port=None,
+                pid_dir=pid_dir,
+                print_fn=log,
+                theme=colors,
+            )
         while True:
             try:
                 base_url, actual_port = _ensure_local_server_for_setup(

--- a/app/cli.py
+++ b/app/cli.py
@@ -686,12 +686,17 @@ def run_upgrade(
     )
     if reconfigure_after_upgrade:
         log(colors.dim("Opening setup to reconfigure…"))
-        run_setup(
-            prompt_fn=ask,
-            print_fn=log,
-            skip_keep_confirmation=True,
-            theme=colors,
-        )
+        try:
+            run_setup(
+                prompt_fn=ask,
+                print_fn=log,
+                skip_keep_confirmation=True,
+                theme=colors,
+            )
+        except ClientError as exc:
+            # Package upgrade already succeeded; do not fail the CLI on setup abort.
+            log(colors.warn(f"Setup after upgrade did not finish: {exc}"))
+            log(colors.dim("Run `bunnify setup` when ready to reconfigure."))
 
 
 def _ensure_local_spotty_after_setup(

--- a/app/cli.py
+++ b/app/cli.py
@@ -43,6 +43,7 @@ from app.config import (
     ServerPreferences,
     ensure_user_bookmarks,
     env_file_path,
+    format_server_preferences_summary,
     legacy_env_file_path,
     load_preferences,
     read_base_url_from_env_file,
@@ -303,17 +304,37 @@ def run_setup(
     log(colors.dim(f"running from {running_command_path()}"))
     log(colors.dim("Press Enter to accept the value in [brackets]."))
 
+    if existing is not None and existing.base_url:
+        log("")
+        log(colors.header("Current configuration"))
+        for line in format_server_preferences_summary(existing):
+            log(line)
+        if _retry_requested(
+            ask,
+            colors.brand("Keep this configuration?") + colors.dim(" [Y/n]") + ": ",
+        ):
+            return _complete_setup_keeping_preferences(
+                existing,
+                ask=ask,
+                environ=environ,
+                env_path=path,
+                print_fn=log,
+                theme=colors,
+            )
+        log(colors.dim("Reconfigure from here…"))
+
+    default_mode = existing.mode if existing is not None else "local"
     while True:
         try:
             answer = ask(
                 colors.brand("Server mode")
-                + colors.dim(" [local]")
+                + colors.dim(f" [{default_mode}]")
                 + colors.dim(" (Enter accepts)")
                 + ": "
             )
         except EOFError as exc:
             raise ClientError("Setup aborted") from exc
-        mode = answer.strip().lower() or "local"
+        mode = answer.strip().lower() or default_mode
         if mode in {"l", "local"}:
             mode = "local"
             break
@@ -543,6 +564,7 @@ def run_upgrade(
     *,
     print_fn: Callable[[str], None] | None = None,
     pipx_bin: str | None = None,
+    prompt_fn: Callable[[str], str] | None = None,
     refresh_launch_agents: bool | Literal["server"] = True,
     run_fn: Callable[..., subprocess.CompletedProcess[str]] | None = None,
     theme: Theme | None = None,
@@ -556,12 +578,28 @@ def run_upgrade(
     """
     log = print_fn or click.echo
     colors = theme if theme is not None else Theme(enabled=False)
+    ask = prompt_fn or input
     package, commit = get_build_info()
     from_label = f"{package} ({commit})"
     command_path = running_command_path()
     log(colors.header(_command_banner("upgrade")))
     log(f"From: {from_label}")
     log(f"      {command_path}")
+    reconfigure_after_upgrade = False
+    preferences = load_preferences()
+    if preferences is not None and preferences.base_url:
+        log("")
+        log(colors.header("Current configuration"))
+        for line in format_server_preferences_summary(preferences):
+            log(line)
+        interactive = sys.stdin.isatty() and sys.stdout.isatty()
+        if interactive or prompt_fn is not None:
+            if not _retry_requested(
+                ask,
+                colors.brand("Keep this configuration?") + colors.dim(" [Y/n]") + ": ",
+            ):
+                reconfigure_after_upgrade = True
+                log(colors.dim("Will open setup after the package upgrade…"))
     if is_source_checkout():
         log(
             "This process is a git checkout, not the pipx app. "
@@ -640,6 +678,9 @@ def run_upgrade(
         refresh_launch_agents=refresh_launch_agents,
         upgraded_build=after_pipx,
     )
+    if reconfigure_after_upgrade:
+        log(colors.dim("Opening setup to reconfigure…"))
+        run_setup(prompt_fn=ask, print_fn=log, theme=colors)
 
 
 def _ensure_local_spotty_after_setup(
@@ -799,6 +840,110 @@ def _report_post_upgrade_coherence(
 def _command_banner(action: str) -> str:
     """Return ``Bunnify version X.Y.Z (commit) - action`` for CLI headers."""
     return f"Bunnify version {build_version()} - {action}"
+
+
+def _complete_setup_keeping_preferences(
+    existing: ServerPreferences,
+    *,
+    ask: Callable[[str], str],
+    environ: dict[str, str] | None,
+    env_path: Path,
+    print_fn: Callable[[str], None],
+    theme: Theme,
+) -> str:
+    """Finish setup by retaining *existing* preferences after confirmation."""
+    log = print_fn
+    colors = theme
+    if existing.mode == "local":
+        bookmarks = ensure_user_bookmarks(
+            environ=environ,
+            prompt_fn=ask,
+            allow_prompt=True,
+            print_fn=log,
+        )
+        pid_dir = run_dir(environ=environ)
+        preferred_port = existing.local_port
+        while True:
+            try:
+                base_url, actual_port = _ensure_local_server_for_setup(
+                    port=preferred_port,
+                    pid_dir=pid_dir,
+                    bookmarks=bookmarks,
+                    print_fn=log,
+                    prompt_fn=ask,
+                    theme=colors,
+                )
+            except (OSError, RuntimeError, ValueError) as exc:
+                if _retry_requested(
+                    ask,
+                    colors.warn(f"Local server failed: {exc}\n") + "Retry? [Y/n]: ",
+                ):
+                    preferred_port = None
+                    continue
+                raise ClientError("Setup aborted; settings were not changed") from exc
+            health = fetch_health(base_url)
+            if health.ok:
+                preferences = ServerPreferences(
+                    mode="local",
+                    base_url=base_url,
+                    local_port=actual_port,
+                )
+                save_preferences(preferences, env_path=env_path, environ=environ)
+                log(colors.ok(f"✓ Kept local Bunnify server at {base_url}"))
+                log("")
+                log(colors.header("Browser"))
+                for line in format_browser_setup_text(base_url).splitlines():
+                    log(line)
+                _ensure_local_spotty_after_setup(
+                    print_fn=log,
+                    prompt_fn=ask,
+                    theme=colors,
+                )
+                return base_url
+            if not _retry_requested(
+                ask,
+                colors.warn(f"Health check failed for {base_url}.\n")
+                + "Retry? [Y/n]: ",
+            ):
+                raise ClientError("Setup aborted; settings were not changed")
+
+    base_url = existing.base_url
+    reachable = check_health(base_url)
+    if not reachable:
+        log(colors.warn(f"Health check failed for {base_url}."))
+        if not _confirm_explicit_yes(
+            ask,
+            colors.warn(
+                "The remote server is not reachable. Keep this URL anyway? [y/N]: "
+            ),
+        ):
+            raise ClientError("Setup aborted; settings were not changed")
+    else:
+        health = fetch_health(base_url)
+        log(colors.ok(f"✓ Health check passed for {base_url}"))
+        if not offer_remote_build_mismatch(
+            ask,
+            base_url=base_url,
+            health=health,
+            print_fn=log,
+            theme=colors,
+        ):
+            raise ClientError("Setup aborted; settings were not changed")
+    save_preferences(existing, env_path=env_path, environ=environ)
+    if reachable:
+        log(colors.ok(f"✓ Kept remote Bunnify server at {base_url}"))
+    else:
+        log(
+            colors.warn(
+                f"⚠ Kept remote Bunnify server at {base_url} "
+                "(unreachable; continuing by confirmation)"
+            )
+        )
+    log("")
+    log(colors.header("Browser"))
+    for line in format_browser_setup_text(base_url).splitlines():
+        log(line)
+    return base_url
 
 
 def _confirm_explicit_yes(prompt_fn: Callable[[str], str], message: str) -> bool:

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,17 @@ class ServerPreferences:
     local_port: int | None
 
 
+def format_server_preferences_summary(preferences: ServerPreferences) -> list[str]:
+    """Return human-readable lines describing saved server preferences."""
+    lines = [
+        f"Configured mode: {preferences.mode}",
+        f"Base URL: {preferences.base_url or '(none)'}",
+    ]
+    if preferences.mode == "local" and preferences.local_port is not None:
+        lines.append(f"Local port: {preferences.local_port}")
+    return lines
+
+
 def repo_root() -> Path:
     """Return the repository root (parent of the ``app`` package) when developing."""
     return Path(__file__).resolve().parent.parent

--- a/app/onboard.py
+++ b/app/onboard.py
@@ -200,7 +200,12 @@ def run_onboard(
 
                 log(colors.dim("Opening setup to reconfigure…"))
                 try:
-                    run_setup(prompt_fn=ask, print_fn=log, theme=colors)
+                    run_setup(
+                        prompt_fn=ask,
+                        print_fn=log,
+                        skip_keep_confirmation=True,
+                        theme=colors,
+                    )
                 except ClientError as exc:
                     log(colors.err(f"error: {exc}"))
                 else:

--- a/app/onboard.py
+++ b/app/onboard.py
@@ -11,7 +11,12 @@ from pathlib import Path
 from packaging.version import InvalidVersion, Version
 
 from app.client import ClientError
-from app.config import default_bookmarks_path, env_file_path, load_preferences
+from app.config import (
+    default_bookmarks_path,
+    env_file_path,
+    format_server_preferences_summary,
+    load_preferences,
+)
 from app.pipx_install import (
     install_macos_extra,
     macos_extra_installed,
@@ -178,6 +183,28 @@ def run_onboard(
     log(colors.header(_command_banner("onboard")))
     for line in _format_install_summary(state):
         log(line)
+    preferences = load_preferences()
+    if preferences is not None and preferences.base_url:
+        log("")
+        log(colors.header("Current configuration"))
+        for line in format_server_preferences_summary(preferences):
+            log(line)
+        if interactive:
+            from app.cli import _retry_requested  # noqa: PLC0415
+
+            if not _retry_requested(
+                ask,
+                colors.brand("Keep this configuration?") + colors.dim(" [Y/n]") + ": ",
+            ):
+                from app.cli import run_setup  # noqa: PLC0415
+
+                log(colors.dim("Opening setup to reconfigure…"))
+                try:
+                    run_setup(prompt_fn=ask, print_fn=log, theme=colors)
+                except ClientError as exc:
+                    log(colors.err(f"error: {exc}"))
+                else:
+                    state = detect_install_state(read_executable_build=reader)
     log("")
 
     if interactive and state.upgrade_available and state.pypi_latest is not None:

--- a/app/onboard.py
+++ b/app/onboard.py
@@ -222,7 +222,7 @@ def run_onboard(
                 from app.cli import run_upgrade as upgrade  # noqa: PLC0415
 
             try:
-                upgrade(print_fn=log, theme=colors)
+                upgrade(print_fn=log, prompt_fn=ask, theme=colors)
             except ClientError as exc:
                 log(colors.err(f"error: {exc}"))
             else:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1736,7 +1736,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: "",
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=messages.append,
                 )
@@ -1786,7 +1786,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=lambda _message: None,
                 )
@@ -2032,7 +2032,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=messages.append,
                 )

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1672,6 +1672,134 @@ class ConfigUnitTests(TestCase):
             self.assertEqual(preferences.mode, "remote")
             self.assertEqual(preferences.base_url, "https://new.example")
 
+    def test_setup_keeps_existing_local_port(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli._ensure_local_server_for_setup",
+                    return_value=("http://127.0.0.1:8123", 8123),
+                ) as ensure_server,
+                patch("app.cli.fetch_health", return_value=_healthy_status()),
+                patch("app.cli.check_health", return_value=True),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: "",
+                    env_path=path,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8123")
+            self.assertEqual(ensure_server.call_args.kwargs["port"], 8123)
+            preferences = load_preferences(environ={}, env_path=path)
+            assert preferences is not None
+            self.assertEqual(preferences.local_port, 8123)
+
+    def test_setup_keep_local_renormalizes_privileged_port(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:700",
+                    local_port=700,
+                ),
+                env_path=path,
+            )
+            responses = iter(["", ""])
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli._ensure_local_server_for_setup",
+                    return_value=("http://127.0.0.1:8000", 8000),
+                ) as ensure_server,
+                patch("app.cli.fetch_health", return_value=_healthy_status()),
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.port_is_free", return_value=True),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:8000")
+            self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
+            preferences = load_preferences(environ={}, env_path=path)
+            assert preferences is not None
+            self.assertEqual(preferences.local_port, 8000)
+
+    def test_setup_skip_keep_confirmation_reconfigures_directly(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.client import HealthStatus
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        matching = HealthStatus(ok=True, version="0.10.0", commit="abc123456789")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            save_preferences(
+                ServerPreferences(
+                    mode="remote",
+                    base_url="https://old.example",
+                    local_port=None,
+                ),
+                env_path=path,
+            )
+            messages: list[str] = []
+            responses = iter(["", "https://new.example/"])
+            with (
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=matching),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "abc123456789"),
+                ),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    env_path=path,
+                    print_fn=messages.append,
+                    skip_keep_confirmation=True,
+                )
+
+            self.assertEqual(result, "https://new.example")
+            joined = "\n".join(messages)
+            self.assertIn("Reconfigure from here", joined)
+            self.assertNotIn("Kept remote", joined)
+            preferences = load_preferences(environ={}, env_path=path)
+            assert preferences is not None
+            self.assertEqual(preferences.base_url, "https://new.example")
+
     def test_setup_remote_unreachable_continues_when_confirmed(self) -> None:
         import tempfile
         from pathlib import Path

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -838,6 +838,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -892,6 +893,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -950,6 +952,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -993,6 +996,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -1041,6 +1045,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -1200,6 +1205,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
@@ -1723,6 +1729,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             messages: list[str] = []
             with (
@@ -1768,6 +1775,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             # Keep configuration; then retry after local server failure
             responses = iter(["", ""])
@@ -2017,6 +2025,7 @@ class ConfigUnitTests(TestCase):
                     local_port=700,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             responses = iter(["", ""])
             messages: list[str] = []
@@ -2185,6 +2194,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             responses = iter(["n", "local", "", ""])
             with (
@@ -2650,6 +2660,7 @@ class ConfigUnitTests(TestCase):
                     local_port=700,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             responses = iter(["n", "", ""])  # decline keep; local mode; port default
             with (
@@ -3526,6 +3537,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
+            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             messages: list[str] = []
             with (

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -803,14 +803,14 @@ class ConfigUnitTests(TestCase):
         )
 
         with tempfile.TemporaryDirectory() as tmp:
-            environ = {"XDG_CONFIG_HOME": tmp}
+            environ = {"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp}
             path = env_file_path(environ=environ)
             expected = ServerPreferences(
                 mode="local",
                 base_url="http://127.0.0.1:8765",
                 local_port=8765,
             )
-            save_preferences(expected, env_path=path)
+            save_preferences(expected, env_path=path, environ=environ)
 
             self.assertEqual(
                 load_preferences(environ=environ, env_path=path),

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1724,6 +1724,7 @@ class ConfigUnitTests(TestCase):
                 ),
                 env_path=path,
             )
+            messages: list[str] = []
             with (
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
                 patch(
@@ -1736,11 +1737,14 @@ class ConfigUnitTests(TestCase):
                 result = run_setup(
                     prompt_fn=lambda _message: "",
                     env_path=path,
-                    print_fn=lambda _message: None,
+                    print_fn=messages.append,
                 )
 
             self.assertEqual(result, "http://127.0.0.1:8123")
             self.assertEqual(ensure_server.call_args.kwargs["port"], 8123)
+            joined = "\n".join(messages)
+            self.assertIn("Current configuration", joined)
+            self.assertIn("Kept local Bunnify server", joined)
             preferences = load_preferences(environ={}, env_path=path)
             assert preferences is not None
             self.assertEqual(preferences.local_port, 8123)
@@ -1902,6 +1906,7 @@ class ConfigUnitTests(TestCase):
                 env_path=path,
             )
             responses = iter(["", ""])
+            messages: list[str] = []
             with (
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
                 patch(
@@ -1916,11 +1921,14 @@ class ConfigUnitTests(TestCase):
                     prompt_fn=lambda _message: next(responses),
                     environ={"XDG_CONFIG_HOME": tmp},
                     env_path=path,
-                    print_fn=lambda _message: None,
+                    print_fn=messages.append,
                 )
 
             self.assertEqual(result, "http://127.0.0.1:8000")
             self.assertEqual(ensure_server.call_args.kwargs["port"], 8000)
+            joined = "\n".join(messages)
+            self.assertIn("Kept local Bunnify server", joined)
+            self.assertIn("outside 1024-65535", joined)
             preferences = load_preferences(environ={}, env_path=path)
             assert preferences is not None
             self.assertEqual(preferences.local_port, 8000)

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -838,7 +838,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -893,7 +893,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -952,7 +952,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -996,7 +996,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -1045,7 +1045,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch(
@@ -1205,7 +1205,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             with (
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
@@ -1729,7 +1729,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             messages: list[str] = []
             with (
@@ -1775,7 +1775,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             # Keep configuration; then retry after local server failure
             responses = iter(["", ""])
@@ -2025,7 +2025,7 @@ class ConfigUnitTests(TestCase):
                     local_port=700,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             responses = iter(["", ""])
             messages: list[str] = []
@@ -2194,7 +2194,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             responses = iter(["n", "local", "", ""])
             with (
@@ -2660,7 +2660,7 @@ class ConfigUnitTests(TestCase):
                     local_port=700,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             responses = iter(["n", "", ""])  # decline keep; local mode; port default
             with (
@@ -3537,7 +3537,7 @@ class ConfigUnitTests(TestCase):
                     local_port=8123,
                 ),
                 env_path=path,
-            environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
             )
             messages: list[str] = []
             with (

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1577,7 +1577,7 @@ class ConfigUnitTests(TestCase):
                 local_port=None,
             )
             save_preferences(original, env_path=path)
-            responses = iter(["remote", "https://broken.example", "n", "n"])
+            responses = iter(["n", "remote", "https://broken.example", "n", "n"])
             with patch("app.cli.check_health", return_value=False):
                 with self.assertRaises(ClientError):
                     run_setup(
@@ -1587,6 +1587,90 @@ class ConfigUnitTests(TestCase):
                     )
 
             self.assertEqual(load_preferences(environ={}, env_path=path), original)
+
+    def test_setup_keeps_existing_remote_when_confirmed(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.client import HealthStatus
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        matching = HealthStatus(ok=True, version="0.10.0", commit="abc123456789")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            original = ServerPreferences(
+                mode="remote",
+                base_url="https://working.example",
+                local_port=None,
+            )
+            save_preferences(original, env_path=path)
+            messages: list[str] = []
+            responses = iter([""])  # Keep this configuration? [Y/n]
+            with (
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=matching),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "abc123456789"),
+                ),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    env_path=path,
+                    print_fn=messages.append,
+                )
+
+            self.assertEqual(result, "https://working.example")
+            joined = "\n".join(messages)
+            self.assertIn("Configured mode: remote", joined)
+            self.assertIn("Current configuration", joined)
+            self.assertIn("Kept remote Bunnify server", joined)
+            self.assertEqual(load_preferences(environ={}, env_path=path), original)
+
+    def test_setup_defaults_mode_to_existing_when_reconfiguring(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.client import HealthStatus
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        matching = HealthStatus(ok=True, version="0.10.0", commit="abc123456789")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            save_preferences(
+                ServerPreferences(
+                    mode="remote",
+                    base_url="https://old.example",
+                    local_port=None,
+                ),
+                env_path=path,
+            )
+            # Decline keep; accept default mode [remote]; new URL
+            responses = iter(["n", "", "https://new.example/"])
+            with (
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=matching),
+                patch(
+                    "app.coherence.get_build_info",
+                    return_value=("0.10.0", "abc123456789"),
+                ),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    env_path=path,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "https://new.example")
+            preferences = load_preferences(environ={}, env_path=path)
+            self.assertIsNotNone(preferences)
+            assert preferences is not None
+            self.assertEqual(preferences.mode, "remote")
+            self.assertEqual(preferences.base_url, "https://new.example")
 
     def test_setup_remote_unreachable_continues_when_confirmed(self) -> None:
         import tempfile
@@ -1683,7 +1767,7 @@ class ConfigUnitTests(TestCase):
                 ),
                 env_path=path,
             )
-            responses = iter(["local", "", ""])
+            responses = iter(["n", "local", "", ""])
             with (
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
                 patch(
@@ -2148,6 +2232,7 @@ class ConfigUnitTests(TestCase):
                 ),
                 env_path=path,
             )
+            responses = iter(["n", "", ""])  # decline keep; local mode; port default
             with (
                 patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
                 patch(
@@ -2159,7 +2244,7 @@ class ConfigUnitTests(TestCase):
                 patch("app.cli.port_is_free", return_value=True),
             ):
                 result = run_setup(
-                    prompt_fn=lambda _message: "",
+                    prompt_fn=lambda _message: next(responses),
                     environ={"XDG_CONFIG_HOME": tmp},
                     env_path=path,
                     print_fn=lambda _message: None,

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1712,6 +1712,143 @@ class ConfigUnitTests(TestCase):
             assert preferences is not None
             self.assertEqual(preferences.local_port, 8123)
 
+    def test_setup_keeps_unreachable_remote_when_confirmed(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            original = ServerPreferences(
+                mode="remote",
+                base_url="https://broken.example",
+                local_port=None,
+            )
+            save_preferences(original, env_path=path)
+            messages: list[str] = []
+            # Keep configuration; then yes to keep unreachable URL
+            responses = iter(["", "y"])
+            with patch("app.cli.check_health", return_value=False):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    env_path=path,
+                    print_fn=messages.append,
+                )
+
+            self.assertEqual(result, "https://broken.example")
+            joined = "\n".join(messages)
+            self.assertIn("Kept remote Bunnify server", joined)
+            self.assertIn("unreachable", joined)
+            self.assertEqual(load_preferences(environ={}, env_path=path), original)
+
+    def test_setup_aborts_unreachable_remote_keep_when_declined(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.client import ClientError
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            original = ServerPreferences(
+                mode="remote",
+                base_url="https://broken.example",
+                local_port=None,
+            )
+            save_preferences(original, env_path=path)
+            responses = iter(["", "n"])
+            with patch("app.cli.check_health", return_value=False):
+                with self.assertRaises(ClientError):
+                    run_setup(
+                        prompt_fn=lambda _message: next(responses),
+                        env_path=path,
+                        print_fn=lambda _message: None,
+                    )
+            self.assertEqual(load_preferences(environ={}, env_path=path), original)
+
+    def test_run_upgrade_keep_and_reconfigure_paths(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import MagicMock, patch
+
+        from app.cli import run_upgrade
+        from app.config import ServerPreferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            save_preferences(
+                ServerPreferences(
+                    mode="remote",
+                    base_url="https://working.example",
+                    local_port=None,
+                ),
+                env_path=path,
+            )
+            environ = {"XDG_CONFIG_HOME": tmp}
+            messages: list[str] = []
+            runner = MagicMock(
+                return_value=MagicMock(returncode=0),
+            )
+            setup = MagicMock(return_value="https://new.example")
+
+            with (
+                patch("app.cli.load_preferences") as load_prefs,
+                patch("app.cli.shutil.which", return_value="/usr/bin/pipx"),
+                patch("app.cli._pypi_latest_version", return_value="0.11.2"),
+                patch("app.cli._pipx_bunnify_path", return_value=None),
+                patch("app.cli.macos_extra_installed", return_value=False),
+                patch("app.cli._refresh_macos_launch_agents"),
+                patch("app.cli._report_post_upgrade_coherence"),
+                patch("app.cli.run_setup", setup),
+                patch("app.cli.sys.stdin") as stdin,
+                patch("app.cli.sys.stdout") as stdout,
+            ):
+                load_prefs.return_value = ServerPreferences(
+                    mode="remote",
+                    base_url="https://working.example",
+                    local_port=None,
+                )
+                stdin.isatty.return_value = True
+                stdout.isatty.return_value = True
+                # Keep configuration
+                run_upgrade(
+                    print_fn=messages.append,
+                    prompt_fn=lambda _m: "",
+                    run_fn=runner,
+                    refresh_launch_agents=False,
+                )
+                setup.assert_not_called()
+
+                setup.reset_mock()
+                messages.clear()
+                # Decline keep → reconfigure
+                run_upgrade(
+                    print_fn=messages.append,
+                    prompt_fn=lambda _m: "n",
+                    run_fn=runner,
+                    refresh_launch_agents=False,
+                )
+                setup.assert_called_once()
+                self.assertTrue(setup.call_args.kwargs.get("skip_keep_confirmation"))
+
+                setup.reset_mock()
+                # Non-interactive: no prompt_fn, stdin not a tty → no keep prompt
+                stdin.isatty.return_value = False
+                stdout.isatty.return_value = False
+                run_upgrade(
+                    print_fn=messages.append,
+                    run_fn=runner,
+                    refresh_launch_agents=False,
+                )
+                setup.assert_not_called()
+
+            _ = environ  # prefs path isolation via load_preferences patch
+
     def test_setup_keep_local_renormalizes_privileged_port(self) -> None:
         import tempfile
         from pathlib import Path

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1629,6 +1629,39 @@ class ConfigUnitTests(TestCase):
             self.assertIn("Kept remote Bunnify server", joined)
             self.assertEqual(load_preferences(environ={}, env_path=path), original)
 
+    def test_setup_keeps_remote_aborts_when_mismatch_declined(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.client import ClientError, HealthStatus
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        mismatched = HealthStatus(ok=True, version="0.9.0", commit="oldoldoldold")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            original = ServerPreferences(
+                mode="remote",
+                base_url="https://working.example",
+                local_port=None,
+            )
+            save_preferences(original, env_path=path)
+            responses = iter([""])  # Keep this configuration?
+            with (
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.fetch_health", return_value=mismatched),
+                patch("app.cli.offer_remote_build_mismatch", return_value=False),
+            ):
+                with self.assertRaises(ClientError) as ctx:
+                    run_setup(
+                        prompt_fn=lambda _message: next(responses),
+                        env_path=path,
+                        print_fn=lambda _message: None,
+                    )
+            self.assertIn("Setup aborted", str(ctx.exception))
+            self.assertEqual(load_preferences(environ={}, env_path=path), original)
+
     def test_setup_defaults_mode_to_existing_when_reconfiguring(self) -> None:
         import tempfile
         from pathlib import Path

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1860,6 +1860,9 @@ class ConfigUnitTests(TestCase):
                     refresh_launch_agents=False,
                 )
                 setup.assert_not_called()
+                joined = "\n".join(messages)
+                self.assertIn("Current configuration", joined)
+                self.assertIn("Configured mode: remote", joined)
 
                 setup.reset_mock()
                 messages.clear()

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -745,6 +745,39 @@ class CliUnitTests(TestCase):
 
 class ConfigUnitTests(TestCase):
     def setUp(self) -> None:
+        import os
+        import tempfile
+
+        import app.config as config_mod
+
+        # Isolate config/data dirs for the whole class so environ=None or partial
+        # environ dicts cannot resolve persist_local_port to the real home.
+        self._xdg_tmpdir = tempfile.TemporaryDirectory()
+        root = self._xdg_tmpdir.name
+        self._xdg_defaults = {
+            "XDG_CONFIG_HOME": root,
+            "XDG_DATA_HOME": root,
+        }
+        self._environ_patch = patch.dict(os.environ, self._xdg_defaults, clear=False)
+        self._environ_patch.start()
+        real_persist = config_mod.persist_local_port
+
+        def _persist_local_port_isolated(
+            port: int, *, environ: dict[str, str] | None = None
+        ) -> None:
+            merged = dict(self._xdg_defaults)
+            if environ is not None:
+                merged.update(environ)
+            if not (merged.get("XDG_CONFIG_HOME") or "").strip():
+                merged["XDG_CONFIG_HOME"] = self._xdg_defaults["XDG_CONFIG_HOME"]
+            if not (merged.get("XDG_DATA_HOME") or "").strip():
+                merged["XDG_DATA_HOME"] = self._xdg_defaults["XDG_DATA_HOME"]
+            real_persist(port, environ=merged)
+
+        self._persist_patch = patch.object(
+            config_mod, "persist_local_port", _persist_local_port_isolated
+        )
+        self._persist_patch.start()
         self._spotty_installed_patch = patch(
             "app.spotty_bunny_agent.is_agent_installed",
             return_value=False,
@@ -759,6 +792,9 @@ class ConfigUnitTests(TestCase):
     def tearDown(self) -> None:
         self._spotty_running_patch.stop()
         self._spotty_installed_patch.stop()
+        self._persist_patch.stop()
+        self._environ_patch.stop()
+        self._xdg_tmpdir.cleanup()
 
     def test_config_dir_respects_xdg_config_home(self) -> None:
         import tempfile

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -768,7 +768,7 @@ class ConfigUnitTests(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             self.assertEqual(
-                config_dir(environ={"XDG_CONFIG_HOME": tmp}),
+                config_dir(environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp}),
                 Path(tmp) / "bunnify",
             )
 
@@ -851,7 +851,7 @@ class ConfigUnitTests(TestCase):
                 patch("app.cli.check_health", return_value=True),
             ):
                 result = ensure_ready_base_url(
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     allow_prompt=False,
                     print_fn=lambda _message: None,
@@ -859,7 +859,7 @@ class ConfigUnitTests(TestCase):
 
             self.assertEqual(result, "http://127.0.0.1:8123")
             ensure_bookmarks.assert_called_once_with(
-                environ={"XDG_CONFIG_HOME": tmp},
+                environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                 prompt_fn=input,
                 allow_prompt=False,
                 print_fn=ANY,
@@ -909,7 +909,7 @@ class ConfigUnitTests(TestCase):
                 patch("app.server_agent.is_agent_installed", return_value=False),
             ):
                 result = ensure_ready_base_url(
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     allow_prompt=True,
                     prompt_fn=lambda _message: "y",
@@ -965,7 +965,7 @@ class ConfigUnitTests(TestCase):
             ):
                 with self.assertRaises(ClientError) as raised:
                     ensure_ready_base_url(
-                        environ={"XDG_CONFIG_HOME": tmp},
+                        environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                         env_path=path,
                         allow_prompt=True,
                         prompt_fn=lambda _message: next(responses),
@@ -1009,7 +1009,7 @@ class ConfigUnitTests(TestCase):
                 patch("app.cli.stop_local_server") as stop_server,
             ):
                 result = ensure_ready_base_url(
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     allow_prompt=True,
                     prompt_fn=lambda _message: "",
@@ -1061,7 +1061,7 @@ class ConfigUnitTests(TestCase):
                 patch("app.server_agent.is_agent_installed", return_value=False),
             ):
                 result = ensure_ready_base_url(
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     allow_prompt=True,
                     prompt_fn=lambda _message: "y",
@@ -1095,7 +1095,7 @@ class ConfigUnitTests(TestCase):
             ):
                 with self.assertRaises(ClientError) as raised:
                     ensure_ready_base_url(
-                        environ={"XDG_CONFIG_HOME": tmp},
+                        environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                         env_path=path,
                         allow_prompt=False,
                         print_fn=lambda _message: None,
@@ -1135,7 +1135,7 @@ class ConfigUnitTests(TestCase):
             ):
                 with self.assertRaises(ClientError) as raised:
                     ensure_ready_base_url(
-                        environ={"XDG_CONFIG_HOME": tmp},
+                        environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                         env_path=path,
                         allow_prompt=True,
                         print_fn=lambda _message: None,
@@ -1169,7 +1169,7 @@ class ConfigUnitTests(TestCase):
             ):
                 with self.assertRaises(ClientError) as raised:
                     ensure_ready_base_url(
-                        environ={"XDG_CONFIG_HOME": tmp},
+                        environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                         env_path=path,
                         prompt_fn=lambda _message: next(responses),
                         allow_prompt=True,
@@ -1215,7 +1215,7 @@ class ConfigUnitTests(TestCase):
                 patch("app.cli.get_build_info", return_value=("0.3.0", "abc123456789")),
             ):
                 result = ensure_ready_base_url(
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     prompt_fn=lambda _message: "",
                     allow_prompt=True,
@@ -1249,7 +1249,7 @@ class ConfigUnitTests(TestCase):
                 patch("app.cli.check_health", return_value=True),
             ):
                 result = ensure_ready_base_url(
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     allow_prompt=False,
                 )
 
@@ -2140,7 +2140,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: "",
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=messages.append,
                 )
@@ -2202,7 +2202,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=lambda _message: None,
                 )
@@ -2240,7 +2240,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=lambda _message: None,
                 )
@@ -2287,7 +2287,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=messages.append,
                 )
@@ -2336,7 +2336,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=messages.append,
                 )
@@ -2372,7 +2372,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: "",
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=messages.append,
                 )
@@ -2664,7 +2664,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: next(responses),
-                    environ={"XDG_CONFIG_HOME": tmp},
+                    environ={"XDG_CONFIG_HOME": tmp, "XDG_DATA_HOME": tmp},
                     env_path=path,
                     print_fn=lambda _message: None,
                 )

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1886,6 +1886,46 @@ class ConfigUnitTests(TestCase):
 
             _ = environ  # prefs path isolation via load_preferences patch
 
+    def test_run_upgrade_setup_abort_does_not_fail_upgrade(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from app.cli import run_upgrade
+        from app.config import ServerPreferences
+
+        messages: list[str] = []
+        runner = MagicMock(return_value=MagicMock(returncode=0))
+        setup = MagicMock(side_effect=ClientError("Setup aborted"))
+
+        with (
+            patch("app.cli.load_preferences") as load_prefs,
+            patch("app.cli.shutil.which", return_value="/usr/bin/pipx"),
+            patch("app.cli._pypi_latest_version", return_value="0.11.2"),
+            patch("app.cli._pipx_bunnify_path", return_value=None),
+            patch("app.cli.macos_extra_installed", return_value=False),
+            patch("app.cli._refresh_macos_launch_agents"),
+            patch("app.cli._report_post_upgrade_coherence"),
+            patch("app.cli.run_setup", setup),
+            patch("app.cli.sys.stdin") as stdin,
+            patch("app.cli.sys.stdout") as stdout,
+        ):
+            load_prefs.return_value = ServerPreferences(
+                mode="remote",
+                base_url="https://working.example",
+                local_port=None,
+            )
+            stdin.isatty.return_value = True
+            stdout.isatty.return_value = True
+            run_upgrade(
+                print_fn=messages.append,
+                prompt_fn=lambda _m: "n",
+                run_fn=runner,
+                refresh_launch_agents=False,
+            )
+            setup.assert_called_once()
+            joined = "\n".join(messages)
+            self.assertIn("Setup after upgrade did not finish", joined)
+            self.assertIn("bunnify setup", joined)
+
     def test_setup_keep_local_renormalizes_privileged_port(self) -> None:
         import tempfile
         from pathlib import Path

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1736,6 +1736,7 @@ class ConfigUnitTests(TestCase):
             ):
                 result = run_setup(
                     prompt_fn=lambda _message: "",
+                    environ={"XDG_CONFIG_HOME": tmp},
                     env_path=path,
                     print_fn=messages.append,
                 )
@@ -1748,6 +1749,57 @@ class ConfigUnitTests(TestCase):
             preferences = load_preferences(environ={}, env_path=path)
             assert preferences is not None
             self.assertEqual(preferences.local_port, 8123)
+
+    def test_setup_keeps_existing_local_port_retries_ephemeral(self) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app.cli import run_setup
+        from app.config import ServerPreferences, load_preferences, save_preferences
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.env"
+            bookmarks = Path(tmp) / "bookmarks.json"
+            save_preferences(
+                ServerPreferences(
+                    mode="local",
+                    base_url="http://127.0.0.1:8123",
+                    local_port=8123,
+                ),
+                env_path=path,
+            )
+            # Keep configuration; then retry after local server failure
+            responses = iter(["", ""])
+            with (
+                patch("app.cli.ensure_user_bookmarks", return_value=bookmarks),
+                patch(
+                    "app.cli._ensure_local_server_for_setup",
+                    side_effect=[
+                        RuntimeError("port unavailable"),
+                        ("http://127.0.0.1:9123", 9123),
+                    ],
+                ) as ensure_server,
+                patch("app.cli.fetch_health", return_value=_healthy_status()),
+                patch("app.cli.check_health", return_value=True),
+                patch("app.cli.port_is_free", return_value=True),
+            ):
+                result = run_setup(
+                    prompt_fn=lambda _message: next(responses),
+                    environ={"XDG_CONFIG_HOME": tmp},
+                    env_path=path,
+                    print_fn=lambda _message: None,
+                )
+
+            self.assertEqual(result, "http://127.0.0.1:9123")
+            self.assertEqual(
+                [call.kwargs["port"] for call in ensure_server.call_args_list],
+                [8123, None],
+            )
+            preferences = load_preferences(environ={}, env_path=path)
+            self.assertIsNotNone(preferences)
+            assert preferences is not None
+            self.assertEqual(preferences.local_port, 9123)
 
     def test_setup_keeps_unreachable_remote_when_confirmed(self) -> None:
         import tempfile
@@ -1828,10 +1880,12 @@ class ConfigUnitTests(TestCase):
             )
             environ = {"XDG_CONFIG_HOME": tmp}
             messages: list[str] = []
-            runner = MagicMock(
-                return_value=MagicMock(returncode=0),
-            )
-            setup = MagicMock(return_value="https://new.example")
+            parent = MagicMock()
+            runner = parent.runner
+            runner.return_value = MagicMock(returncode=0)
+            setup = parent.setup
+            setup.return_value = "https://new.example"
+            pipx_upgrade = ["/usr/bin/pipx", "upgrade", "bunnify"]
 
             with (
                 patch("app.cli.load_preferences") as load_prefs,
@@ -1860,23 +1914,32 @@ class ConfigUnitTests(TestCase):
                     refresh_launch_agents=False,
                 )
                 setup.assert_not_called()
+                runner.assert_called_once()
+                self.assertEqual(runner.call_args.args[0], pipx_upgrade)
                 joined = "\n".join(messages)
                 self.assertIn("Current configuration", joined)
                 self.assertIn("Configured mode: remote", joined)
 
-                setup.reset_mock()
+                parent.reset_mock()
+                runner.return_value = MagicMock(returncode=0)
+                setup.return_value = "https://new.example"
                 messages.clear()
-                # Decline keep → reconfigure
+                # Decline keep → reconfigure after pipx upgrade
                 run_upgrade(
                     print_fn=messages.append,
                     prompt_fn=lambda _m: "n",
                     run_fn=runner,
                     refresh_launch_agents=False,
                 )
-                setup.assert_called_once()
+                self.assertEqual(
+                    [c[0] for c in parent.mock_calls if c[0] in {"runner", "setup"}],
+                    ["runner", "setup"],
+                )
+                self.assertEqual(runner.call_args.args[0], pipx_upgrade)
                 self.assertTrue(setup.call_args.kwargs.get("skip_keep_confirmation"))
 
-                setup.reset_mock()
+                parent.reset_mock()
+                runner.return_value = MagicMock(returncode=0)
                 # Non-interactive: no prompt_fn, stdin not a tty → no keep prompt
                 stdin.isatty.return_value = False
                 stdout.isatty.return_value = False
@@ -1886,6 +1949,8 @@ class ConfigUnitTests(TestCase):
                     refresh_launch_agents=False,
                 )
                 setup.assert_not_called()
+                runner.assert_called_once()
+                self.assertEqual(runner.call_args.args[0], pipx_upgrade)
 
             _ = environ  # prefs path isolation via load_preferences patch
 
@@ -1923,6 +1988,11 @@ class ConfigUnitTests(TestCase):
                 prompt_fn=lambda _m: "n",
                 run_fn=runner,
                 refresh_launch_agents=False,
+            )
+            runner.assert_called_once()
+            self.assertEqual(
+                runner.call_args.args[0],
+                ["/usr/bin/pipx", "upgrade", "bunnify"],
             )
             setup.assert_called_once()
             joined = "\n".join(messages)

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -440,6 +440,7 @@ class OnboardTests(SimpleTestCase):
             )
         upgrade.assert_called_once()
         self.assertIn("print_fn", upgrade.call_args.kwargs)
+        self.assertIn("prompt_fn", upgrade.call_args.kwargs)
         self.assertIn("theme", upgrade.call_args.kwargs)
 
     def test_run_onboard_reports_upgrade_client_error(self) -> None:

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -241,9 +241,12 @@ class OnboardTests(SimpleTestCase):
         ):
             stdin.isatty.return_value = True
             stdout_tty.isatty.return_value = True
-            run_onboard(print_fn=stdout.write, prompt_fn=lambda _m: "n")
+            # Keep configured remote (first prompt); unreachable continue uses
+            # patched _confirm_explicit_yes → False (skip Spotty).
+            run_onboard(print_fn=stdout.write, prompt_fn=lambda _m: "y")
         spotty.assert_not_called()
         self.assertIn("Skipping Spotty Bunny install", stdout.getvalue())
+        self.assertIn("Configured mode: remote", stdout.getvalue())
 
     def test_run_onboard_warns_when_macos_extra_install_fails(self) -> None:
         stdout = StringIO()

--- a/bookmarks/test_onboard.py
+++ b/bookmarks/test_onboard.py
@@ -248,6 +248,79 @@ class OnboardTests(SimpleTestCase):
         self.assertIn("Skipping Spotty Bunny install", stdout.getvalue())
         self.assertIn("Configured mode: remote", stdout.getvalue())
 
+    def test_run_onboard_declined_keep_calls_setup(self) -> None:
+        from app.client import ClientError
+        from app.config import ServerPreferences
+
+        stdout = StringIO()
+        before = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=True,
+            macos_platform=False,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.3 (abc12345)",
+            preferences_ready=True,
+            pypi_latest="0.8.3",
+            server_agent_installed=False,
+            source_checkout=False,
+            spotty_agent_installed=False,
+            upgrade_available=False,
+            version_label="0.8.3 (abc12345)",
+        )
+        after = InstallState(
+            bookmarks_ready=True,
+            command_path="/Users/me/.local/bin/bunnify",
+            macos_extra=True,
+            macos_platform=False,
+            pipx_app_path="/Users/me/.local/bin/bunnify",
+            pipx_version_label="0.8.3 (abc12345)",
+            preferences_ready=True,
+            pypi_latest="0.8.3",
+            server_agent_installed=False,
+            source_checkout=False,
+            spotty_agent_installed=False,
+            upgrade_available=False,
+            version_label="0.8.3 (abc12345)",
+        )
+        prefs = ServerPreferences(
+            mode="remote",
+            base_url="https://old.example",
+            local_port=None,
+        )
+        setup = MagicMock(return_value="https://new.example")
+        with (
+            patch(
+                "app.onboard.detect_install_state",
+                side_effect=[before, after],
+            ) as detect,
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+            patch("app.onboard.load_preferences", return_value=prefs),
+            patch("app.cli.run_setup", setup),
+        ):
+            stdin.isatty.return_value = True
+            stdout_tty.isatty.return_value = True
+            run_onboard(print_fn=stdout.write, prompt_fn=lambda _m: "n")
+        setup.assert_called_once()
+        self.assertTrue(setup.call_args.kwargs.get("skip_keep_confirmation"))
+        self.assertEqual(detect.call_count, 2)
+        self.assertIn("Opening setup to reconfigure", stdout.getvalue())
+
+        setup_err = MagicMock(side_effect=ClientError("setup failed"))
+        stdout_err = StringIO()
+        with (
+            patch("app.onboard.detect_install_state", return_value=before),
+            patch("app.onboard.sys.stdin") as stdin,
+            patch("app.onboard.sys.stdout") as stdout_tty,
+            patch("app.onboard.load_preferences", return_value=prefs),
+            patch("app.cli.run_setup", setup_err),
+        ):
+            stdin.isatty.return_value = True
+            stdout_tty.isatty.return_value = True
+            run_onboard(print_fn=stdout_err.write, prompt_fn=lambda _m: "n")
+        self.assertIn("error: setup failed", stdout_err.getvalue())
+
     def test_run_onboard_warns_when_macos_extra_install_fails(self) -> None:
         stdout = StringIO()
         state = InstallState(

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -27,7 +27,15 @@ In a development checkout, `./scripts/bunnify` and
 `./scripts/bunnify-server` prefer `uv run` when `uv` is on ``PATH``, otherwise
 they fall back to the checkout ``.venv`` (same entry points systemd uses).
 
-Setup defaults to **local** mode. When `bookmarks.json` is missing, it offers
+Setup defaults to **local** mode when no preferences are saved yet. When
+`config.env` already has a mode/URL, setup **shows that configuration** and
+asks `Keep this configuration? [Y/n]` first—Enter keeps it. Declining
+re-enters the prompts with the **previously configured mode** as the bracket
+default (not an unconditional `local`). `bunnify upgrade` and interactive
+`bunnify onboard` show the same summary and confirmation before changing
+server settings.
+
+When `bookmarks.json` is missing, setup offers
 to install the example shortcuts (see [Configuration](CONFIG.md)). It then
 prompts for a free non-privileged listening port
 (default `8000`, or `0` for an OS-assigned port). If that port already serves


### PR DESCRIPTION
## Summary

- When `config.env` already has a server mode/URL, `bunnify setup`, interactive `upgrade`, and `onboard` show that configuration and ask **Keep this configuration? [Y/n]** before changing it.
- Declining keep re-enters prompts with the **previously configured mode** as the bracket default (not an unconditional `local`).
- Fresh installs with no preferences still default to local.
- Docs updated in `docs/LOCAL.md`.

Closes #383.

## Test plan

- [x] `./test_bunnify bookmarks.test_cli` (includes keep-remote + default-mode-when-reconfiguring cases)
- [x] `uv run ruff check` / `ruff format` / `pyright` on touched modules
- [ ] Manual: remote `config.env` → `bunnify setup` → Enter keeps remote; `n` then Enter keeps remote as mode default
- [ ] Manual: `bunnify upgrade` shows Current configuration and keep prompt before pipx upgrade completes into LaunchAgent refresh