### PR TITLE
fix: import NSWorkspaceDidWakeNotification from Cocoa

### DIFF
--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -65,6 +65,7 @@ from Cocoa import (
     NSWindowStyleMaskBorderless,
     NSWindowStyleMaskNonactivatingPanel,
     NSWorkspace,
+    NSWorkspaceDidWakeNotification,
 )
 from Foundation import (
     NSAttributedString,
@@ -74,7 +75,6 @@ from Foundation import (
     NSOperationQueue,
     NSThread,
     NSTimer,
-    NSWorkspaceDidWakeNotification,
 )
 from PyObjCTools import MachSignals
 from Quartz import (


### PR DESCRIPTION
Foundation does not expose this constant in PyObjC; importing it there
crashes Spotty Bunny at startup on pipx installs.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>