### PR TITLE
chore: adopt agent-bootstrap shims + pre-pr-checks cursor rule

### DIFF
--- a/.cursor/rules/pre-pr-checks.mdc
+++ b/.cursor/rules/pre-pr-checks.mdc
@@ -1,0 +1,51 @@
+---
+description: Block PR submit until pre-pr-checks pass; format before check; no truncated output
+alwaysApply: true
+---
+
+# Pre-PR checks (required)
+
+Before **`gt submit`** / **`gh stack submit`** or opening a PR:
+
+1. Run **`scripts/dev/pre-pr-checks`** from the feature worktree (must exit 0).
+   - Prefer **`scripts/dev/submit-stack`** (or this repo’s submit helper) instead of bare submit.
+
+2. Do **not** submit if pre-pr-checks failed or was skipped. Escape hatch only:
+   `PRE_PR_CHECKS_SKIP=job1,job2` (documented; never silent).
+
+3. In the PR **Test plan**, note that `scripts/dev/pre-pr-checks` passed (or paste the final
+   `==> pre-pr-checks passed` line).
+
+4. Scripts must not leave changes on the **primary (main) worktree**.
+
+## Apply formatters before check (required)
+
+`pre-pr-checks` is **check-only** by default (e.g. `ruff format --check`, `cargo fmt -- --check`).
+After review-fix edits — especially string literals — **apply** formatters first, then run the gate:
+
+```bash
+# Python (match CI paths; adjust for the repo)
+uv run ruff format .
+# Rust
+cargo fmt --all
+# Then the gate
+scripts/dev/pre-pr-checks
+# Or apply + check in one shot (mutates the worktree):
+scripts/dev/pre-pr-checks --fix
+```
+
+Commit any format-only diff before submit. Do **not** treat a green `pytest` / `ruff check` /
+partial job as a pre-PR pass.
+
+## No truncated pre-PR output
+
+Do **not** pipe `pre-pr-checks` to `tail` / `head`. Require exit **0** and the final
+`==> pre-pr-checks passed` line from the full run.
+
+```bash
+# ❌ Truncated — hides failures above the last few lines
+scripts/dev/pre-pr-checks 2>&1 | tail -8
+
+# ✅ Full output + exit status
+scripts/dev/pre-pr-checks
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,7 @@
+**Read [`AGENTS.md`](../AGENTS.md) at the repo root first — it is the single source of truth for this repo, and it tells you to also load every `alwaysApply: true` rule under `.cursor/rules/`.** The notes below are repo-specific Copilot hints only; do not treat them as a second rules source.
+
+---
+
 # Copilot Instructions for Bunnify
 
 ## Python Version Policy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file defines the non-negotiable standards for all contributors (human or AI
 
 ## Session Startup & Cleanup
 
+- At the **start of every agent session**, before acting from assumed conventions, read this `AGENTS.md` in full, then read every `alwaysApply: true` rule under `.cursor/rules/*.mdc` (plus any whose `globs` match files you will touch) — `AGENTS.md` and `.cursor/rules/` together are the contract. `CLAUDE.md` (a `@AGENTS.md` import) and `.github/copilot-instructions.md` are thin shims so Claude Code and Copilot reach the same guidance.
 - **Mandatory Action**: At the beginning of every session (before starting any task), run `~/work/ai/repository-helpers/scripts/dev/start-development` from [repository-helpers](https://github.com/the-hcma/repository-helpers).
 - This script cleans up merged worktrees, prunes stale metadata, and syncs via the stacking backend in `.github/stacking-tool` (`gh-stack` — `gh stack sync` / rebase as needed).
 - By default it prompts for a new stack name and creates a new worktree under `.worktrees/<stack-name>-wt` ready for work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+@AGENTS.md
+
+<!--
+This file exists only so Claude Code loads the repo's ground rules at session
+start. AGENTS.md is the single source of truth (Cursor and Copilot read it too);
+Claude Code does not read AGENTS.md on its own, so it imports it here via @path.
+AGENTS.md itself instructs the agent to also load every `alwaysApply: true` rule
+under `.cursor/rules/`. Keep this file to the import line — put real guidance in
+AGENTS.md. Org template: repository-helpers#574.
+-->


### PR DESCRIPTION
## Summary

Org-wide rollout of the **agent-bootstrap** check group (repository-helpers#574) and the **pre-pr-checks** cursor rule.

- **`CLAUDE.md`** — `@AGENTS.md` import so Claude Code loads the same ground rules as Cursor/Copilot.
- **`.github/copilot-instructions.md`** — prepends an "AGENTS.md is the single source of truth" pointer above the existing repo-specific Copilot notes (kept, not replaced).
- **`AGENTS.md`** — one bullet in the session-startup section: read `AGENTS.md` + every `alwaysApply: true` rule under `.cursor/rules/*.mdc`.
- **`.cursor/rules/pre-pr-checks.mdc`** — org template (format before check; no truncated pre-PR output).

Templates: `repository-helpers/scripts/lib/repo-practices-agents/` and `repository-helpers/scripts/lib/repo-practices-cursor/pre-pr-checks.mdc`.

## Test plan
- [ ] `github-repo-lint --repo the-hcma/bunnify --suggest` no longer flags agent-bootstrap shims or pre-pr-checks
- [ ] Agent review