### PR TITLE
feat: auto-heal Spotty Bunny stale event taps

### DIFF
--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -26,6 +26,12 @@ from app.spotty_bunny_launch import (
     spotty_bunny_is_running,
     stop_spotty_bunny,
 )
+from app.spotty_bunny_tap_health import (
+    TAP_STATE_OK,
+    TAP_STATE_REINSTALLING,
+    format_activity_timestamp,
+    read_spotty_bunny_health,
+)
 from app.version import build_version
 
 AGENT_COMMANDS = frozenset({"install", "status", "uninstall", "upgrade"})
@@ -401,7 +407,15 @@ def status_agent(
     out(f"version: {build_version()}")
     out(f"accessibility: {'yes' if tcc.accessibility else 'no'}")
     out(f"input_monitoring: {'yes' if tcc.input_monitoring else 'no'}")
-    healthy = installed and loaded and running and binary_ok
+    health = read_spotty_bunny_health()
+    if health is None:
+        out("tap: unknown")
+        out("last_chord: unknown")
+    else:
+        out(f"tap: {health.tap}")
+        out(f"last_chord: {format_activity_timestamp(health.last_chord_at)}")
+    tap_ok = health is None or health.tap in {TAP_STATE_OK, TAP_STATE_REINSTALLING}
+    healthy = installed and loaded and running and binary_ok and tap_ok
     return 0 if healthy else 1
 
 

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -28,7 +28,6 @@ from app.spotty_bunny_launch import (
 )
 from app.spotty_bunny_tap_health import (
     TAP_STATE_OK,
-    TAP_STATE_REINSTALLING,
     format_activity_timestamp,
     read_spotty_bunny_health,
 )
@@ -414,10 +413,7 @@ def status_agent(
     else:
         out(f"tap: {health.tap}")
         out(f"last_chord: {format_activity_timestamp(health.last_chord_at)}")
-    tap_ok = health is not None and health.tap in {
-        TAP_STATE_OK,
-        TAP_STATE_REINSTALLING,
-    }
+    tap_ok = health is not None and health.tap == TAP_STATE_OK
     if running and not tap_ok:
         healthy = False
     else:

--- a/app/spotty_bunny_agent.py
+++ b/app/spotty_bunny_agent.py
@@ -414,8 +414,14 @@ def status_agent(
     else:
         out(f"tap: {health.tap}")
         out(f"last_chord: {format_activity_timestamp(health.last_chord_at)}")
-    tap_ok = health is None or health.tap in {TAP_STATE_OK, TAP_STATE_REINSTALLING}
-    healthy = installed and loaded and running and binary_ok and tap_ok
+    tap_ok = health is not None and health.tap in {
+        TAP_STATE_OK,
+        TAP_STATE_REINSTALLING,
+    }
+    if running and not tap_ok:
+        healthy = False
+    else:
+        healthy = installed and loaded and running and binary_ok
     return 0 if healthy else 1
 
 

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import signal
 import sys
+import time
 
 import objc
 from Cocoa import (
@@ -62,6 +64,7 @@ from Cocoa import (
     NSWindowCollectionBehaviorFullScreenAuxiliary,
     NSWindowStyleMaskBorderless,
     NSWindowStyleMaskNonactivatingPanel,
+    NSWorkspace,
 )
 from Foundation import (
     NSAttributedString,
@@ -70,18 +73,22 @@ from Foundation import (
     NSMutableAttributedString,
     NSOperationQueue,
     NSThread,
+    NSTimer,
+    NSWorkspaceDidWakeNotification,
 )
 from PyObjCTools import MachSignals
 from Quartz import (
     CFMachPortCreateRunLoopSource,
     CFRunLoopAddSource,
     CFRunLoopGetCurrent,
+    CFRunLoopRemoveSource,
     CGEventGetFlags,
     CGEventGetIntegerValueField,
     CGEventMaskBit,
     CGEventSourceKeyState,
     CGEventTapCreate,
     CGEventTapEnable,
+    CGEventTapIsEnabled,
     CGRequestListenEventAccess,
     kCFRunLoopCommonModes,
     kCGEventFlagMaskAlternate,
@@ -196,6 +203,16 @@ from app.spotty_bunny_status import (
     status_text_runs,
     wrap_status_preferring_punctuation,
 )
+from app.spotty_bunny_tap_health import (
+    TAP_HEALTH_CHECK_INTERVAL_S,
+    TAP_STATE_DISABLED,
+    TAP_STATE_MISSING,
+    TAP_STATE_OK,
+    TAP_STATE_REINSTALLING,
+    read_spotty_bunny_health,
+    should_exit_after_reinstall_failures,
+    write_spotty_bunny_health,
+)
 from app.spotty_bunny_update import (
     UpdateStatus,
     cache_is_stale,
@@ -293,6 +310,10 @@ class SpottyBunnyController(NSObject):
         logger.debug("field-editor command ignored: %s", name)
         return False
 
+    def checkEventTapHealth_(self, _timer) -> None:
+        """Periodic timer: re-enable or reinstall a stale CGEventTap."""
+        _check_event_tap_health(self)
+
     def dismissWithEscape_(self, _sender) -> None:
         """Hide About first, then the overlay. Ignore repeats until key-up."""
         if self._escape_held:
@@ -361,6 +382,7 @@ class SpottyBunnyController(NSObject):
         self.status = None
         self.table = None
         self.tap = None
+        self._tap_health_timer = None
         self.visible = False
         self._build_panel()
         self._apply_update_status()
@@ -468,6 +490,11 @@ class SpottyBunnyController(NSObject):
         resigning = notification.object()
         if resigning is self.panel and self._became_key:
             self.hide()
+
+    def workspaceDidWake_(self, _notification) -> None:
+        """Reinstall the event tap after sleep/wake."""
+        logger.info("system wake; reinstalling event tap")
+        _reinstall_event_tap(self)
 
     def _apply_line_navigation(self, text_view, selector: str) -> None:
         """Move or extend the caret for Home/End (and Cocoa document aliases)."""
@@ -1283,6 +1310,8 @@ def run_spotty_bunny_app() -> int:
     controller = SpottyBunnyController.alloc().init()
     logger.info("NSApplication ready (activationPolicy=accessory)")
     _install_event_tap(controller)
+    _register_wake_observer(controller)
+    _schedule_tap_health_checks(controller)
     print(
         "spotty-bunny: hold one Control, press the other for the search box "
         "(Ctrl-C to quit)",
@@ -1491,34 +1520,31 @@ def _event_type_name(event_type: int) -> str:
     return names.get(int(event_type), f"type:{event_type}")
 
 
-def _install_edit_menu() -> None:
-    """Install a hidden Edit menu so Command cut/copy/paste reach the field editor."""
-    main = NSMenu.alloc().initWithTitle_("MainMenu")
-    edit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("Edit", None, "")
-    edit_menu = NSMenu.alloc().initWithTitle_("Edit")
-    command = int(NSEventModifierFlagCommand)
-    command_shift = command | int(NSEventModifierFlagShift)
-    for title, action, key, modifiers in (
-        ("Undo", "undo:", "z", command),
-        ("Redo", "redo:", "z", command_shift),
-        ("Cut", "cut:", "x", command),
-        ("Copy", "copy:", "c", command),
-        ("Paste", "paste:", "v", command),
-        ("Select All", "selectAll:", "a", command),
-    ):
-        item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            title, action, key
-        )
-        item.setKeyEquivalentModifierMask_(modifiers)
-        edit_menu.addItem_(item)
-    edit_item.setSubmenu_(edit_menu)
-    main.addItem_(edit_item)
-    NSApp.setMainMenu_(main)
+def _check_event_tap_health(controller: SpottyBunnyController) -> None:
+    """Re-enable or reinstall the tap when macOS disables it silently."""
+    tap = controller.tap
+    if tap is None:
+        logger.warning("event tap health check: tap missing; reinstalling")
+        _reinstall_event_tap(controller)
+        return
+    if _event_tap_enabled(tap):
+        write_spotty_bunny_health(tap=TAP_STATE_OK)
+        return
+    logger.warning("event tap health check: tap disabled; re-enabling")
+    write_spotty_bunny_health(tap=TAP_STATE_DISABLED)
+    CGEventTapEnable(tap, True)
+    if _event_tap_enabled(tap):
+        write_spotty_bunny_health(tap=TAP_STATE_OK)
+        return
+    logger.warning("event tap health check: re-enable failed; reinstalling")
+    _reinstall_event_tap(controller)
 
 
-def _install_event_tap(controller: SpottyBunnyController) -> None:
-    tap_holder: dict[str, object] = {}
-
+def _create_event_tap_callback(
+    controller: SpottyBunnyController,
+    *,
+    tap_holder: dict[str, object],
+) -> object:
     def callback(_proxy, event_type, event, _refcon):
         tap = tap_holder.get("tap")
         if event_type in (
@@ -1529,8 +1555,13 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
                 "event tap disabled (%s); re-enabling",
                 _event_type_name(event_type),
             )
+            write_spotty_bunny_health(tap=TAP_STATE_DISABLED)
             if tap is not None:
                 CGEventTapEnable(tap, True)
+                if _event_tap_enabled(tap):
+                    write_spotty_bunny_health(tap=TAP_STATE_OK)
+                else:
+                    _run_on_main(lambda: _reinstall_event_tap(controller))
             return event
         keycode = int(CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode))
         flags = int(CGEventGetFlags(event))
@@ -1582,6 +1613,7 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
             fired,
         )
         if fired:
+            _record_tap_activity(chord=True)
             logger.info(
                 "chord complete %s keycode=%s tracker left=%s right=%s",
                 key_name,
@@ -1592,6 +1624,24 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
             _run_on_main(lambda: controller.toggle())
         return event
 
+    return callback
+
+
+def _event_tap_enabled(tap: object) -> bool:
+    return bool(CGEventTapIsEnabled(tap))
+
+
+def _exit_after_tap_failure(failures: int) -> None:
+    logger.error(
+        "event tap reinstall failed %s times; exiting for KeepAlive restart",
+        failures,
+    )
+    os._exit(1)
+
+
+def _install_event_tap(controller: SpottyBunnyController) -> None:
+    tap_holder: dict[str, object] = {}
+    callback = _create_event_tap_callback(controller, tap_holder=tap_holder)
     CGRequestListenEventAccess()
     tap = CGEventTapCreate(
         kCGSessionEventTap,
@@ -1624,6 +1674,90 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
     controller.callback = callback
     controller.source = source
     controller.tap = tap
+    write_spotty_bunny_health(tap=TAP_STATE_OK)
+
+
+def _record_tap_activity(*, chord: bool) -> None:
+    now = time.time()
+    write_spotty_bunny_health(
+        last_chord_at=now if chord else None,
+        last_event_at=now,
+        tap=TAP_STATE_OK,
+    )
+
+
+def _register_wake_observer(controller: SpottyBunnyController) -> None:
+    center = NSWorkspace.sharedWorkspace().notificationCenter()
+    center.addObserver_selector_name_object_(
+        controller,
+        "workspaceDidWake:",
+        NSWorkspaceDidWakeNotification,
+        None,
+    )
+
+
+def _reinstall_event_tap(controller: SpottyBunnyController) -> None:
+    write_spotty_bunny_health(tap=TAP_STATE_REINSTALLING)
+    _teardown_event_tap(controller)
+    try:
+        _install_event_tap(controller)
+    except SpottyBunnyEventTapError:
+        prior = read_spotty_bunny_health()
+        failures = (prior.reinstall_failures if prior else 0) + 1
+        write_spotty_bunny_health(tap=TAP_STATE_MISSING, reinstall_failures=failures)
+        if should_exit_after_reinstall_failures(failures):
+            _exit_after_tap_failure(failures)
+        return
+    write_spotty_bunny_health(tap=TAP_STATE_OK, reinstall_failures=0)
+
+
+def _schedule_tap_health_checks(controller: SpottyBunnyController) -> None:
+    controller._tap_health_timer = (
+        NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+            TAP_HEALTH_CHECK_INTERVAL_S,
+            controller,
+            "checkEventTapHealth:",
+            None,
+            True,
+        )
+    )
+
+
+def _teardown_event_tap(controller: SpottyBunnyController) -> None:
+    tap = controller.tap
+    source = controller.source
+    if tap is not None:
+        CGEventTapEnable(tap, False)
+    if source is not None:
+        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes)
+    controller.callback = None
+    controller.source = None
+    controller.tap = None
+
+
+def _install_edit_menu() -> None:
+    """Install a hidden Edit menu so Command cut/copy/paste reach the field editor."""
+    main = NSMenu.alloc().initWithTitle_("MainMenu")
+    edit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_("Edit", None, "")
+    edit_menu = NSMenu.alloc().initWithTitle_("Edit")
+    command = int(NSEventModifierFlagCommand)
+    command_shift = command | int(NSEventModifierFlagShift)
+    for title, action, key, modifiers in (
+        ("Undo", "undo:", "z", command),
+        ("Redo", "redo:", "z", command_shift),
+        ("Cut", "cut:", "x", command),
+        ("Copy", "copy:", "c", command),
+        ("Paste", "paste:", "v", command),
+        ("Select All", "selectAll:", "a", command),
+    ):
+        item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            title, action, key
+        )
+        item.setKeyEquivalentModifierMask_(modifiers)
+        edit_menu.addItem_(item)
+    edit_item.setSubmenu_(edit_menu)
+    main.addItem_(edit_item)
+    NSApp.setMainMenu_(main)
 
 
 def _post_wake_event() -> None:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -209,10 +209,10 @@ from app.spotty_bunny_tap_health import (
     TAP_STATE_MISSING,
     TAP_STATE_OK,
     TAP_STATE_REINSTALLING,
+    next_reinstall_failure_count,
     read_spotty_bunny_health,
     should_exit_after_reinstall_failures,
     try_write_spotty_bunny_health,
-    write_spotty_bunny_health,
 )
 from app.spotty_bunny_update import (
     UpdateStatus,
@@ -1680,7 +1680,7 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
     controller.callback = callback
     controller.source = source
     controller.tap = tap
-    write_spotty_bunny_health(tap=TAP_STATE_OK, reinstall_failures=0)
+    try_write_spotty_bunny_health(tap=TAP_STATE_OK, reinstall_failures=0)
 
 
 def _record_tap_activity(*, chord: bool) -> None:
@@ -1703,18 +1703,21 @@ def _register_wake_observer(controller: SpottyBunnyController) -> None:
 
 
 def _reinstall_event_tap(controller: SpottyBunnyController) -> None:
-    write_spotty_bunny_health(tap=TAP_STATE_REINSTALLING)
+    try_write_spotty_bunny_health(tap=TAP_STATE_REINSTALLING)
     _teardown_event_tap(controller)
     try:
         _install_event_tap(controller)
     except SpottyBunnyEventTapError:
         prior = read_spotty_bunny_health()
-        failures = (prior.reinstall_failures if prior else 0) + 1
-        write_spotty_bunny_health(tap=TAP_STATE_MISSING, reinstall_failures=failures)
+        failures = next_reinstall_failure_count(prior)
+        try_write_spotty_bunny_health(
+            tap=TAP_STATE_MISSING,
+            reinstall_failures=failures,
+        )
         if should_exit_after_reinstall_failures(failures):
             _exit_after_tap_failure(failures)
         return
-    write_spotty_bunny_health(tap=TAP_STATE_OK, reinstall_failures=0)
+    try_write_spotty_bunny_health(tap=TAP_STATE_OK, reinstall_failures=0)
 
 
 def _schedule_tap_health_checks(controller: SpottyBunnyController) -> None:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -211,6 +211,7 @@ from app.spotty_bunny_tap_health import (
     TAP_STATE_REINSTALLING,
     read_spotty_bunny_health,
     should_exit_after_reinstall_failures,
+    try_write_spotty_bunny_health,
     write_spotty_bunny_health,
 )
 from app.spotty_bunny_update import (
@@ -1528,14 +1529,14 @@ def _check_event_tap_health(controller: SpottyBunnyController) -> None:
         _reinstall_event_tap(controller)
         return
     if _event_tap_enabled(tap):
-        write_spotty_bunny_health(tap=TAP_STATE_OK)
+        try_write_spotty_bunny_health(tap=TAP_STATE_OK)
         return
     logger.warning("event tap health check: tap disabled; re-enabling")
-    write_spotty_bunny_health(tap=TAP_STATE_DISABLED)
     CGEventTapEnable(tap, True)
     if _event_tap_enabled(tap):
-        write_spotty_bunny_health(tap=TAP_STATE_OK)
+        try_write_spotty_bunny_health(tap=TAP_STATE_OK)
         return
+    try_write_spotty_bunny_health(tap=TAP_STATE_DISABLED)
     logger.warning("event tap health check: re-enable failed; reinstalling")
     _reinstall_event_tap(controller)
 
@@ -1555,13 +1556,14 @@ def _create_event_tap_callback(
                 "event tap disabled (%s); re-enabling",
                 _event_type_name(event_type),
             )
-            write_spotty_bunny_health(tap=TAP_STATE_DISABLED)
             if tap is not None:
                 CGEventTapEnable(tap, True)
                 if _event_tap_enabled(tap):
-                    write_spotty_bunny_health(tap=TAP_STATE_OK)
+                    try_write_spotty_bunny_health(tap=TAP_STATE_OK)
                 else:
                     _run_on_main(lambda: _reinstall_event_tap(controller))
+            else:
+                try_write_spotty_bunny_health(tap=TAP_STATE_DISABLED)
             return event
         keycode = int(CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode))
         flags = int(CGEventGetFlags(event))
@@ -1613,7 +1615,6 @@ def _create_event_tap_callback(
             fired,
         )
         if fired:
-            _record_tap_activity(chord=True)
             logger.info(
                 "chord complete %s keycode=%s tracker left=%s right=%s",
                 key_name,
@@ -1621,7 +1622,12 @@ def _create_event_tap_callback(
                 controller.chord.held_left,
                 controller.chord.held_right,
             )
-            _run_on_main(lambda: controller.toggle())
+
+            def chord_action() -> None:
+                controller.toggle()
+                _record_tap_activity(chord=True)
+
+            _run_on_main(chord_action)
         return event
 
     return callback
@@ -1674,12 +1680,12 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
     controller.callback = callback
     controller.source = source
     controller.tap = tap
-    write_spotty_bunny_health(tap=TAP_STATE_OK)
+    write_spotty_bunny_health(tap=TAP_STATE_OK, reinstall_failures=0)
 
 
 def _record_tap_activity(*, chord: bool) -> None:
     now = time.time()
-    write_spotty_bunny_health(
+    try_write_spotty_bunny_health(
         last_chord_at=now if chord else None,
         last_event_at=now,
         tap=TAP_STATE_OK,

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -79,6 +79,7 @@ from Foundation import (
 from PyObjCTools import MachSignals
 from Quartz import (
     CFMachPortCreateRunLoopSource,
+    CFMachPortInvalidate,
     CFRunLoopAddSource,
     CFRunLoopGetCurrent,
     CFRunLoopRemoveSource,
@@ -209,9 +210,10 @@ from app.spotty_bunny_tap_health import (
     TAP_STATE_MISSING,
     TAP_STATE_OK,
     TAP_STATE_REINSTALLING,
-    next_reinstall_failure_count,
+    decide_tap_health_check,
+    process_reinstall_failure,
     read_spotty_bunny_health,
-    should_exit_after_reinstall_failures,
+    reset_reinstall_failures,
     try_write_spotty_bunny_health,
 )
 from app.spotty_bunny_update import (
@@ -1524,14 +1526,19 @@ def _event_type_name(event_type: int) -> str:
 def _check_event_tap_health(controller: SpottyBunnyController) -> None:
     """Re-enable or reinstall the tap when macOS disables it silently."""
     tap = controller.tap
-    if tap is None:
+    action = decide_tap_health_check(
+        tap_is_none=tap is None,
+        tap_enabled=_event_tap_enabled(tap) if tap is not None else False,
+    )
+    if action == "reinstall":
         logger.warning("event tap health check: tap missing; reinstalling")
         _reinstall_event_tap(controller)
         return
-    if _event_tap_enabled(tap):
+    if action == "ok":
         try_write_spotty_bunny_health(tap=TAP_STATE_OK)
         return
     logger.warning("event tap health check: tap disabled; re-enabling")
+    assert tap is not None
     CGEventTapEnable(tap, True)
     if _event_tap_enabled(tap):
         try_write_spotty_bunny_health(tap=TAP_STATE_OK)
@@ -1645,6 +1652,17 @@ def _exit_after_tap_failure(failures: int) -> None:
     os._exit(1)
 
 
+def _handle_reinstall_failure() -> None:
+    prior = read_spotty_bunny_health()
+    failures, should_exit = process_reinstall_failure(prior)
+    try_write_spotty_bunny_health(
+        tap=TAP_STATE_MISSING,
+        reinstall_failures=failures,
+    )
+    if should_exit:
+        _exit_after_tap_failure(failures)
+
+
 def _install_event_tap(controller: SpottyBunnyController) -> None:
     tap_holder: dict[str, object] = {}
     callback = _create_event_tap_callback(controller, tap_holder=tap_holder)
@@ -1681,6 +1699,7 @@ def _install_event_tap(controller: SpottyBunnyController) -> None:
     controller.source = source
     controller.tap = tap
     try_write_spotty_bunny_health(tap=TAP_STATE_OK, reinstall_failures=0)
+    reset_reinstall_failures()
 
 
 def _record_tap_activity(*, chord: bool) -> None:
@@ -1704,20 +1723,18 @@ def _register_wake_observer(controller: SpottyBunnyController) -> None:
 
 def _reinstall_event_tap(controller: SpottyBunnyController) -> None:
     try_write_spotty_bunny_health(tap=TAP_STATE_REINSTALLING)
-    _teardown_event_tap(controller)
     try:
+        _teardown_event_tap(controller)
         _install_event_tap(controller)
     except SpottyBunnyEventTapError:
-        prior = read_spotty_bunny_health()
-        failures = next_reinstall_failure_count(prior)
-        try_write_spotty_bunny_health(
-            tap=TAP_STATE_MISSING,
-            reinstall_failures=failures,
-        )
-        if should_exit_after_reinstall_failures(failures):
-            _exit_after_tap_failure(failures)
+        _handle_reinstall_failure()
+        return
+    except Exception:
+        logger.exception("event tap reinstall failed unexpectedly")
+        _handle_reinstall_failure()
         return
     try_write_spotty_bunny_health(tap=TAP_STATE_OK, reinstall_failures=0)
+    reset_reinstall_failures()
 
 
 def _schedule_tap_health_checks(controller: SpottyBunnyController) -> None:
@@ -1737,6 +1754,7 @@ def _teardown_event_tap(controller: SpottyBunnyController) -> None:
     source = controller.source
     if tap is not None:
         CGEventTapEnable(tap, False)
+        CFMachPortInvalidate(tap)
     if source is not None:
         CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes)
     controller.callback = None

--- a/app/spotty_bunny_cli.py
+++ b/app/spotty_bunny_cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from app.config import data_dir
 from app.process_marker import BUILD_MARKER_FLAG
 from app.spotty_bunny_launch import clear_spotty_bunny_pid, write_spotty_bunny_pid
+from app.spotty_bunny_tap_health import clear_spotty_bunny_health
 from app.version import build_version
 
 COMMAND_NAME = "spotty-bunny"
@@ -130,6 +131,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         write_spotty_bunny_pid(os.getpid())
         pid = os.getpid()
         atexit.register(lambda: clear_spotty_bunny_pid(only_pid=pid))
+        atexit.register(clear_spotty_bunny_health)
     return run_spotty_bunny()
 
 

--- a/app/spotty_bunny_tap_health.py
+++ b/app/spotty_bunny_tap_health.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -18,6 +19,10 @@ TAP_STATE_MISSING = "missing"
 TAP_STATE_OK = "ok"
 TAP_STATE_REINSTALLING = "reinstalling"
 
+logger = logging.getLogger(__name__)
+
+_health_cache: SpottyBunnyHealth | None = None
+
 
 @dataclass(frozen=True)
 class SpottyBunnyHealth:
@@ -32,6 +37,8 @@ class SpottyBunnyHealth:
 
 def clear_spotty_bunny_health(*, health_dir: Path | None = None) -> None:
     """Remove the health snapshot (overlay exit)."""
+    global _health_cache
+    _health_cache = None
     spotty_bunny_health_path(health_dir=health_dir).unlink(missing_ok=True)
 
 
@@ -46,28 +53,13 @@ def format_activity_timestamp(epoch: float | None) -> str:
 def read_spotty_bunny_health(
     *, health_dir: Path | None = None
 ) -> SpottyBunnyHealth | None:
-    """Return the latest health snapshot, or None when missing/unreadable."""
+    """Return the latest on-disk health snapshot, or None when missing/unreadable."""
     path = spotty_bunny_health_path(health_dir=health_dir)
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return None
-    fields: dict[str, str] = {}
-    for line in lines:
-        if ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        fields[key.strip()] = value.strip()
-    tap = fields.get("tap")
-    if tap is None:
-        return None
-    return SpottyBunnyHealth(
-        last_chord_at=_parse_optional_float(fields.get("last_chord_at")),
-        last_event_at=_parse_optional_float(fields.get("last_event_at")),
-        reinstall_failures=_parse_int(fields.get("reinstall_failures"), default=0),
-        tap=tap,
-        updated_at=_parse_float(fields.get("updated_at"), default=0.0),
-    )
+    return _health_from_lines(lines)
 
 
 def should_exit_after_reinstall_failures(failures: int) -> bool:
@@ -81,6 +73,32 @@ def spotty_bunny_health_path(*, health_dir: Path | None = None) -> Path:
     return directory / HEALTH_FILE_NAME
 
 
+def try_write_spotty_bunny_health(
+    *,
+    health_dir: Path | None = None,
+    last_chord_at: float | None = None,
+    last_event_at: float | None = None,
+    previous: SpottyBunnyHealth | None = None,
+    reinstall_failures: int | None = None,
+    tap: str,
+    time_fn: Callable[[], float] | None = None,
+) -> SpottyBunnyHealth | None:
+    """Persist tap health; return None when the data dir is not writable."""
+    try:
+        return write_spotty_bunny_health(
+            health_dir=health_dir,
+            last_chord_at=last_chord_at,
+            last_event_at=last_event_at,
+            previous=previous,
+            reinstall_failures=reinstall_failures,
+            tap=tap,
+            time_fn=time_fn,
+        )
+    except OSError as exc:
+        logger.warning("could not write spotty-bunny health snapshot: %s", exc)
+        return None
+
+
 def write_spotty_bunny_health(
     *,
     health_dir: Path | None = None,
@@ -92,9 +110,15 @@ def write_spotty_bunny_health(
     time_fn: Callable[[], float] | None = None,
 ) -> SpottyBunnyHealth:
     """Persist tap health for ``status`` and external diagnostics."""
+    global _health_cache
     now = time.time if time_fn is None else time_fn
     updated_at = now()
-    prior = previous or read_spotty_bunny_health(health_dir=health_dir)
+    use_cache = health_dir is None
+    prior = previous
+    if prior is None and use_cache:
+        prior = _health_cache
+    if prior is None:
+        prior = read_spotty_bunny_health(health_dir=health_dir)
     chord = last_chord_at
     if chord is None and prior is not None:
         chord = prior.last_chord_at
@@ -113,7 +137,12 @@ def write_spotty_bunny_health(
     )
     path = spotty_bunny_health_path(health_dir=health_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_format_health(snapshot), encoding="utf-8")
+    payload = _format_health(snapshot)
+    temp = path.with_name(f"{path.name}.tmp")
+    temp.write_text(payload, encoding="utf-8")
+    temp.replace(path)
+    if use_cache:
+        _health_cache = snapshot
     return snapshot
 
 
@@ -132,6 +161,25 @@ def _format_optional_float(value: float | None) -> str:
     if value is None:
         return ""
     return f"{value:.3f}"
+
+
+def _health_from_lines(lines: list[str]) -> SpottyBunnyHealth | None:
+    fields: dict[str, str] = {}
+    for line in lines:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip()
+    tap = fields.get("tap")
+    if tap is None:
+        return None
+    return SpottyBunnyHealth(
+        last_chord_at=_parse_optional_float(fields.get("last_chord_at")),
+        last_event_at=_parse_optional_float(fields.get("last_event_at")),
+        reinstall_failures=_parse_int(fields.get("reinstall_failures"), default=0),
+        tap=tap,
+        updated_at=_parse_float(fields.get("updated_at"), default=0.0),
+    )
 
 
 def _parse_float(raw: str | None, *, default: float) -> float:

--- a/app/spotty_bunny_tap_health.py
+++ b/app/spotty_bunny_tap_health.py
@@ -22,6 +22,7 @@ TAP_STATE_REINSTALLING = "reinstalling"
 logger = logging.getLogger(__name__)
 
 _health_cache: SpottyBunnyHealth | None = None
+_reinstall_failures_in_memory: int = 0
 
 
 @dataclass(frozen=True)
@@ -39,7 +40,17 @@ def clear_spotty_bunny_health(*, health_dir: Path | None = None) -> None:
     """Remove the health snapshot (overlay exit)."""
     global _health_cache
     _health_cache = None
+    reset_reinstall_failures()
     spotty_bunny_health_path(health_dir=health_dir).unlink(missing_ok=True)
+
+
+def decide_tap_health_check(*, tap_enabled: bool, tap_is_none: bool) -> str:
+    """Return the next heal action: ``ok``, ``reinstall``, or ``reenable``."""
+    if tap_is_none:
+        return "reinstall"
+    if tap_enabled:
+        return "ok"
+    return "reenable"
 
 
 def format_activity_timestamp(epoch: float | None) -> str:
@@ -57,6 +68,14 @@ def next_reinstall_failure_count(
     return (prior.reinstall_failures if prior else 0) + 1
 
 
+def process_reinstall_failure(
+    prior: SpottyBunnyHealth | None,
+) -> tuple[int, bool]:
+    """Record a reinstall failure and return ``(count, should_exit)``."""
+    failures = record_reinstall_failure(prior)
+    return failures, should_exit_after_reinstall_failures(failures)
+
+
 def read_spotty_bunny_health(
     *, health_dir: Path | None = None
 ) -> SpottyBunnyHealth | None:
@@ -67,6 +86,21 @@ def read_spotty_bunny_health(
     except OSError:
         return None
     return _health_from_lines(lines)
+
+
+def record_reinstall_failure(prior: SpottyBunnyHealth | None) -> int:
+    """Increment and return the reinstall failure count (survives disk write loss)."""
+    global _reinstall_failures_in_memory
+    disk = prior.reinstall_failures if prior else 0
+    failures = max(disk, _reinstall_failures_in_memory) + 1
+    _reinstall_failures_in_memory = failures
+    return failures
+
+
+def reset_reinstall_failures() -> None:
+    """Clear the in-process reinstall failure counter."""
+    global _reinstall_failures_in_memory
+    _reinstall_failures_in_memory = 0
 
 
 def should_exit_after_reinstall_failures(failures: int) -> bool:

--- a/app/spotty_bunny_tap_health.py
+++ b/app/spotty_bunny_tap_health.py
@@ -1,0 +1,161 @@
+"""Runtime health snapshot for Spotty Bunny's CGEventTap (macOS)."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.config import data_dir
+
+HEALTH_FILE_NAME = ".spotty-bunny-health"
+MAX_TAP_REINSTALL_FAILURES = 3
+TAP_HEALTH_CHECK_INTERVAL_S = 60.0
+TAP_STATE_DISABLED = "disabled"
+TAP_STATE_MISSING = "missing"
+TAP_STATE_OK = "ok"
+TAP_STATE_REINSTALLING = "reinstalling"
+
+
+@dataclass(frozen=True)
+class SpottyBunnyHealth:
+    """Persisted tap activity written by the overlay process."""
+
+    last_chord_at: float | None
+    last_event_at: float | None
+    reinstall_failures: int
+    tap: str
+    updated_at: float
+
+
+def clear_spotty_bunny_health(*, health_dir: Path | None = None) -> None:
+    """Remove the health snapshot (overlay exit)."""
+    spotty_bunny_health_path(health_dir=health_dir).unlink(missing_ok=True)
+
+
+def format_activity_timestamp(epoch: float | None) -> str:
+    """Format *epoch* for ``status`` output, or ``never`` when unset."""
+    if epoch is None:
+        return "never"
+    when = datetime.fromtimestamp(epoch, tz=UTC).astimezone()
+    return when.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def read_spotty_bunny_health(
+    *, health_dir: Path | None = None
+) -> SpottyBunnyHealth | None:
+    """Return the latest health snapshot, or None when missing/unreadable."""
+    path = spotty_bunny_health_path(health_dir=health_dir)
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    fields: dict[str, str] = {}
+    for line in lines:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip()
+    tap = fields.get("tap")
+    if tap is None:
+        return None
+    return SpottyBunnyHealth(
+        last_chord_at=_parse_optional_float(fields.get("last_chord_at")),
+        last_event_at=_parse_optional_float(fields.get("last_event_at")),
+        reinstall_failures=_parse_int(fields.get("reinstall_failures"), default=0),
+        tap=tap,
+        updated_at=_parse_float(fields.get("updated_at"), default=0.0),
+    )
+
+
+def should_exit_after_reinstall_failures(failures: int) -> bool:
+    """Return whether KeepAlive should restart after repeated reinstall failures."""
+    return failures >= MAX_TAP_REINSTALL_FAILURES
+
+
+def spotty_bunny_health_path(*, health_dir: Path | None = None) -> Path:
+    """Path to the overlay health snapshot under the data directory."""
+    directory = data_dir() if health_dir is None else health_dir
+    return directory / HEALTH_FILE_NAME
+
+
+def write_spotty_bunny_health(
+    *,
+    health_dir: Path | None = None,
+    last_chord_at: float | None = None,
+    last_event_at: float | None = None,
+    previous: SpottyBunnyHealth | None = None,
+    reinstall_failures: int | None = None,
+    tap: str,
+    time_fn: Callable[[], float] | None = None,
+) -> SpottyBunnyHealth:
+    """Persist tap health for ``status`` and external diagnostics."""
+    now = time.time if time_fn is None else time_fn
+    updated_at = now()
+    prior = previous or read_spotty_bunny_health(health_dir=health_dir)
+    chord = last_chord_at
+    if chord is None and prior is not None:
+        chord = prior.last_chord_at
+    event = last_event_at
+    if event is None and prior is not None:
+        event = prior.last_event_at
+    failures = reinstall_failures
+    if failures is None:
+        failures = prior.reinstall_failures if prior is not None else 0
+    snapshot = SpottyBunnyHealth(
+        last_chord_at=chord,
+        last_event_at=event,
+        reinstall_failures=failures,
+        tap=tap,
+        updated_at=updated_at,
+    )
+    path = spotty_bunny_health_path(health_dir=health_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_format_health(snapshot), encoding="utf-8")
+    return snapshot
+
+
+def _format_health(health: SpottyBunnyHealth) -> str:
+    lines = (
+        f"last_chord_at: {_format_optional_float(health.last_chord_at)}",
+        f"last_event_at: {_format_optional_float(health.last_event_at)}",
+        f"reinstall_failures: {health.reinstall_failures}",
+        f"tap: {health.tap}",
+        f"updated_at: {health.updated_at:.3f}",
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _format_optional_float(value: float | None) -> str:
+    if value is None:
+        return ""
+    return f"{value:.3f}"
+
+
+def _parse_float(raw: str | None, *, default: float) -> float:
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _parse_int(raw: str | None, *, default: int) -> int:
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _parse_optional_float(raw: str | None) -> float | None:
+    if raw is None or not raw.strip():
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None

--- a/app/spotty_bunny_tap_health.py
+++ b/app/spotty_bunny_tap_health.py
@@ -50,6 +50,13 @@ def format_activity_timestamp(epoch: float | None) -> str:
     return when.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
+def next_reinstall_failure_count(
+    prior: SpottyBunnyHealth | None,
+) -> int:
+    """Return the failure count after one more reinstall error."""
+    return (prior.reinstall_failures if prior else 0) + 1
+
+
 def read_spotty_bunny_health(
     *, health_dir: Path | None = None
 ) -> SpottyBunnyHealth | None:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1287,6 +1287,64 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertIn("version: " + build_version(), text)
             self.assertIn("accessibility: yes", text)
             self.assertIn("input_monitoring: no", text)
+            self.assertIn("tap: unknown", text)
+            self.assertIn("last_chord: unknown", text)
+
+    def test_status_fails_when_tap_disabled(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
+        from app.spotty_bunny_tap_health import (
+            TAP_STATE_DISABLED,
+            write_spotty_bunny_health,
+        )
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = True
+        stdout = StringIO()
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            health_dir = home / "data"
+            health_dir.mkdir()
+            write_spotty_bunny_health(
+                health_dir=health_dir,
+                tap=TAP_STATE_DISABLED,
+            )
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            program = home / "spotty-bunny"
+            _write_executable(program)
+            plist.write_text(
+                format_agent_plist(
+                    home=home,
+                    program_arguments=[str(program)],
+                ),
+                encoding="utf-8",
+            )
+            pid_dir = home / "run"
+            pid_dir.mkdir()
+            (pid_dir / ".spotty-bunny.pid").write_text("99\n", encoding="utf-8")
+            with (
+                patch(
+                    "app.spotty_bunny_agent.spotty_bunny_is_running",
+                    return_value=True,
+                ),
+                patch(
+                    "app.spotty_bunny_tap_health.data_dir",
+                    return_value=health_dir,
+                ),
+            ):
+                code = status_agent(
+                    home=home,
+                    launchctl=ctl,
+                    pid_dir=pid_dir,
+                    platform="darwin",
+                    print_fn=lambda line: stdout.write(line + "\n"),
+                    probe_tcc=lambda _p: TccStatus(True, True),
+                    program=program,
+                )
+            text = stdout.getvalue()
+            self.assertEqual(code, 1)
+            self.assertIn("tap: disabled", text)
+            self.assertIn("last_chord: never", text)
 
     def test_status_fails_when_plist_binary_missing(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
@@ -3469,6 +3527,50 @@ class SpottyBunnyStatusTests(SimpleTestCase):
         self.assertIn("apply_spotty_chrome", source)
         self.assertIn("fill_rgb=PANEL_FILL_RGB", source)
         self.assertIn("frame_rgb=PANEL_FRAME_RGB", source)
+
+
+class SpottyBunnyTapHealthTests(SimpleTestCase):
+    def test_read_write_health_round_trip(self) -> None:
+        from app.spotty_bunny_tap_health import (
+            TAP_STATE_OK,
+            read_spotty_bunny_health,
+            write_spotty_bunny_health,
+        )
+
+        with TemporaryDirectory() as tmp:
+            health_dir = Path(tmp)
+            write_spotty_bunny_health(
+                health_dir=health_dir,
+                last_chord_at=1000.0,
+                last_event_at=1000.5,
+                reinstall_failures=0,
+                tap=TAP_STATE_OK,
+                time_fn=lambda: 1001.0,
+            )
+            health = read_spotty_bunny_health(health_dir=health_dir)
+            assert health is not None
+            self.assertEqual(health.tap, TAP_STATE_OK)
+            self.assertEqual(health.last_chord_at, 1000.0)
+            self.assertEqual(health.last_event_at, 1000.5)
+            self.assertEqual(health.updated_at, 1001.0)
+
+    def test_should_exit_after_reinstall_failures(self) -> None:
+        from app.spotty_bunny_tap_health import (
+            MAX_TAP_REINSTALL_FAILURES,
+            should_exit_after_reinstall_failures,
+        )
+
+        self.assertFalse(
+            should_exit_after_reinstall_failures(MAX_TAP_REINSTALL_FAILURES - 1)
+        )
+        self.assertTrue(
+            should_exit_after_reinstall_failures(MAX_TAP_REINSTALL_FAILURES)
+        )
+
+    def test_format_activity_timestamp_never(self) -> None:
+        from app.spotty_bunny_tap_health import format_activity_timestamp
+
+        self.assertEqual(format_activity_timestamp(None), "never")
 
 
 class SpottyBunnyUpdateTests(SimpleTestCase):

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -3656,6 +3656,22 @@ class SpottyBunnyTapHealthTests(SimpleTestCase):
             )
             self.assertIsNone(result)
 
+    def test_next_reinstall_failure_count(self) -> None:
+        from app.spotty_bunny_tap_health import (
+            SpottyBunnyHealth,
+            next_reinstall_failure_count,
+        )
+
+        self.assertEqual(next_reinstall_failure_count(None), 1)
+        prior = SpottyBunnyHealth(
+            last_chord_at=None,
+            last_event_at=None,
+            reinstall_failures=2,
+            tap="missing",
+            updated_at=1.0,
+        )
+        self.assertEqual(next_reinstall_failure_count(prior), 3)
+
     def test_should_exit_after_reinstall_failures(self) -> None:
         from app.spotty_bunny_tap_health import (
             MAX_TAP_REINSTALL_FAILURES,

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1403,6 +1403,61 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertIn("tap: disabled", text)
             self.assertIn("last_chord: never", text)
 
+    def test_status_fails_when_tap_reinstalling(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
+        from app.spotty_bunny_tap_health import (
+            TAP_STATE_REINSTALLING,
+            write_spotty_bunny_health,
+        )
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = True
+        stdout = StringIO()
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            health_dir = home / "data"
+            health_dir.mkdir()
+            write_spotty_bunny_health(
+                health_dir=health_dir,
+                tap=TAP_STATE_REINSTALLING,
+            )
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            program = home / "spotty-bunny"
+            _write_executable(program)
+            plist.write_text(
+                format_agent_plist(
+                    home=home,
+                    program_arguments=[str(program)],
+                ),
+                encoding="utf-8",
+            )
+            pid_dir = home / "run"
+            pid_dir.mkdir()
+            (pid_dir / ".spotty-bunny.pid").write_text("99\n", encoding="utf-8")
+            with (
+                patch(
+                    "app.spotty_bunny_agent.spotty_bunny_is_running",
+                    return_value=True,
+                ),
+                patch(
+                    "app.spotty_bunny_tap_health.data_dir",
+                    return_value=health_dir,
+                ),
+            ):
+                code = status_agent(
+                    home=home,
+                    launchctl=ctl,
+                    pid_dir=pid_dir,
+                    platform="darwin",
+                    print_fn=lambda line: stdout.write(line + "\n"),
+                    probe_tcc=lambda _p: TccStatus(True, True),
+                    program=program,
+                )
+            text = stdout.getvalue()
+            self.assertEqual(code, 1)
+            self.assertIn("tap: reinstalling", text)
+
     def test_status_fails_when_plist_binary_missing(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
 
@@ -3587,6 +3642,22 @@ class SpottyBunnyStatusTests(SimpleTestCase):
 
 
 class SpottyBunnyTapHealthTests(SimpleTestCase):
+    def test_decide_tap_health_check(self) -> None:
+        from app.spotty_bunny_tap_health import decide_tap_health_check
+
+        self.assertEqual(
+            decide_tap_health_check(tap_is_none=True, tap_enabled=False),
+            "reinstall",
+        )
+        self.assertEqual(
+            decide_tap_health_check(tap_is_none=False, tap_enabled=True),
+            "ok",
+        )
+        self.assertEqual(
+            decide_tap_health_check(tap_is_none=False, tap_enabled=False),
+            "reenable",
+        )
+
     def test_read_write_health_round_trip(self) -> None:
         from app.spotty_bunny_tap_health import (
             TAP_STATE_OK,
@@ -3671,6 +3742,45 @@ class SpottyBunnyTapHealthTests(SimpleTestCase):
             updated_at=1.0,
         )
         self.assertEqual(next_reinstall_failure_count(prior), 3)
+
+    def test_process_reinstall_failure_triggers_exit_at_threshold(self) -> None:
+        from app.spotty_bunny_tap_health import (
+            MAX_TAP_REINSTALL_FAILURES,
+            SpottyBunnyHealth,
+            process_reinstall_failure,
+            reset_reinstall_failures,
+        )
+
+        reset_reinstall_failures()
+        prior = SpottyBunnyHealth(
+            last_chord_at=None,
+            last_event_at=None,
+            reinstall_failures=MAX_TAP_REINSTALL_FAILURES - 1,
+            tap="missing",
+            updated_at=1.0,
+        )
+        failures, should_exit = process_reinstall_failure(prior)
+        self.assertEqual(failures, MAX_TAP_REINSTALL_FAILURES)
+        self.assertTrue(should_exit)
+
+    def test_record_reinstall_failure_accumulates_when_disk_stale(self) -> None:
+        from app.spotty_bunny_tap_health import (
+            SpottyBunnyHealth,
+            record_reinstall_failure,
+            reset_reinstall_failures,
+        )
+
+        reset_reinstall_failures()
+        stale = SpottyBunnyHealth(
+            last_chord_at=None,
+            last_event_at=None,
+            reinstall_failures=0,
+            tap="missing",
+            updated_at=1.0,
+        )
+        self.assertEqual(record_reinstall_failure(stale), 1)
+        self.assertEqual(record_reinstall_failure(stale), 2)
+        self.assertEqual(record_reinstall_failure(stale), 3)
 
     def test_should_exit_after_reinstall_failures(self) -> None:
         from app.spotty_bunny_tap_health import (

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1239,6 +1239,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
 
     def test_status_reports_log_version_and_tcc(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
+        from app.spotty_bunny_tap_health import TAP_STATE_OK, write_spotty_bunny_health
         from app.version import build_version
 
         ctl = _FakeLaunchctl()
@@ -1246,6 +1247,9 @@ class SpottyBunnyAgentTests(SimpleTestCase):
         stdout = StringIO()
         with TemporaryDirectory() as tmp:
             home = Path(tmp)
+            health_dir = home / "data"
+            health_dir.mkdir()
+            write_spotty_bunny_health(health_dir=health_dir, tap=TAP_STATE_OK)
             plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
             plist.parent.mkdir(parents=True)
             program = home / "spotty-bunny"
@@ -1260,9 +1264,15 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             pid_dir = home / "run"
             pid_dir.mkdir()
             (pid_dir / ".spotty-bunny.pid").write_text("99\n", encoding="utf-8")
-            with patch(
-                "app.spotty_bunny_agent.spotty_bunny_is_running",
-                return_value=True,
+            with (
+                patch(
+                    "app.spotty_bunny_agent.spotty_bunny_is_running",
+                    return_value=True,
+                ),
+                patch(
+                    "app.spotty_bunny_tap_health.data_dir",
+                    return_value=health_dir,
+                ),
             ):
                 code = status_agent(
                     home=home,
@@ -1287,8 +1297,55 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertIn("version: " + build_version(), text)
             self.assertIn("accessibility: yes", text)
             self.assertIn("input_monitoring: no", text)
+            self.assertIn("tap: ok", text)
+            self.assertIn("last_chord: never", text)
+
+    def test_status_fails_when_running_without_health_snapshot(self) -> None:
+        from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
+
+        ctl = _FakeLaunchctl()
+        ctl.loaded = True
+        stdout = StringIO()
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            health_dir = home / "data"
+            health_dir.mkdir()
+            plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
+            plist.parent.mkdir(parents=True)
+            program = home / "spotty-bunny"
+            _write_executable(program)
+            plist.write_text(
+                format_agent_plist(
+                    home=home,
+                    program_arguments=[str(program)],
+                ),
+                encoding="utf-8",
+            )
+            pid_dir = home / "run"
+            pid_dir.mkdir()
+            (pid_dir / ".spotty-bunny.pid").write_text("99\n", encoding="utf-8")
+            with (
+                patch(
+                    "app.spotty_bunny_agent.spotty_bunny_is_running",
+                    return_value=True,
+                ),
+                patch(
+                    "app.spotty_bunny_tap_health.data_dir",
+                    return_value=health_dir,
+                ),
+            ):
+                code = status_agent(
+                    home=home,
+                    launchctl=ctl,
+                    pid_dir=pid_dir,
+                    platform="darwin",
+                    print_fn=lambda line: stdout.write(line + "\n"),
+                    probe_tcc=lambda _p: TccStatus(True, True),
+                    program=program,
+                )
+            text = stdout.getvalue()
+            self.assertEqual(code, 1)
             self.assertIn("tap: unknown", text)
-            self.assertIn("last_chord: unknown", text)
 
     def test_status_fails_when_tap_disabled(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
@@ -3553,6 +3610,51 @@ class SpottyBunnyTapHealthTests(SimpleTestCase):
             self.assertEqual(health.last_chord_at, 1000.0)
             self.assertEqual(health.last_event_at, 1000.5)
             self.assertEqual(health.updated_at, 1001.0)
+
+    def test_write_preserves_unset_fields_from_previous_snapshot(self) -> None:
+        from app.spotty_bunny_tap_health import (
+            TAP_STATE_DISABLED,
+            TAP_STATE_OK,
+            read_spotty_bunny_health,
+            write_spotty_bunny_health,
+        )
+
+        with TemporaryDirectory() as tmp:
+            health_dir = Path(tmp)
+            write_spotty_bunny_health(
+                health_dir=health_dir,
+                last_chord_at=1000.0,
+                last_event_at=1000.5,
+                reinstall_failures=2,
+                tap=TAP_STATE_OK,
+                time_fn=lambda: 1001.0,
+            )
+            write_spotty_bunny_health(
+                health_dir=health_dir,
+                tap=TAP_STATE_DISABLED,
+                time_fn=lambda: 1002.0,
+            )
+            health = read_spotty_bunny_health(health_dir=health_dir)
+            assert health is not None
+            self.assertEqual(health.tap, TAP_STATE_DISABLED)
+            self.assertEqual(health.last_chord_at, 1000.0)
+            self.assertEqual(health.reinstall_failures, 2)
+
+    def test_try_write_spotty_bunny_health_swallows_os_error(self) -> None:
+        from app.spotty_bunny_tap_health import (
+            TAP_STATE_OK,
+            try_write_spotty_bunny_health,
+        )
+
+        with TemporaryDirectory() as tmp:
+            health_dir = Path(tmp)
+            blocked = health_dir / ".spotty-bunny-health"
+            blocked.mkdir()
+            result = try_write_spotty_bunny_health(
+                health_dir=health_dir,
+                tap=TAP_STATE_OK,
+            )
+            self.assertIsNone(result)
 
     def test_should_exit_after_reinstall_failures(self) -> None:
         from app.spotty_bunny_tap_health import (

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -1239,7 +1239,11 @@ class SpottyBunnyAgentTests(SimpleTestCase):
 
     def test_status_reports_log_version_and_tcc(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
-        from app.spotty_bunny_tap_health import TAP_STATE_OK, write_spotty_bunny_health
+        from app.spotty_bunny_tap_health import (
+            TAP_STATE_OK,
+            format_activity_timestamp,
+            write_spotty_bunny_health,
+        )
         from app.version import build_version
 
         ctl = _FakeLaunchctl()
@@ -1249,7 +1253,12 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             home = Path(tmp)
             health_dir = home / "data"
             health_dir.mkdir()
-            write_spotty_bunny_health(health_dir=health_dir, tap=TAP_STATE_OK)
+            chord_at = 1_700_000_000.0
+            write_spotty_bunny_health(
+                health_dir=health_dir,
+                last_chord_at=chord_at,
+                tap=TAP_STATE_OK,
+            )
             plist = home / "Library" / "LaunchAgents" / f"{AGENT_LABEL}.plist"
             plist.parent.mkdir(parents=True)
             program = home / "spotty-bunny"
@@ -1298,7 +1307,7 @@ class SpottyBunnyAgentTests(SimpleTestCase):
             self.assertIn("accessibility: yes", text)
             self.assertIn("input_monitoring: no", text)
             self.assertIn("tap: ok", text)
-            self.assertIn("last_chord: never", text)
+            self.assertIn(f"last_chord: {format_activity_timestamp(chord_at)}", text)
 
     def test_status_fails_when_running_without_health_snapshot(self) -> None:
         from app.spotty_bunny_agent import AGENT_LABEL, format_agent_plist, status_agent
@@ -3799,6 +3808,19 @@ class SpottyBunnyTapHealthTests(SimpleTestCase):
         from app.spotty_bunny_tap_health import format_activity_timestamp
 
         self.assertEqual(format_activity_timestamp(None), "never")
+
+    def test_format_activity_timestamp_renders_epoch(self) -> None:
+        from datetime import UTC, datetime
+
+        from app.spotty_bunny_tap_health import format_activity_timestamp
+
+        epoch = 1_700_000_000.0
+        expected = (
+            datetime.fromtimestamp(epoch, tz=UTC)
+            .astimezone()
+            .strftime("%Y-%m-%d %H:%M:%S %Z")
+        )
+        self.assertEqual(format_activity_timestamp(epoch), expected)
 
 
 class SpottyBunnyUpdateTests(SimpleTestCase):


### PR DESCRIPTION
## Summary
- Reinstall the CGEventTap on system wake and on a 60s health timer when macOS disables it silently while the process stays alive
- Persist tap/chord health to `~/.local/share/bunnify/.spotty-bunny-health` and surface `tap:` / `last_chord:` in `bunnify spotty-bunny status`
- Exit after three consecutive reinstall failures so LaunchAgent KeepAlive restarts a clean process

Fixes #387

## Test plan
- [x] `scripts/checks` (ruff, pyright, 487 unit tests, integration)
- [x] New `SpottyBunnyTapHealthTests` and status coverage for disabled tap
- [ ] Manual: sleep/wake laptop, confirm Control chord still works without manual kickstart
- [ ] Manual: `bunnify spotty-bunny status` shows `tap: ok` and `last_chord:` after using the overlay

---
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>