### PR TITLE
chore: alwaysApply remote-timeouts-retries cursor rule

### DIFF
--- a/.cursor/rules/remote-timeouts-retries.mdc
+++ b/.cursor/rules/remote-timeouts-retries.mdc
@@ -1,0 +1,74 @@
+---
+description: All remote/network I/O must use explicit timeouts and bounded retries
+alwaysApply: true
+---
+
+# Remote timeouts and retries
+
+Any code that talks to a network peer — the bunny/link service HTTP API
+(`app/client.py` via `urllib.request`), the PyPI JSON API (`app/pypi.py`),
+webhooks, package indexes, `gh`/`curl` helpers — must not hang indefinitely and
+must not retry without a bound. Org template sync: repository-helpers#570.
+
+## Timeouts (required)
+
+- Set an **explicit timeout** on every remote call. Never call
+  `urllib.request.urlopen(req)` without the `timeout=` keyword — the urllib
+  default is "block forever".
+- Reuse the module constant, not a fresh literal: `DEFAULT_TIMEOUT_SECONDS` /
+  the per-call `timeout` parameter in `app/client.py`, `PYPI_TIMEOUT_S` in
+  `app/pypi.py`. Every public function that makes a request already threads a
+  `timeout` argument through — keep that shape.
+- Defaults must be finite and documented.
+- Agent / shell wrappers that hit the network should use the helpers'
+  `--timeout` / `run_command … --timeout` patterns when available.
+
+## Retries (required when retrying)
+
+- Retries are for **transient** failures only: connect/read timeouts, connection
+  reset, and `429` / `502` / `503` / `504`. Do **not** blanket-retry
+  `urllib.error.URLError` or `urllib.error.HTTPError` — `HTTPError` is raised for
+  every non-2xx status including permanent `400` / `404`. Check `err.code` (or
+  catch `TimeoutError` / `URLError` with a transient `reason`) and retry only
+  the transient subset.
+- Cap attempts (small fixed `N`, typically 2–5) **or** a total retry budget.
+- Back off between attempts (exponential with jitter when practical). Honor
+  `Retry-After` when the peer sends it, clamped to a ceiling with a wall-clock
+  deadline.
+- Do **not** retry a non-idempotent write (a shortcut/key mutation `POST`)
+  unless the API contract is safe (dedupe keys / explicit idempotency). Prefer
+  fail fast on 4xx except `408` / `429`.
+- Log or surface a clear timeout / retry-exhaustion error — never spin silently.
+  `app/client.py` already maps transport failures to a typed result / `ok=False`
+  (`fetch_health`, `_request_json`); keep new callers on that surface.
+
+## Anti-patterns
+
+```python
+# bad — no timeout
+urllib.request.urlopen(request)
+
+# bad — unbounded retry
+while True:
+    try:
+        return _request_json(url)
+    except urllib.error.URLError:
+        continue
+```
+
+```python
+# good — explicit timeout from the module constant
+with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
+    ...
+
+# good — bounded, backed-off retry of a transient read
+for attempt in range(1, _MAX_ATTEMPTS + 1):
+    try:
+        return _request_json(url, timeout=DEFAULT_TIMEOUT_SECONDS)
+    except (TimeoutError, urllib.error.URLError) as err:
+        if isinstance(err, urllib.error.HTTPError) and err.code not in (429, 502, 503, 504):
+            raise
+        if attempt == _MAX_ATTEMPTS:
+            raise
+        time.sleep(_BACKOFF_S * 2 ** (attempt - 1))
+```

--- a/.cursor/rules/remote-timeouts-retries.mdc
+++ b/.cursor/rules/remote-timeouts-retries.mdc
@@ -15,10 +15,11 @@ must not retry without a bound. Org template sync: repository-helpers#570.
 - Set an **explicit timeout** on every remote call. Never call
   `urllib.request.urlopen(req)` without the `timeout=` keyword — the urllib
   default is "block forever".
