### PR TITLE
feat(cli): emit shell completion via `bunnify --completion <shell>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,14 @@ Unknown keys exit non-zero in direct mode (no search-engine fallback).
 Tab completion for shortcut keys, outside the interactive REPL:
 
 ```bash
+mkdir -p ~/.local/share/bash-completion/completions
 bunnify --completion bash > ~/.local/share/bash-completion/completions/bunnify.bash
 ```
 
 That's a [bash-completion v2](https://github.com/scop/bash-completion) user
 directory — no rc file edit, lazy-loaded on first Tab press in a new shell.
-`zsh`/`fish` aren't supported yet.
+`zsh`/`fish` aren't supported yet. The emitted script calls `bunnify --list-keys`
+at completion time, so Tab-completing shortcuts needs the server running.
 
 `source etc/bunnify-completion` (from a source checkout) still works too.
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ bunnify --print-url gh
 
 Unknown keys exit non-zero in direct mode (no search-engine fallback).
 
+### 4. Shell completion (optional)
+
+Tab completion for shortcut keys, outside the interactive REPL:
+
+```bash
+bunnify --completion bash > ~/.local/share/bash-completion/completions/bunnify.bash
+```
+
+That's a [bash-completion v2](https://github.com/scop/bash-completion) user
+directory — no rc file edit, lazy-loaded on first Tab press in a new shell.
+`zsh`/`fish` aren't supported yet.
+
+`source etc/bunnify-completion` (from a source checkout) still works too.
+
 ## Features
 
 - **CLI / REPL** — fuzzy Tab completion, fzf mode, Vim/Emacs edit keys

--- a/app/cli.py
+++ b/app/cli.py
@@ -41,6 +41,7 @@ from app.config import (
     LOCAL_PORT_FILE_NAME,
     MIN_LOCAL_PORT,
     ServerPreferences,
+    completion_script_bytes,
     ensure_user_bookmarks,
     env_file_path,
     format_server_preferences_summary,
@@ -1876,6 +1877,27 @@ def _print_cli_version(
     ctx.exit()
 
 
+_SUPPORTED_COMPLETION_SHELLS = ("bash",)
+
+
+def _print_completion_script(
+    ctx: click.Context,
+    _param: click.Parameter,
+    value: str | None,
+) -> None:
+    if value is None or ctx.resilient_parsing:
+        return
+    if value not in _SUPPORTED_COMPLETION_SHELLS:
+        click.echo(f"bunnify: --completion {value} is not yet supported", err=True)
+        ctx.exit(2)
+    script = completion_script_bytes()
+    if script is None:
+        click.echo("bunnify: unable to locate the bash completion script", err=True)
+        ctx.exit(1)
+    click.echo(script.decode("utf-8"), nl=False)
+    ctx.exit(0)
+
+
 @click.command(
     context_settings={"help_option_names": ["-h", "--help"]},
 )
@@ -1886,6 +1908,15 @@ def _print_cli_version(
     expose_value=False,
     callback=_print_cli_version,
     help="Show the version and exit.",
+)
+@click.option(
+    "--completion",
+    type=click.Choice(_SUPPORTED_COMPLETION_SHELLS + ("zsh", "fish")),
+    is_eager=True,
+    expose_value=False,
+    callback=_print_completion_script,
+    metavar="SHELL",
+    help="Print the shell completion script for SHELL and exit (bash only, for now).",
 )
 @click.argument("shortcut_args", nargs=-1)
 @click.option(

--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,7 @@ from app.client import DEFAULT_BASE_URL
 
 BOOKMARKS_ENV_VAR = "BUNNIFY_BOOKMARKS"
 BOOKMARKS_FILE_NAME = "bookmarks.json"
+COMPLETION_SCRIPT_NAME = "bunnify-completion"
 DATA_DIR_ENV_VAR = "BUNNIFY_DATA_DIR"
 ENV_FILE_NAME = "config.env"
 ENV_VAR = "BUNNIFY_BASE_URL"
@@ -301,6 +302,31 @@ def example_bookmarks_bytes() -> bytes | None:
 def example_bookmarks_path(*, root: Path | None = None) -> Path:
     """Return the canonical example bookmarks file in a repository checkout."""
     return (root if root is not None else repo_root()) / EXAMPLE_BOOKMARKS_NAME
+
+
+def completion_script_bytes() -> bytes | None:
+    """Load the bash completion script from the packaged resource or repo etc/."""
+    try:
+        packaged = resources.files("app").joinpath("data", COMPLETION_SCRIPT_NAME)
+        return packaged.read_bytes()
+    except (
+        FileNotFoundError,
+        ModuleNotFoundError,
+        OSError,
+        TypeError,
+        AttributeError,
+    ):
+        pass
+
+    repo_script = completion_script_path()
+    if repo_script.is_file():
+        return repo_script.read_bytes()
+    return None
+
+
+def completion_script_path(*, root: Path | None = None) -> Path:
+    """Return the canonical bash completion script in a repository checkout."""
+    return (root if root is not None else repo_root()) / "etc" / COMPLETION_SCRIPT_NAME
 
 
 def seed_bookmarks_from_example(dest: Path) -> Path:

--- a/bookmarks/test_cli.py
+++ b/bookmarks/test_cli.py
@@ -1387,6 +1387,33 @@ class ConfigUnitTests(TestCase):
             self.assertNotIn("No bookmarks example found", str(context.exception))
             self.assertFalse(target.exists())
 
+    def test_completion_script_bytes_reads_packaged_resource(self) -> None:
+        from unittest.mock import patch
+
+        from app.config import completion_script_bytes
+
+        with patch("app.config.resources.files") as mock_files:
+            mock_files.return_value.joinpath.return_value.read_bytes.return_value = (
+                b"packaged script"
+            )
+            script = completion_script_bytes()
+
+        self.assertEqual(script, b"packaged script")
+        mock_files.assert_called_once_with("app")
+
+    def test_completion_script_bytes_falls_back_to_repo_etc(self) -> None:
+        from unittest.mock import patch
+
+        from app.config import completion_script_bytes
+
+        with patch(
+            "app.config.resources.files", side_effect=ModuleNotFoundError("app")
+        ):
+            script = completion_script_bytes()
+
+        self.assertIsNotNone(script)
+        self.assertIn(b"_bunnify_completion", script)
+
     def test_ensure_user_bookmarks_returns_existing_on_seed_race(self) -> None:
         import tempfile
         from pathlib import Path
@@ -2955,6 +2982,48 @@ class ConfigUnitTests(TestCase):
             flagged = CliRunner().invoke(main, ["--onboard"])
             self.assertEqual(flagged.exit_code, 0)
             self.assertIn("bunnify setup", flagged.output)
+
+    def test_completion_bash_prints_script(self) -> None:
+        from app.cli import main
+
+        result = CliRunner().invoke(main, ["--completion", "bash"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("_bunnify_completion", result.output)
+        self.assertIn("complete -F _bunnify_completion bunnify", result.output)
+
+    def test_completion_unsupported_shell_exits_two(self) -> None:
+        from app.cli import main
+
+        for shell in ("zsh", "fish"):
+            with self.subTest(shell=shell):
+                result = CliRunner().invoke(main, ["--completion", shell])
+                self.assertEqual(result.exit_code, 2)
+                self.assertIn("not yet supported", result.output)
+
+    def test_completion_invalid_shell_is_usage_error(self) -> None:
+        from app.cli import main
+
+        result = CliRunner().invoke(main, ["--completion", "powershell"])
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("Invalid value", result.output)
+
+    def test_completion_missing_value_is_usage_error(self) -> None:
+        from app.cli import main
+
+        result = CliRunner().invoke(main, ["--completion"])
+
+        self.assertEqual(result.exit_code, 2)
+
+    def test_completion_missing_script_errors(self) -> None:
+        from app.cli import main
+
+        with patch("app.cli.completion_script_bytes", return_value=None):
+            result = CliRunner().invoke(main, ["--completion", "bash"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("unable to locate", result.output)
 
     def test_upgrade_runs_pipx_and_explains_checkout(self) -> None:
         import subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,14 +57,16 @@ packages = ["app", "bookmarks"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "bunnify.json.example" = "app/data/bookmarks.example.json"
+"etc/bunnify-completion" = "app/data/bunnify-completion"
 
 [tool.hatch.build.targets.sdist]
 packages = ["app", "bookmarks"]
 
-# Keep the repo-root path inside the sdist so `uv build` (wheel-from-sdist) can
-# still resolve the wheel force-include source path above.
+# Keep the repo-root paths inside the sdist so `uv build` (wheel-from-sdist) can
+# still resolve the wheel force-include source paths above.
 [tool.hatch.build.targets.sdist.force-include]
 "bunnify.json.example" = "bunnify.json.example"
+"etc/bunnify-completion" = "etc/bunnify-completion"
 
 [dependency-groups]
 dev = [

--- a/test_packaging
+++ b/test_packaging
@@ -96,6 +96,43 @@ if packaged != canonical:
     )
 PY
 
+echo "📦 Verifying sdist keeps etc/bunnify-completion at repo-root path..."
+uv run python - "$repo_root/etc/bunnify-completion" "$sdist_path" <<'PY'
+import sys
+import tarfile
+from pathlib import Path
+
+canonical = Path(sys.argv[1]).read_bytes()
+with tarfile.open(sys.argv[2], "r:gz") as sdist:
+    members = [
+        name
+        for name in sdist.getnames()
+        if name.endswith("/etc/bunnify-completion") or name == "etc/bunnify-completion"
+    ]
+    if len(members) != 1:
+        raise SystemExit(
+            f"Expected one etc/bunnify-completion in sdist, got {members!r}"
+        )
+    packaged = sdist.extractfile(members[0]).read()
+if packaged != canonical:
+    raise SystemExit("Sdist etc/bunnify-completion does not match repo file")
+PY
+
+echo "📦 Verifying wheel bundles etc/bunnify-completion..."
+uv run python - "$repo_root/etc/bunnify-completion" "$wheel_path" <<'PY'
+import sys
+import zipfile
+from pathlib import Path
+
+canonical = Path(sys.argv[1]).read_bytes()
+with zipfile.ZipFile(sys.argv[2]) as wheel:
+    packaged = wheel.read("app/data/bunnify-completion")
+if packaged != canonical:
+    raise SystemExit(
+        "Wheel app/data/bunnify-completion does not match etc/bunnify-completion"
+    )
+PY
+
 echo "📦 Installing wheel into an isolated virtual environment..."
 timeout 120 uv venv --python 3.14 "$venv_dir"
 timeout 120 uv pip install --python "$venv_dir/bin/python" "$wheel_path"
@@ -136,6 +173,13 @@ installed_env "$bin_dir/bunnify-server" --help >/dev/null
 installed_env "$bin_dir/bunnify-server" --version
 installed_env "$bin_dir/spotty-bunny" --help >/dev/null
 installed_env "$bin_dir/spotty-bunny" --version
+
+echo "📦 Verifying installed --completion bash needs no source checkout..."
+completion_output="$("$bin_dir/bunnify" --completion bash)"
+if [[ "$completion_output" != *"_bunnify_completion"* ]]; then
+    echo "Installed --completion bash did not print the completion script" >&2
+    exit 1
+fi
 
 echo "🐰 Starting installed server outside the repository..."
 installed_env "$bin_dir/bunnify-server" \


### PR DESCRIPTION
## Summary
- Add an eager `--completion <bash|zsh|fish>` option to `bunnify`, mirroring the existing `--version` flag, that prints the bash completion script and exits (zsh/fish exit 2, not yet supported)
- Ship `etc/bunnify-completion` as wheel/sdist package data (`app/data/bunnify-completion`) so `pipx install bunnify` can reach it without a source checkout, with a packaged-resource → repo `etc/` fallback
- Document the bash-completion v2 user-dir one-liner in the README; `source etc/bunnify-completion` still works for source checkouts

Closes #398.

## Test plan
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright --warnings`
- [x] `./test_bunnify` (503 tests)
- [x] `./scripts/checks` (full preflight, including `test_packaging` and `test_integration`)
- [x] Extended `test_packaging` to verify the wheel/sdist bundle `etc/bunnify-completion` and that an installed wheel's `bunnify --completion bash` works outside the repo
- [x] Manually verified `bunnify --completion bash|zsh|nope|<missing>` behavior and a clean-venv wheel install