### PR TITLE
chore: sync pre-pr-checks cursor rule (resolve scripts/dev via helpers clone)

### DIFF
--- a/.cursor/rules/pre-pr-checks.mdc
+++ b/.cursor/rules/pre-pr-checks.mdc
@@ -5,16 +5,32 @@ alwaysApply: true
 
 # Pre-PR checks (required)
 
-Before **`gt submit`** / **`gh stack submit`** or opening a PR:
+`pre-pr-checks` lives in **repository-helpers**, not in this repo. Resolve the
+clone once:
 
-1. Run **`scripts/dev/pre-pr-checks`** from the feature worktree (must exit 0).
-   - Prefer **`scripts/dev/submit-stack`** (or this repo’s submit helper) instead of bare submit.
+```bash
+rh="${REPOSITORY_HELPERS_DIR:-$HOME/work/ai/repository-helpers}"
+```
 
-2. Do **not** submit if pre-pr-checks failed or was skipped. Escape hatch only:
-   `PRE_PR_CHECKS_SKIP=job1,job2` (documented; never silent).
+`pre-pr-checks` resolves its target from `$PWD`, so it audits **this** repo when
+run from a feature worktree here. The `submit-stack` wrapper does **not** — it
+resolves the repo from its own path and would submit the repository-helpers
+clone, so consumers submit with a bare `gh stack submit` / `gt submit`.
 
-3. In the PR **Test plan**, note that `scripts/dev/pre-pr-checks` passed (or paste the final
-   `==> pre-pr-checks passed` line).
+Before submitting a PR:
+
+1. Run **`"${rh}/scripts/dev/pre-pr-checks"`** from this repo's feature worktree
+   (must exit 0), then submit with bare **`gh stack submit --auto`** or
+   **`gt submit`** per this repo's `.github/stacking-tool` marker, from the same
+   worktree. Do **not** use `"${rh}/scripts/dev/submit-stack"` from here.
+
+2. Do **not** submit if pre-pr-checks failed or was skipped. A skipped job is
+   allowed **only** when the user has approved it for this PR: pass
+   `PRE_PR_CHECKS_SKIP=job1,job2` (never a silent skip) and record the skipped
+   jobs and the reason in the PR **Test plan**.
+
+3. In the PR **Test plan**, note that `"${rh}/scripts/dev/pre-pr-checks"` passed
+   (paste the final `==> pre-pr-checks passed` line from the full run).
 
 4. Scripts must not leave changes on the **primary (main) worktree**.
 
@@ -29,9 +45,9 @@ uv run ruff format .
 # Rust
 cargo fmt --all
 # Then the gate
-scripts/dev/pre-pr-checks
+"${rh}/scripts/dev/pre-pr-checks"
 # Or apply + check in one shot (mutates the worktree):
-scripts/dev/pre-pr-checks --fix
+"${rh}/scripts/dev/pre-pr-checks" --fix
 ```
 
 Commit any format-only diff before submit. Do **not** treat a green `pytest` / `ruff check` /
@@ -44,8 +60,8 @@ Do **not** pipe `pre-pr-checks` to `tail` / `head`. Require exit **0** and the f
 
 ```bash
 # ❌ Truncated — hides failures above the last few lines
-scripts/dev/pre-pr-checks 2>&1 | tail -8
+"${rh}/scripts/dev/pre-pr-checks" 2>&1 | tail -8
 
 # ✅ Full output + exit status
-scripts/dev/pre-pr-checks
+"${rh}/scripts/dev/pre-pr-checks"
 ```


### PR DESCRIPTION
## Summary

Sync `.cursor/rules/pre-pr-checks.mdc` to the corrected org template
([the-hcma/repository-helpers#579](https://github.com/the-hcma/repository-helpers/pull/581)):
`pre-pr-checks` / `submit-stack` live in **repository-helpers**, not here, so the
rule now resolves them through `${REPOSITORY_HELPERS_DIR:-$HOME/work/ai/repository-helpers}`
instead of bare `scripts/dev/` paths that do not exist in this repo. Also drops the
`submit-stack` recommendation (it resolves its repo from its own path and would
submit the repository-helpers clone).

Template-only change; no behaviour change to this repo.

## Test plan

- Cursor-rule template sync only — no code paths touched.
- CI (shellcheck / tests / secret-scan) covers the rest.