### PR TITLE
docs: hyperlink the GitHub handle in the README license notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,5 +366,5 @@ Maintainers:
 
 ## License
 
-MIT © 2026 Henrique Andrade (GitHub's thehcma) — see
+MIT © 2026 Henrique Andrade ([GitHub's thehcma](https://github.com/thehcma)) — see
 [LICENSE](https://github.com/the-hcma/bunnify/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

- The README's license line named "GitHub's thehcma" as plain text; links
  it to the actual profile instead.

## Test plan

- [x] `"${REPOSITORY_HELPERS_DIR}/scripts/dev/pre-pr-checks"` - `==> pre-pr-checks passed`