### PR TITLE
docs(rules): route ad-hoc gh through scripts/gh-api (repository-helpers#608)

### DIFF
--- a/.cursor/rules/remote-timeouts-retries.mdc
+++ b/.cursor/rules/remote-timeouts-retries.mdc
@@ -5,79 +5,69 @@ alwaysApply: true
 
 # Remote timeouts and retries
 
-Any code that talks to a network peer — the bunny/link service HTTP API
-(`app/client.py` via `urllib.request`), the PyPI JSON API (`app/pypi.py`),
-webhooks, package indexes, `gh`/`curl` helpers — must not hang indefinitely and
-must not retry without a bound. Org template sync: repository-helpers#570.
+Any code that talks to a network peer (HTTP APIs, OAuth token endpoints, webhooks,
+package indexes, `gh`/`curl` helpers, cloud SDKs, etc.) must not hang indefinitely
+and must not retry without a bound. See repository-helpers#570.
 
 ## Timeouts (required)
 
-- Set an **explicit timeout** on every remote call. Never call
-  `urllib.request.urlopen(req)` without the `timeout=` keyword — the urllib
-  default is "block forever".
-- Reuse the module's existing timeout constant, not a fresh literal:
-  `DEFAULT_TIMEOUT_SECONDS` / the per-call `timeout` parameter in
-  `app/client.py`, `PYPI_TIMEOUT_S` in `app/pypi.py`, `_DEFAULT_TIMEOUT_SECONDS`
-  in `app/github_complete.py`. Every function that makes a request already
-  threads a `timeout` through — keep that shape.
-- Defaults must be finite and documented.
+- Set an **explicit timeout** on every remote call (connect + read, or a single
+  overall deadline the library supports).
+- Prefer the product's shared HTTP client / config timeout knob when one exists.
+  Defaults must be finite and documented. Never leave library defaults that mean
+  "wait forever."
 - Agent / shell wrappers that hit the network should use the helpers'
   `--timeout` / `run_command … --timeout` patterns when available.
+- For GitHub API work, honor rate-limit / secondary-limit waits
+  (`GITHUB_API_RATE_LIMIT` / documented cooldown helpers) rather than spinning —
+  route ad-hoc `gh` calls through `scripts/gh-api` (see Product-specific below).
 
 ## Retries (required when retrying)
 
-- Retries are for **transient** failures only: connect/read timeouts, connection
-  reset, and `429` / `502` / `503` / `504`. Do **not** blanket-retry
-  `urllib.error.URLError` or `urllib.error.HTTPError` — `HTTPError` is raised for
-  every non-2xx status including permanent `400` / `404`. Check `err.code` (or
-  catch `TimeoutError` / `URLError` with a transient `reason`) and retry only
-  the transient subset.
+- Retries are for **transient** failures only (timeouts, 429, 502/503/504, reset).
 - Cap attempts (small fixed `N`, typically 2–5) **or** a total retry budget.
 - Back off between attempts (exponential with jitter when practical). Honor
-  `Retry-After` when the peer sends it, clamped to a ceiling with a wall-clock
-  deadline.
-- Do **not** retry a non-idempotent write (a shortcut/key mutation `POST`)
-  unless the API contract is safe (dedupe keys / explicit idempotency). Prefer
-  fail fast on 4xx except `408` / `429`.
-- Log or surface a clear timeout / retry-exhaustion error — never spin silently.
-  `app/client.py` already maps transport failures to a typed result / `ok=False`
-  (`fetch_health`, `_request_json`); keep new callers on that surface.
+  `Retry-After` when the peer sends it.
+- Do **not** retry non-idempotent writes unless the API contract is safe
+  (dedupe keys / explicit idempotency). Prefer fail fast on 4xx except 408/429.
+- Log or surface a clear timeout/retry exhaustion error — never spin silently.
+
+## Product-specific
+
+Wire timeouts through the repo's shared HTTP client / config knob. Do not add
+one-off unbounded clients beside that shared path.
+
+### GitHub API from agent flows
+
+Never run a bare `gh api`, or a paginated / looped `gh` read or write, directly
+in an agent flow (triage, review, posting a reply, resolving a comment).
+Route every such call through `scripts/gh-api` (resolved from
+`${REPOSITORY_HELPERS_DIR:-$HOME/work/ai/repository-helpers}`) so primary **and**
+secondary rate-limit backoff (`Retry-After` / `X-RateLimit-Reset`,
+`NOTE: GITHUB_RATE_LIMIT_*`, exit `125` on quota-intact fail-fast) is automatic —
+the same logic `wait-for-agent-review` and `github-repo-lint` already use
+internally. Interactive `gh` (`auth`, prompts, `--web`) is exempt;
+`scripts/gh-api -- …` opts a non-listed subcommand in. See repository-helpers#608.
 
 ## Anti-patterns
 
 ```python
 # bad — no timeout
-urllib.request.urlopen(request)
+requests.get(url)
+httpx.get(url)
+client.execute()  # SDK call with no timeout / retry policy
 
 # bad — unbounded retry
 while True:
     try:
-        return _request_json(url)
-    except urllib.error.URLError:
+        return call()
+    except TimeoutError:
         continue
 ```
 
 ```python
-# good — explicit timeout from the module constant
-with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
-    ...
-
-# good — bounded, backed-off retry of a transient read (HTTPError is a subclass
-# of URLError, so match it first; a bare URLError is only transient when its
-# .reason is a connection/timeout error — a cert or DNS failure is permanent)
-_RETRYABLE_STATUS = {408, 429, 502, 503, 504}
-for attempt in range(1, _MAX_ATTEMPTS + 1):
-    try:
-        return _request_json(url, timeout=DEFAULT_TIMEOUT_SECONDS)
-    except urllib.error.HTTPError as err:
-        if err.code not in _RETRYABLE_STATUS:
-            raise
-    except (TimeoutError, ConnectionError):
-        pass
-    except urllib.error.URLError as err:
-        if not isinstance(err.reason, (TimeoutError, ConnectionError)):
-            raise
-    if attempt == _MAX_ATTEMPTS:
-        raise RuntimeError("request retries exhausted")
-    time.sleep(_BACKOFF_S * 2 ** (attempt - 1))
+# good — timeout from config + bounded retries
+http.timeout = httpx.Timeout(timeout_s, connect=min(30.0, timeout_s))
+# or: run_command "label" --timeout 20 -- curl …
+request_with_retries(call, max_attempts=3, retry_after_header=True)
 ```


### PR DESCRIPTION
## Summary

Adopts the **repository-helpers#608** addition to the org
`remote-timeouts-retries` cursor rule: a **"GitHub API from agent flows"** bullet
under `## Product-specific` —

> Never run a bare `gh api`, or a paginated / looped `gh` read or write, directly
> in an agent flow. Route every such call through `scripts/gh-api` (resolved from
> `${REPOSITORY_HELPERS_DIR:-$HOME/work/ai/repository-helpers}`) so primary **and**
> secondary rate-limit backoff is automatic — the same logic `wait-for-agent-review`
> and `github-repo-lint` already use internally.

**Why:** ad-hoc `gh api` / `gh pr` calls an agent makes directly during triage or
review bypass the rate-limit backoff those helpers use internally, and 403 hard
once GitHub's *secondary* limiter trips. `repository-helpers/scripts/gh-api`
(new, on `main`) wraps a one-off `gh` call in
`github_api_exec_with_rate_limit_retry`.

This repo's `.cursor/rules/remote-timeouts-retries.mdc` was a byte-identical copy
of the pre-#608 org template; this PR re-syncs it to the current template
(`repository-helpers/scripts/lib/repo-practices-cursor/remote-timeouts-retries.mdc`).
The org `github-repo-lint` check for the bullet is **SUGGEST-only** during the
rollout, so this is adoption, not a CI gate.

Pilot: the-hcma/blumkin#214 (agent-accepted).

## Test plan

- `.cursor/rules/*.mdc`-only — no source touched; CI runs the full suite.
- `github-repo-lint --repo the-hcma/<this> --strict-onboarding` no longer emits
  the `repository-helpers#608` SUGGEST for `remote-timeouts-retries.mdc`.
