### PR TITLE
docs(rules): adopt dedicated github-api-throttle rule (repository-helpers#608)

### DIFF
--- a/.cursor/rules/github-api-throttle.mdc
+++ b/.cursor/rules/github-api-throttle.mdc
@@ -1,0 +1,23 @@
+---
+description: Run agent `gh` calls through repository-helpers/scripts/gh-api
+alwaysApply: true
+---
+
+# GitHub API rate-limit throttle
+
+Agent flows that shell out to `gh` (PR / issue triage, review replies, CI
+polling, `gh api`, and `gh pr` / `gh issue` reads and writes) **must** run it
+through the throttled wrapper, never `gh` directly:
+
+```
+"${REPOSITORY_HELPERS_DIR:-$HOME/work/ai/repository-helpers}/scripts/gh-api" <gh args…>
+```
+
+so GitHub primary **and** secondary rate-limit backoff is automatic. A direct
+`gh` call 403s hard once the secondary limiter trips.
+
+Full rationale, exemptions (`auth`, prompts, `--web`), and `scripts/gh-api --help`
+(the SSOT) — the canonical rule in repository-helpers:
+
+<!-- github-api-throttle-canonical: https://github.com/the-hcma/repository-helpers/blob/main/.cursor/rules/github-api-throttle.mdc -->
+https://github.com/the-hcma/repository-helpers/blob/main/.cursor/rules/github-api-throttle.mdc


### PR DESCRIPTION
## Summary

Adopt the dedicated **`.cursor/rules/github-api-throttle.mdc`** breadcrumb rule
(canonical rule in repository-helpers, `repository-helpers#608`).

A razor-thin, `gh`-only `alwaysApply` rule: agent flows that shell out to `gh`
(PR / issue triage, review replies, CI polling, `gh api`, `gh pr` / `gh issue`
reads and writes) run it through
`"${REPOSITORY_HELPERS_DIR:-$HOME/work/ai/repository-helpers}/scripts/gh-api"` so
GitHub primary **and** secondary rate-limit backoff is automatic — a direct `gh`
call 403s hard for most of an hour once the *secondary* limiter trips.

The file is a **breadcrumb + canonical URL**, not a copied body — same shape as
`.cursor/rules/stacking-tool.mdc`. New file, no other changes.

## Test plan

- `scripts/dev/pre-pr-checks` → `==> pre-pr-checks passed` (`.mdc`-only diff;
  ecosystem jobs and the pre-existing org-wide `repo-practices-lint` host-ledger
  flake are not affected by this change).
- `github-repo-lint --repo the-hcma/<repo> --suggest` — the
  `add .cursor/rules/github-api-throttle.mdc` SUGGEST clears once merged.