-- Reuse the module constant, not a fresh literal: `DEFAULT_TIMEOUT_SECONDS` /
-  the per-call `timeout` parameter in `app/client.py`, `PYPI_TIMEOUT_S` in
-  `app/pypi.py`. Every public function that makes a request already threads a
-  `timeout` argument through — keep that shape.
+- Reuse the module's existing timeout constant, not a fresh literal:
+  `DEFAULT_TIMEOUT_SECONDS` / the per-call `timeout` parameter in
+  `app/client.py`, `PYPI_TIMEOUT_S` in `app/pypi.py`, `_DEFAULT_TIMEOUT_SECONDS`
+  in `app/github_complete.py`. Every function that makes a request already
+  threads a `timeout` through — keep that shape.
 - Defaults must be finite and documented.
 - Agent / shell wrappers that hit the network should use the helpers'
   `--timeout` / `run_command … --timeout` patterns when available.
@@ -61,14 +62,22 @@ while True:
 with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
     ...
 
-# good — bounded, backed-off retry of a transient read
+# good — bounded, backed-off retry of a transient read (HTTPError is a subclass
+# of URLError, so match it first; a bare URLError is only transient when its
+# .reason is a connection/timeout error — a cert or DNS failure is permanent)
+_RETRYABLE_STATUS = {408, 429, 502, 503, 504}
 for attempt in range(1, _MAX_ATTEMPTS + 1):
     try:
         return _request_json(url, timeout=DEFAULT_TIMEOUT_SECONDS)
-    except (TimeoutError, urllib.error.URLError) as err:
-        if isinstance(err, urllib.error.HTTPError) and err.code not in (429, 502, 503, 504):
+    except urllib.error.HTTPError as err:
+        if err.code not in _RETRYABLE_STATUS:
             raise
-        if attempt == _MAX_ATTEMPTS:
+    except (TimeoutError, ConnectionError):
+        pass
+    except urllib.error.URLError as err:
+        if not isinstance(err.reason, (TimeoutError, ConnectionError)):
             raise
-        time.sleep(_BACKOFF_S * 2 ** (attempt - 1))
+    if attempt == _MAX_ATTEMPTS:
+        raise RuntimeError("request retries exhausted")
+    time.sleep(_BACKOFF_S * 2 ** (attempt - 1))
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ The **primary clone** (repo root — first entry in `git worktree list`, usually
 - Target **Python 3.14+** and **Django 6.0+**. No deprecated APIs.
 - Use `uv` as the project dependency manager and runner.
 - Rely on modern Python features and type hinting whenever possible.
+- **Remote timeouts and bounded retries:** `.cursor/rules/remote-timeouts-retries.mdc`
+  (`alwaysApply`, org rule — template sync
+  [repository-helpers#570](https://github.com/the-hcma/repository-helpers/issues/570)).
+  Every `urllib.request` call passes `timeout=` (reuse `DEFAULT_TIMEOUT_SECONDS` /
+  `PYPI_TIMEOUT_S`); any retry is capped/budgeted, backed off, transient-only
+  (never blanket `HTTPError`), and never re-sends a non-idempotent write.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `alwaysApply` Cursor rule `.cursor/rules/remote-timeouts-retries.mdc` — a product-specific copy of the org template (`the-hcma/repository-helpers#570`).
- Covers this repo's remote surface: the link/bunny service HTTP API (`app/client.py`) and the PyPI JSON API (`app/pypi.py`), both `urllib.request` with the existing `DEFAULT_TIMEOUT_SECONDS` / `PYPI_TIMEOUT_S` constants and typed transport-failure handling.
- Point `AGENTS.md` at the rule.

Part of the org rollout of `remote-timeouts-retries` (pilot `the-hcma/domesti-bot#706` merged). Reference only — not closing `the-hcma/repository-helpers#570`.

## Test plan
- [x] `scripts/dev/pre-pr-checks` passed (`==> pre-pr-checks passed`; python-static, bash-n, shellcheck, repo-practices-lint, secret-scan, verified-commits)
- [ ] CI green on PR head
- [ ] Agent review (MergeStorm) to acceptance
- [ ] Auto-merge