### PR TITLE
fix(spotty-bunny): reflect self-staleness in the update badge, not just PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,13 @@ bunnify spotty-bunny uninstall
 
 That boots the agent out, removes the plist, and stops a leftover overlay
 process. Bookmarks and `config.env` are unchanged. Right-click the bunny icon
-for **Install Spotty Bunny** (when the LaunchAgent is missing), **Quit Spotty
-Bunny**, **Uninstall Spotty Bunny**, and (when installed and a newer PyPI
-version is known) **Upgrade Spotty Bunny**. An up-arrow badge on the
-icon and an About line mark an outdated install (PyPI is checked at most
-once a day).
+for **Check for Updates** (forces an immediate PyPI check, skipping the daily
+cache), **Install** (when the LaunchAgent is missing), **Quit**, **Uninstall**,
+and (when installed and either a newer PyPI release is out or this running
+overlay predates what's actually installed) **Upgrade**. An up-arrow badge on
+the icon and an About line mark either case — a newer PyPI release (checked
+at most once a day) or this process simply running stale bits after a local
+upgrade; both clear once **Upgrade** restarts the overlay.
 
 Left-click the bunny for About: bookmarks file, GitHub repo when that file
 lives in a GitHub checkout, and whether the CLI is talking to a local or

--- a/app/coherence.py
+++ b/app/coherence.py
@@ -10,7 +10,11 @@ from packaging.version import InvalidVersion, Version
 
 from app.client import HealthStatus, fetch_health
 from app.theme import Theme
-from app.version import get_build_info, installed_package_version
+from app.version import (
+    get_build_info,
+    installed_package_commit,
+    installed_package_version,
+)
 
 RestartFn = Callable[[str | None, str], bool]
 
@@ -99,11 +103,14 @@ def running_is_stale(*, running_version: str, installed_version: str) -> bool:
     Used to detect a long-running process (Spotty Bunny) whose own cached
     build predates an in-place upgrade on disk — distinct from a genuine
     server/client skew, since nothing about the server is involved here.
+    Mirrors :func:`cli_is_newer_than`: an unparseable version (e.g. the
+    ``"unknown"`` sentinel) says nothing about direction, so it is never
+    treated as stale.
     """
     try:
         return Version(running_version) < Version(installed_version)
     except InvalidVersion:
-        return running_version != installed_version
+        return False
 
 
 def spotty_self_stale() -> bool:
@@ -114,12 +121,21 @@ def spotty_self_stale() -> bool:
     local upgrade replaces the installed package underneath it. Comparing
     that frozen value to a fresh, uncached read of the installed version
     surfaces that self-staleness without needing a restart to detect it.
+
+    A version bump isn't the only way to drift: a source-checkout rebuild
+    (or a same-version wheel reinstall) can change the commit without
+    changing ``pyproject.toml``'s version, so the commit is checked too.
     """
-    running_version, _running_commit = get_build_info()
-    return running_is_stale(
+    running_version, running_commit = get_build_info()
+    if running_is_stale(
         running_version=running_version,
         installed_version=installed_package_version(),
-    )
+    ):
+        return True
+    installed_commit = installed_package_commit()
+    if running_commit == "unknown" or installed_commit == "unknown":
+        return False
+    return running_commit != installed_commit
 
 
 def ensure_local_spotty_aligned(

--- a/app/coherence.py
+++ b/app/coherence.py
@@ -10,7 +10,7 @@ from packaging.version import InvalidVersion, Version
 
 from app.client import HealthStatus, fetch_health
 from app.theme import Theme
-from app.version import get_build_info
+from app.version import get_build_info, installed_package_version
 
 RestartFn = Callable[[str | None, str], bool]
 
@@ -91,6 +91,35 @@ def cli_is_newer_than(health: HealthStatus) -> bool:
         return Version(health.version) < Version(local_version)
     except InvalidVersion:
         return False
+
+
+def running_is_stale(*, running_version: str, installed_version: str) -> bool:
+    """Return whether *installed_version* is newer than *running_version*.
+
+    Used to detect a long-running process (Spotty Bunny) whose own cached
+    build predates an in-place upgrade on disk — distinct from a genuine
+    server/client skew, since nothing about the server is involved here.
+    """
+    try:
+        return Version(running_version) < Version(installed_version)
+    except InvalidVersion:
+        return running_version != installed_version
+
+
+def spotty_self_stale() -> bool:
+    """Return whether this process's build predates what is now installed.
+
+    ``get_build_info()`` is cached once per process, so a long-running
+    Spotty Bunny overlay keeps reporting its build at launch even after a
+    local upgrade replaces the installed package underneath it. Comparing
+    that frozen value to a fresh, uncached read of the installed version
+    surfaces that self-staleness without needing a restart to detect it.
+    """
+    running_version, _running_commit = get_build_info()
+    return running_is_stale(
+        running_version=running_version,
+        installed_version=installed_package_version(),
+    )
 
 
 def ensure_local_spotty_aligned(

--- a/app/spotty_bunny_about_info.py
+++ b/app/spotty_bunny_about_info.py
@@ -12,7 +12,7 @@ from typing import Literal
 from urllib.parse import unquote, urlparse
 
 from app.client import fetch_health
-from app.coherence import builds_match, format_build_label
+from app.coherence import builds_match, format_build_label, spotty_self_stale
 from app.config import (
     default_bookmarks_path,
     load_preferences,
@@ -36,6 +36,7 @@ class AboutRuntimeInfo:
     github_display: str | None
     github_url: str | None
     local_build_label: str
+    self_stale: bool
     server_agent_installed: bool
     server_build_label: str | None
     server_display: str
@@ -216,6 +217,7 @@ def load_about_runtime_info(
         github_display=github_display,
         github_url=github_url,
         local_build_label=_local_build_label(),
+        self_stale=spotty_self_stale(),
         server_agent_installed=_server_agent_installed(),
         server_build_label=server_build_label,
         server_display=f"{label} · {base_url}",
@@ -256,10 +258,20 @@ def path_from_file_uri(uri: str) -> Path | None:
 def server_skew_message(runtime: AboutRuntimeInfo) -> str | None:
     """Return the About-panel build-skew warning, or None when aligned.
 
+    Self-staleness (this running overlay predates what's now installed)
+    takes priority: it explains a skew this process itself would otherwise
+    misattribute to the server, and it never requires touching the server.
+
     A remote server is deployed independently of this Mac, so skew there is
     advisory. A local server is expected to track this install, so name the
     command that realigns it.
     """
+    if runtime.self_stale:
+        return (
+            "This Spotty Bunny process is running an older build than what's "
+            "installed. Restart it: choose Upgrade from the 🐰 menu (or run "
+            "bunnify spotty-bunny upgrade)."
+        )
     if not runtime.server_skewed:
         return None
     server_build = f"Server build {runtime.server_build_label or 'unknown build'}"

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -390,6 +390,7 @@ class SpottyBunnyController(NSObject):
         self._resolve_seq = 0
         self._resolving = False
         self._shortcuts_load_failed = False
+        self._self_stale = False
         self._server_skewed = False
         self._update_check_pending = False
         self._update_check_requeue = False
@@ -535,10 +536,17 @@ class SpottyBunnyController(NSObject):
         text_view.setSelectedRange_(NSMakeRange(location, sel_length))
 
     def _outdated_badge(self) -> bool:
-        """PyPI is newer, this process is stale, or the server build skews."""
+        """PyPI is newer, this process is stale, or the server build skews.
+
+        ``self._self_stale`` / ``self._server_skewed`` are refreshed on the
+        background daily/manual-check cadence (see ``_check_update_and_skew``)
+        rather than computed here: ``spotty_self_stale()`` can re-exec a file
+        and spawn a ``git`` subprocess, and this is called synchronously from
+        the AppKit main thread (``menuNeedsUpdate_`` on every right-click).
+        """
         return badge_should_show(
             self._update_status,
-            self_stale=spotty_self_stale(),
+            self_stale=self._self_stale,
             server_skewed=self._server_skewed,
         )
 
@@ -1248,15 +1256,16 @@ class SpottyBunnyController(NSObject):
                 if announce:
                     self._set_status("Could not check for updates.")
             elif isinstance(result, tuple) and isinstance(result[0], UpdateStatus):
-                status, server_skewed = result
+                status, server_skewed, self_stale = result
                 self._update_status = status
                 self._server_skewed = server_skewed
+                self._self_stale = self_stale
                 self._apply_update_status()
                 if announce:
                     self._set_status(
                         summarize_update_check(
                             status,
-                            self_stale=spotty_self_stale(),
+                            self_stale=self_stale,
                             server_skewed=server_skewed,
                         )
                     )
@@ -1512,17 +1521,21 @@ def _confirm_install_gh() -> bool:
     return int(alert.runModal()) == int(NSAlertFirstButtonReturn)
 
 
-def _check_update_and_skew(*, force: bool) -> tuple[UpdateStatus, bool]:
+def _check_update_and_skew(*, force: bool) -> tuple[UpdateStatus, bool, bool]:
     """Background-thread work for the daily/manual update check.
 
-    Bundles the PyPI lookup with a fresh server-skew read so a genuine
-    client/server mismatch (the About panel's #377 case) can drive the icon
-    badge too, on the same infrequent cadence as the PyPI check rather than
-    on every icon refresh.
+    Bundles the PyPI lookup with a fresh server-skew read and self-staleness
+    check so a genuine client/server mismatch (the About panel's #377 case)
+    and a stale-in-place-upgrade overlay can both drive the icon badge, on
+    the same infrequent cadence as the PyPI check. Also keeps
+    ``spotty_self_stale()`` — which can re-exec a file and spawn a ``git``
+    subprocess — off the AppKit main thread, which only reads the cached
+    result via ``_outdated_badge()``.
     """
     status = refresh_update_status(force=force)
     server_skewed = load_about_runtime_info().server_skewed
-    return status, server_skewed
+    self_stale = spotty_self_stale()
+    return status, server_skewed, self_stale
 
 
 def _confirm_uninstall() -> bool:

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -9,6 +9,7 @@ import os
 import signal
 import sys
 import time
+from functools import partial
 
 import objc
 from Cocoa import (
@@ -112,6 +113,7 @@ from Quartz import (
 
 from app.cli import open_url
 from app.client import fetch_key_entries, fetch_suggestions
+from app.coherence import spotty_self_stale
 from app.config import resolve_base_url
 from app.github_complete import (
     bootstrap_github_completion_cache,
@@ -185,6 +187,7 @@ from app.spotty_bunny_hotkey import (
 from app.spotty_bunny_icon import make_spotty_bunny_icon
 from app.spotty_bunny_io import ThreadIo
 from app.spotty_bunny_menu import (
+    CHECK_FOR_UPDATES_STATUS,
     INSTALL_STATUS,
     UNINSTALL_INFORMATIVE,
     UNINSTALL_MENU_TITLE,
@@ -218,9 +221,11 @@ from app.spotty_bunny_tap_health import (
 )
 from app.spotty_bunny_update import (
     UpdateStatus,
+    badge_should_show,
     cache_is_stale,
     read_cached_update_status,
     refresh_update_status,
+    summarize_update_check,
 )
 from app.version import get_build_info
 
@@ -316,6 +321,14 @@ class SpottyBunnyController(NSObject):
     def checkEventTapHealth_(self, _timer) -> None:
         """Periodic timer: re-enable or reinstall a stale CGEventTap."""
         _check_event_tap_health(self)
+
+    def checkForUpdates_(self, _sender) -> None:
+        """Force an immediate PyPI check, bypassing the daily cache."""
+        if self._update_check_pending:
+            return
+        logger.info("check for updates from logo menu")
+        self._set_status(CHECK_FOR_UPDATES_STATUS)
+        self._schedule_update_check(force=True, announce=True)
 
     def dismissWithEscape_(self, _sender) -> None:
         """Hide About first, then the overlay. Ignore repeats until key-up."""
@@ -515,8 +528,12 @@ class SpottyBunnyController(NSObject):
         )
         text_view.setSelectedRange_(NSMakeRange(location, sel_length))
 
+    def _outdated_badge(self) -> bool:
+        """PyPI has a newer release, or this process predates what's installed."""
+        return badge_should_show(self._update_status, self_stale=spotty_self_stale())
+
     def _apply_update_status(self) -> None:
-        outdated = self._update_status.outdated
+        outdated = self._outdated_badge()
         if self.logo is not None:
             self.logo.setImage_(make_spotty_bunny_icon(LOGO_SIZE, outdated=outdated))
         if self._logo_menu is not None:
@@ -567,7 +584,7 @@ class SpottyBunnyController(NSObject):
         logo.setBezelStyle_(NSBezelStyleShadowlessSquare)
         logo.setBordered_(False)
         logo.setImage_(
-            make_spotty_bunny_icon(LOGO_SIZE, outdated=self._update_status.outdated)
+            make_spotty_bunny_icon(LOGO_SIZE, outdated=self._outdated_badge())
         )
         logo.setImageScaling_(NSImageScaleProportionallyUpOrDown)
         logo.setTarget_(self)
@@ -928,7 +945,7 @@ class SpottyBunnyController(NSObject):
         menu.removeAllItems()
         for title, action in logo_menu_specs(
             installed=is_agent_installed(),
-            outdated=self._update_status.outdated,
+            outdated=self._outdated_badge(),
         ):
             item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
                 title,
@@ -1045,11 +1062,21 @@ class SpottyBunnyController(NSObject):
             )
         self._center_panel()
 
-    def _schedule_update_check(self) -> None:
+    def _schedule_update_check(
+        self, *, force: bool = False, announce: bool = False
+    ) -> None:
         if self._update_check_pending:
             return
         self._update_check_pending = True
-        self._io.submit(refresh_update_status, self._update_check_ready)
+        check = (
+            partial(refresh_update_status, force=True)
+            if force
+            else refresh_update_status
+        )
+        self._io.submit(
+            check,
+            lambda result: self._update_check_ready(result, announce=announce),
+        )
 
     def _show_completions(
         self,
@@ -1202,15 +1229,21 @@ class SpottyBunnyController(NSObject):
 
         self._io.submit(work, lambda result: self._resolve_ready(result, seq=seq))
 
-    def _update_check_ready(self, result: object) -> None:
+    def _update_check_ready(self, result: object, *, announce: bool = False) -> None:
         def apply() -> None:
             self._update_check_pending = False
             if isinstance(result, Exception):
                 logger.warning("PyPI version check failed: %s", result)
+                if announce:
+                    self._set_status("Could not check for updates.")
                 return
             if isinstance(result, UpdateStatus):
                 self._update_status = result
                 self._apply_update_status()
+                if announce:
+                    self._set_status(
+                        summarize_update_check(result, self_stale=spotty_self_stale())
+                    )
 
         _run_on_main(apply)
 

--- a/app/spotty_bunny_app.py
+++ b/app/spotty_bunny_app.py
@@ -132,6 +132,7 @@ from app.spotty_bunny_about import (
     build_about_panel,
     position_about_panel,
 )
+from app.spotty_bunny_about_info import load_about_runtime_info
 from app.spotty_bunny_agent import (
     bootout_loaded_agent,
     install_agent,
@@ -323,9 +324,12 @@ class SpottyBunnyController(NSObject):
         _check_event_tap_health(self)
 
     def checkForUpdates_(self, _sender) -> None:
-        """Force an immediate PyPI check, bypassing the daily cache."""
-        if self._update_check_pending:
-            return
+        """Force an immediate PyPI/server check, bypassing the daily cache.
+
+        If a check is already in flight, queue this one instead of dropping
+        it silently — it runs (forced, with a result reported) as soon as
+        the in-flight one finishes.
+        """
         logger.info("check for updates from logo menu")
         self._set_status(CHECK_FOR_UPDATES_STATUS)
         self._schedule_update_check(force=True, announce=True)
@@ -386,7 +390,9 @@ class SpottyBunnyController(NSObject):
         self._resolve_seq = 0
         self._resolving = False
         self._shortcuts_load_failed = False
+        self._server_skewed = False
         self._update_check_pending = False
+        self._update_check_requeue = False
         self._update_status = read_cached_update_status()
         self.callback = None
         self.chord = ChordTracker()
@@ -529,8 +535,12 @@ class SpottyBunnyController(NSObject):
         text_view.setSelectedRange_(NSMakeRange(location, sel_length))
 
     def _outdated_badge(self) -> bool:
-        """PyPI has a newer release, or this process predates what's installed."""
-        return badge_should_show(self._update_status, self_stale=spotty_self_stale())
+        """PyPI is newer, this process is stale, or the server build skews."""
+        return badge_should_show(
+            self._update_status,
+            self_stale=spotty_self_stale(),
+            server_skewed=self._server_skewed,
+        )
 
     def _apply_update_status(self) -> None:
         outdated = self._outdated_badge()
@@ -1066,15 +1076,14 @@ class SpottyBunnyController(NSObject):
         self, *, force: bool = False, announce: bool = False
     ) -> None:
         if self._update_check_pending:
+            # Don't drop a manual check on the floor because a background one
+            # is already in flight — run it (forced, announced) right after.
+            if force:
+                self._update_check_requeue = True
             return
         self._update_check_pending = True
-        check = (
-            partial(refresh_update_status, force=True)
-            if force
-            else refresh_update_status
-        )
         self._io.submit(
-            check,
+            partial(_check_update_and_skew, force=force),
             lambda result: self._update_check_ready(result, announce=announce),
         )
 
@@ -1232,18 +1241,28 @@ class SpottyBunnyController(NSObject):
     def _update_check_ready(self, result: object, *, announce: bool = False) -> None:
         def apply() -> None:
             self._update_check_pending = False
+            requeue = self._update_check_requeue
+            self._update_check_requeue = False
             if isinstance(result, Exception):
-                logger.warning("PyPI version check failed: %s", result)
+                logger.warning("update/skew check failed: %s", result)
                 if announce:
                     self._set_status("Could not check for updates.")
-                return
-            if isinstance(result, UpdateStatus):
-                self._update_status = result
+            elif isinstance(result, tuple) and isinstance(result[0], UpdateStatus):
+                status, server_skewed = result
+                self._update_status = status
+                self._server_skewed = server_skewed
                 self._apply_update_status()
                 if announce:
                     self._set_status(
-                        summarize_update_check(result, self_stale=spotty_self_stale())
+                        summarize_update_check(
+                            status,
+                            self_stale=spotty_self_stale(),
+                            server_skewed=server_skewed,
+                        )
                     )
+            if requeue:
+                self._set_status(CHECK_FOR_UPDATES_STATUS)
+                self._schedule_update_check(force=True, announce=True)
 
         _run_on_main(apply)
 
@@ -1491,6 +1510,19 @@ def _confirm_install_gh() -> bool:
     alert.addButtonWithTitle_("Install")
     alert.addButtonWithTitle_("Not now")
     return int(alert.runModal()) == int(NSAlertFirstButtonReturn)
+
+
+def _check_update_and_skew(*, force: bool) -> tuple[UpdateStatus, bool]:
+    """Background-thread work for the daily/manual update check.
+
+    Bundles the PyPI lookup with a fresh server-skew read so a genuine
+    client/server mismatch (the About panel's #377 case) can drive the icon
+    badge too, on the same infrequent cadence as the PyPI check rather than
+    on every icon refresh.
+    """
+    status = refresh_update_status(force=force)
+    server_skewed = load_about_runtime_info().server_skewed
+    return status, server_skewed
 
 
 def _confirm_uninstall() -> bool:

--- a/app/spotty_bunny_menu.py
+++ b/app/spotty_bunny_menu.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-INSTALL_MENU_TITLE = "Install Spotty Bunny"
+CHECK_FOR_UPDATES_MENU_TITLE = "Check for Updates"
+CHECK_FOR_UPDATES_STATUS = "Checking for updates…"
+INSTALL_MENU_TITLE = "Install"
 INSTALL_STATUS = "Installing LaunchAgent…"
-QUIT_MENU_TITLE = "Quit Spotty Bunny"
+QUIT_MENU_TITLE = "Quit"
 UNINSTALL_INFORMATIVE = (
     "Removes the login LaunchAgent and stops Spotty Bunny. "
     "Bookmarks and config.env are kept."
 )
-UNINSTALL_MENU_TITLE = "Uninstall Spotty Bunny"
-UPGRADE_MENU_TITLE = "Upgrade Spotty Bunny"
+UNINSTALL_MENU_TITLE = "Uninstall"
+UPGRADE_MENU_TITLE = "Upgrade"
 UPGRADE_STATUS = "Upgrading Bunnify from PyPI…"
 
 
@@ -21,10 +23,14 @@ def logo_menu_specs(
 ) -> tuple[tuple[str, str], ...]:
     """Return logo menu (title, action) pairs in lexicographic title order.
 
-    Install is shown when the LaunchAgent is missing. Upgrade is shown only
-    when the agent is installed and a newer PyPI version is known.
+    Check for Updates always shows. Install is shown when the LaunchAgent is
+    missing. Upgrade is shown only when the agent is installed and either a
+    newer PyPI version is known or the running overlay is itself stale.
     """
-    items: list[tuple[str, str]] = [(QUIT_MENU_TITLE, "quitSpottyBunny:")]
+    items: list[tuple[str, str]] = [
+        (CHECK_FOR_UPDATES_MENU_TITLE, "checkForUpdates:"),
+        (QUIT_MENU_TITLE, "quitSpottyBunny:"),
+    ]
     if installed:
         items.append((UNINSTALL_MENU_TITLE, "uninstallSpottyBunny:"))
         if outdated:

--- a/app/spotty_bunny_update.py
+++ b/app/spotty_bunny_update.py
@@ -37,23 +37,31 @@ def cache_is_stale(checked_at: float | None, *, now: float | None = None) -> boo
     return moment - checked_at >= CHECK_INTERVAL_S
 
 
-def badge_should_show(status: UpdateStatus, *, self_stale: bool) -> bool:
+def badge_should_show(
+    status: UpdateStatus, *, self_stale: bool, server_skewed: bool = False
+) -> bool:
     """True when the update badge should show.
 
-    Either PyPI has a newer release than what's installed, or this running
-    process's own build predates what is now installed (self-staleness —
-    fixable by Upgrade alone, no PyPI release required).
+    Any of three signals: PyPI has a newer release than what's installed,
+    this running process's own build predates what is now installed
+    (self-staleness — fixable by Upgrade alone, no PyPI release required),
+    or the server's build genuinely differs from a freshly resolved local
+    build (the About panel's #377 skew message).
     """
-    return status.outdated or self_stale
+    return status.outdated or self_stale or server_skewed
 
 
-def summarize_update_check(status: UpdateStatus, *, self_stale: bool) -> str:
+def summarize_update_check(
+    status: UpdateStatus, *, self_stale: bool, server_skewed: bool = False
+) -> str:
     """One-line result for a user-initiated "Check for Updates"."""
     if self_stale:
         return (
             "This overlay is running an older build than what's installed. "
             "Choose Upgrade to restart it."
         )
+    if server_skewed:
+        return "Server build differs from this Mac's — see About for details."
     if status.outdated and status.latest:
         return f"Update available: {status.latest}"
     return "Spotty Bunny is up to date."

--- a/app/spotty_bunny_update.py
+++ b/app/spotty_bunny_update.py
@@ -64,6 +64,10 @@ def summarize_update_check(
         return "Server build differs from this Mac's — see About for details."
     if status.outdated and status.latest:
         return f"Update available: {status.latest}"
+    if status.latest is None:
+        # No successful PyPI lookup has ever completed (offline, unreachable,
+        # or a transient failure) — that's not the same as confirmed current.
+        return "Could not check for updates."
     return "Spotty Bunny is up to date."
 
 

--- a/app/spotty_bunny_update.py
+++ b/app/spotty_bunny_update.py
@@ -37,6 +37,28 @@ def cache_is_stale(checked_at: float | None, *, now: float | None = None) -> boo
     return moment - checked_at >= CHECK_INTERVAL_S
 
 
+def badge_should_show(status: UpdateStatus, *, self_stale: bool) -> bool:
+    """True when the update badge should show.
+
+    Either PyPI has a newer release than what's installed, or this running
+    process's own build predates what is now installed (self-staleness —
+    fixable by Upgrade alone, no PyPI release required).
+    """
+    return status.outdated or self_stale
+
+
+def summarize_update_check(status: UpdateStatus, *, self_stale: bool) -> str:
+    """One-line result for a user-initiated "Check for Updates"."""
+    if self_stale:
+        return (
+            "This overlay is running an older build than what's installed. "
+            "Choose Upgrade to restart it."
+        )
+    if status.outdated and status.latest:
+        return f"Update available: {status.latest}"
+    return "Spotty Bunny is up to date."
+
+
 def is_version_outdated(current: str, latest: str | None) -> bool:
     """True when *latest* is a newer package version than *current*."""
     if not latest:

--- a/app/version.py
+++ b/app/version.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -105,6 +106,59 @@ def installed_package_version(*, pyproject_path: Path | None = None) -> str:
     except PackageNotFoundError:
         path = pyproject_path or Path(__file__).resolve().parents[1] / "pyproject.toml"
         return _pyproject_version(path)
+
+
+def installed_package_commit(
+    *,
+    environ: Mapping[str, str] | None = None,
+    repository: Path | None = None,
+) -> str:
+    """Return the commit actually installed on disk right now.
+
+    Distribution metadata has no standard commit field, so (unlike
+    :func:`installed_package_version`) this cannot lean on
+    :mod:`importlib.metadata`. Instead it re-reads the on-disk
+    ``_build_metadata`` module file fresh — bypassing the copy already
+    imported into this process, which an in-place upgrade (pipx reinstall,
+    sdist rebuild at the same version) leaves stale — falling back to a
+    live ``git`` lookup exactly like :func:`git_commit`.
+    """
+    environment = os.environ if environ is None else environ
+    for key in ("BUNNIFY_GIT_SHA", "GITHUB_SHA"):
+        configured_sha = environment.get(key, "").strip()
+        if configured_sha:
+            return _normalize_commit(configured_sha)
+
+    fresh_embedded = _reread_build_metadata_attr("EMBEDDED_COMMIT")
+    if fresh_embedded:
+        return _normalize_commit(fresh_embedded)
+
+    return git_commit(environ=environment, repository=repository)
+
+
+def _reread_build_metadata_attr(name: str) -> str:
+    """Re-read *name* from ``_build_metadata``'s current on-disk file.
+
+    Loaded as a throwaway module (never registered in ``sys.modules``) so a
+    file an in-place upgrade replaced on disk is reflected immediately,
+    instead of the already-imported ``app._build_metadata`` object's frozen
+    values.
+    """
+    path = getattr(_build_metadata, "__file__", None)
+    if not path:
+        return ""
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_bunnify_fresh_build_metadata", path
+        )
+        if spec is None or spec.loader is None:
+            return ""
+        fresh = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(fresh)
+    except OSError, SyntaxError:
+        return ""
+    value = getattr(fresh, name, "")
+    return value.strip() if isinstance(value, str) else ""
 
 
 def running_command_path() -> Path:

--- a/app/version.py
+++ b/app/version.py
@@ -91,6 +91,22 @@ def package_version(*, pyproject_path: Path | None = None) -> str:
         return _pyproject_version(path)
 
 
+def installed_package_version(*, pyproject_path: Path | None = None) -> str:
+    """Return the version actually installed on disk right now.
+
+    Unlike :func:`package_version`, this never returns the baked-in
+    ``EMBEDDED_VERSION`` a long-running process resolved at import time — it
+    re-reads distribution metadata (or, in a source checkout, ``pyproject.toml``)
+    on every call, so an in-place upgrade underneath an already-running process
+    is visible without restarting it.
+    """
+    try:
+        return version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        path = pyproject_path or Path(__file__).resolve().parents[1] / "pyproject.toml"
+        return _pyproject_version(path)
+
+
 def running_command_path() -> Path:
     """Return the path of the command that started this process.
 

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -528,6 +528,7 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             github_display="github.com/acme/repo",
             github_url="https://github.com/acme/repo",
             local_build_label="0.10.0 (abc123456789)",
+            self_stale=False,
             server_agent_installed=False,
             server_build_label="0.10.0 (abc123456789)",
             server_display="Local server · http://127.0.0.1:8000",
@@ -656,6 +657,92 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
         self.assertIn("this Mac's 0.10.0 (newnewnewnew)", message)
         self.assertIn("redeploy", message)
         self.assertNotIn("bunnify-server", message)
+
+    def test_server_skew_message_self_stale_takes_priority(self) -> None:
+        from app.spotty_bunny_about_info import server_skew_message
+
+        message = server_skew_message(
+            _about_runtime(
+                self_stale=True,
+                server_mode="remote",
+                server_skewed=True,
+            )
+        )
+        self.assertIsNotNone(message)
+        assert message is not None
+        self.assertIn("older build", message)
+        self.assertIn("bunnify spotty-bunny upgrade", message)
+        self.assertNotIn("redeploy", message)
+        self.assertNotIn("Server build", message)
+
+    def test_server_skew_message_self_stale_without_server_skew(self) -> None:
+        from app.spotty_bunny_about_info import server_skew_message
+
+        message = server_skew_message(
+            _about_runtime(self_stale=True, server_mode="local", server_skewed=False)
+        )
+        self.assertIsNotNone(message)
+        assert message is not None
+        self.assertIn("older build", message)
+
+    def test_running_is_stale_compares_pep440(self) -> None:
+        from app.coherence import running_is_stale
+
+        self.assertTrue(
+            running_is_stale(running_version="0.12.0", installed_version="0.13.0")
+        )
+        self.assertFalse(
+            running_is_stale(running_version="0.13.0", installed_version="0.13.0")
+        )
+        self.assertFalse(
+            running_is_stale(running_version="0.13.0", installed_version="0.12.0")
+        )
+
+    def test_running_is_stale_falls_back_to_string_compare_when_unparseable(
+        self,
+    ) -> None:
+        from app.coherence import running_is_stale
+
+        self.assertTrue(
+            running_is_stale(running_version="unknown", installed_version="0.13.0")
+        )
+        self.assertFalse(
+            running_is_stale(running_version="unknown", installed_version="unknown")
+        )
+
+    def test_spotty_self_stale_detects_in_place_upgrade(self) -> None:
+        from unittest.mock import patch
+
+        from app.coherence import spotty_self_stale
+
+        with (
+            patch("app.coherence.get_build_info", return_value=("0.12.0", "oldold")),
+            patch("app.coherence.installed_package_version", return_value="0.13.0"),
+        ):
+            self.assertTrue(spotty_self_stale())
+
+    def test_installed_package_version_ignores_embedded_version(self) -> None:
+        from unittest.mock import patch
+
+        from app.version import installed_package_version, package_version
+
+        with patch("app.version._build_metadata.EMBEDDED_VERSION", "0.12.0+stale"):
+            self.assertEqual(package_version(), "0.12.0+stale")
+            # A real distribution is installed in this dev/test environment
+            # (via uv), so the fresh, uncached read differs from the frozen
+            # embedded stamp above.
+            self.assertNotEqual(installed_package_version(), "0.12.0+stale")
+
+    def test_spotty_self_stale_false_when_matching(self) -> None:
+        from unittest.mock import patch
+
+        from app.coherence import spotty_self_stale
+
+        with (
+            patch("app.coherence.get_build_info", return_value=("0.13.0", "newnew")),
+            patch("app.coherence.installed_package_version", return_value="0.13.0"),
+        ):
+            self.assertFalse(spotty_self_stale())
 
 
 class SpottyBunnyAgentTests(SimpleTestCase):
@@ -3333,20 +3420,29 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertNotIn('setTitle_("spotty-bunny")', source)
         self.assertIn("showAbout:", source)
         self.assertIn("SpottyBunnyLogoButton", source)
+        self.assertIn("def checkForUpdates_", source)
         self.assertIn("def installSpottyBunny_", source)
         self.assertIn("def quitSpottyBunny_", source)
         self.assertIn("def uninstallSpottyBunny_", source)
         self.assertIn("def upgradeSpottyBunny_", source)
         self.assertIn("menuNeedsUpdate_", source)
         self.assertIn("installed=is_agent_installed()", source)
-        self.assertIn("outdated=self._update_status.outdated", source)
+        self.assertIn("outdated=self._outdated_badge()", source)
+        self.assertIn("def _outdated_badge(self) -> bool:", source)
+        self.assertIn("badge_should_show(self._update_status, self_stale=", source)
         menu_source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_menu.py"
         ).read_text(encoding="utf-8")
-        self.assertIn("Install Spotty Bunny", menu_source)
-        self.assertIn("Quit Spotty Bunny", menu_source)
-        self.assertIn("Uninstall Spotty Bunny", menu_source)
-        self.assertIn("Upgrade Spotty Bunny", menu_source)
+        self.assertIn('CHECK_FOR_UPDATES_MENU_TITLE = "Check for Updates"', menu_source)
+        self.assertIn('INSTALL_MENU_TITLE = "Install"', menu_source)
+        self.assertIn('QUIT_MENU_TITLE = "Quit"', menu_source)
+        self.assertIn('UNINSTALL_MENU_TITLE = "Uninstall"', menu_source)
+        self.assertIn('UPGRADE_MENU_TITLE = "Upgrade"', menu_source)
+        self.assertNotIn("Install Spotty Bunny", menu_source)
+        self.assertNotIn("Quit Spotty Bunny", menu_source)
+        self.assertNotIn("Uninstall Spotty Bunny", menu_source)
+        self.assertNotIn("Upgrade Spotty Bunny", menu_source)
+        self.assertIn("checkForUpdates:", menu_source)
         self.assertIn("installSpottyBunny:", menu_source)
         self.assertIn("quitSpottyBunny:", menu_source)
         self.assertIn("uninstallSpottyBunny:", menu_source)
@@ -3831,6 +3927,53 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
         self.assertFalse(cache_is_stale(100.0, now=100.0 + CHECK_INTERVAL_S - 1))
         self.assertTrue(cache_is_stale(100.0, now=100.0 + CHECK_INTERVAL_S))
 
+    def test_badge_should_show_reflects_self_stale_or_pypi_outdated(self) -> None:
+        from app.spotty_bunny_update import UpdateStatus, badge_should_show
+
+        current_status = UpdateStatus(
+            checked_at=1.0, current="0.13.0", latest="0.13.0", outdated=False
+        )
+        outdated_status = UpdateStatus(
+            checked_at=1.0, current="0.12.0", latest="0.13.0", outdated=True
+        )
+        self.assertFalse(badge_should_show(current_status, self_stale=False))
+        self.assertTrue(badge_should_show(current_status, self_stale=True))
+        self.assertTrue(badge_should_show(outdated_status, self_stale=False))
+        self.assertTrue(badge_should_show(outdated_status, self_stale=True))
+
+    def test_summarize_update_check_prioritizes_self_stale(self) -> None:
+        from app.spotty_bunny_update import UpdateStatus, summarize_update_check
+
+        outdated_status = UpdateStatus(
+            checked_at=1.0, current="0.12.0", latest="0.13.0", outdated=True
+        )
+        self.assertIn(
+            "older build",
+            summarize_update_check(outdated_status, self_stale=True),
+        )
+
+    def test_summarize_update_check_reports_pypi_release(self) -> None:
+        from app.spotty_bunny_update import UpdateStatus, summarize_update_check
+
+        outdated_status = UpdateStatus(
+            checked_at=1.0, current="0.12.0", latest="0.13.0", outdated=True
+        )
+        self.assertEqual(
+            summarize_update_check(outdated_status, self_stale=False),
+            "Update available: 0.13.0",
+        )
+
+    def test_summarize_update_check_reports_up_to_date(self) -> None:
+        from app.spotty_bunny_update import UpdateStatus, summarize_update_check
+
+        current_status = UpdateStatus(
+            checked_at=1.0, current="0.13.0", latest="0.13.0", outdated=False
+        )
+        self.assertEqual(
+            summarize_update_check(current_status, self_stale=False),
+            "Spotty Bunny is up to date.",
+        )
+
     def test_is_version_outdated_compares_pep440(self) -> None:
         from app.spotty_bunny_update import is_version_outdated
 
@@ -3847,6 +3990,7 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
 
     def test_logo_menu_specs_are_sorted_and_hide_upgrade_when_current(self) -> None:
         from app.spotty_bunny_menu import (
+            CHECK_FOR_UPDATES_MENU_TITLE,
             INSTALL_MENU_TITLE,
             QUIT_MENU_TITLE,
             UNINSTALL_MENU_TITLE,
@@ -3857,20 +4001,28 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
         missing = logo_menu_specs(installed=False, outdated=True)
         missing_titles = [title for title, _action in missing]
         self.assertEqual(missing_titles, sorted(missing_titles))
-        self.assertEqual(missing_titles, [INSTALL_MENU_TITLE, QUIT_MENU_TITLE])
+        self.assertEqual(
+            missing_titles,
+            [CHECK_FOR_UPDATES_MENU_TITLE, INSTALL_MENU_TITLE, QUIT_MENU_TITLE],
+        )
         current = logo_menu_specs(installed=True, outdated=False)
         titles = [title for title, _action in current]
         self.assertEqual(titles, sorted(titles))
         self.assertEqual(
             titles,
-            [QUIT_MENU_TITLE, UNINSTALL_MENU_TITLE],
+            [CHECK_FOR_UPDATES_MENU_TITLE, QUIT_MENU_TITLE, UNINSTALL_MENU_TITLE],
         )
         outdated = logo_menu_specs(installed=True, outdated=True)
         outdated_titles = [title for title, _action in outdated]
         self.assertEqual(outdated_titles, sorted(outdated_titles))
         self.assertEqual(
             outdated_titles,
-            [QUIT_MENU_TITLE, UNINSTALL_MENU_TITLE, UPGRADE_MENU_TITLE],
+            [
+                CHECK_FOR_UPDATES_MENU_TITLE,
+                QUIT_MENU_TITLE,
+                UNINSTALL_MENU_TITLE,
+                UPGRADE_MENU_TITLE,
+            ],
         )
 
     def test_pypi_latest_version_reads_info_version(self) -> None:
@@ -4028,6 +4180,7 @@ class _FakeClock:
 
 def _about_runtime(
     *,
+    self_stale: bool = False,
     server_agent_installed: bool = False,
     server_mode: Literal["local", "remote"],
     server_skewed: bool = False,
@@ -4038,6 +4191,7 @@ def _about_runtime(
         github_display=None,
         github_url=None,
         local_build_label="0.10.0 (newnewnewnew)",
+        self_stale=self_stale,
         server_agent_installed=server_agent_installed,
         server_build_label="0.9.0 (oldoldoldold)",
         server_display="Local server · http://127.0.0.1:8000",

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -448,12 +448,17 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
                     "app.coherence.get_build_info",
                     return_value=("0.10.0", "newnewnewnew"),
                 ),
+                patch(
+                    "app.spotty_bunny_about_info.spotty_self_stale",
+                    return_value=False,
+                ),
             ):
                 info = load_about_runtime_info(
                     environ=env,
                     origin_url_for=lambda _workdir: None,
                 )
             self.assertTrue(info.server_skewed)
+            self.assertFalse(info.self_stale)
             self.assertEqual(info.local_build_label, "0.10.0 (newnewnewnew)")
             self.assertEqual(info.server_mode, "local")
             self.assertTrue(info.server_agent_installed)
@@ -482,12 +487,17 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
                     "app.coherence.get_build_info",
                     return_value=("0.10.0", "newnewnewnew"),
                 ),
+                patch(
+                    "app.spotty_bunny_about_info.spotty_self_stale",
+                    return_value=True,
+                ),
             ):
                 info = load_about_runtime_info(
                     environ=env,
                     origin_url_for=lambda _workdir: None,
                 )
             self.assertFalse(info.server_skewed)
+            self.assertTrue(info.self_stale)
 
     def test_load_about_runtime_info_remote_server_and_github(self) -> None:
         from app.spotty_bunny_about_info import load_about_runtime_info
@@ -698,19 +708,22 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             running_is_stale(running_version="0.13.0", installed_version="0.12.0")
         )
 
-    def test_running_is_stale_falls_back_to_string_compare_when_unparseable(
-        self,
-    ) -> None:
+    def test_running_is_stale_never_claims_stale_when_unparseable(self) -> None:
         from app.coherence import running_is_stale
 
-        self.assertTrue(
+        # An unparseable version says nothing about direction (matches
+        # cli_is_newer_than's InvalidVersion handling) — never "stale".
+        self.assertFalse(
             running_is_stale(running_version="unknown", installed_version="0.13.0")
         )
         self.assertFalse(
             running_is_stale(running_version="unknown", installed_version="unknown")
         )
+        self.assertFalse(
+            running_is_stale(running_version="0.13.0", installed_version="unknown")
+        )
 
-    def test_spotty_self_stale_detects_in_place_upgrade(self) -> None:
+    def test_spotty_self_stale_detects_in_place_version_upgrade(self) -> None:
         from unittest.mock import patch
 
         from app.coherence import spotty_self_stale
@@ -720,6 +733,35 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             patch("app.coherence.installed_package_version", return_value="0.13.0"),
         ):
             self.assertTrue(spotty_self_stale())
+
+    def test_spotty_self_stale_detects_commit_only_drift(self) -> None:
+        from unittest.mock import patch
+
+        from app.coherence import spotty_self_stale
+
+        with (
+            patch(
+                "app.coherence.get_build_info", return_value=("0.13.0", "oldcommit1")
+            ),
+            patch("app.coherence.installed_package_version", return_value="0.13.0"),
+            patch(
+                "app.coherence.installed_package_commit",
+                return_value="newcommit2",
+            ),
+        ):
+            self.assertTrue(spotty_self_stale())
+
+    def test_spotty_self_stale_ignores_unknown_commits(self) -> None:
+        from unittest.mock import patch
+
+        from app.coherence import spotty_self_stale
+
+        with (
+            patch("app.coherence.get_build_info", return_value=("0.13.0", "unknown")),
+            patch("app.coherence.installed_package_version", return_value="0.13.0"),
+            patch("app.coherence.installed_package_commit", return_value="somecommit"),
+        ):
+            self.assertFalse(spotty_self_stale())
 
     def test_installed_package_version_ignores_embedded_version(self) -> None:
         from unittest.mock import patch
@@ -733,6 +775,29 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
             # embedded stamp above.
             self.assertNotEqual(installed_package_version(), "0.12.0+stale")
 
+    def test_installed_package_commit_rereads_file_ignoring_imported_module(
+        self,
+    ) -> None:
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from app import _build_metadata
+        from app.version import installed_package_commit
+
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_module = Path(tmp) / "_build_metadata.py"
+            fake_module.write_text(
+                'EMBEDDED_COMMIT = "freshfromdi"\nEMBEDDED_VERSION = ""\n',
+                encoding="utf-8",
+            )
+            # _build_metadata is already imported with EMBEDDED_COMMIT="" (this
+            # dev checkout); only its __file__ attribute is redirected, so the
+            # function must re-read the file rather than trust the module
+            # object already in memory.
+            with patch.object(_build_metadata, "__file__", str(fake_module)):
+                self.assertEqual(installed_package_commit(environ={}), "freshfromdi")
+
     def test_spotty_self_stale_false_when_matching(self) -> None:
         from unittest.mock import patch
 
@@ -741,6 +806,7 @@ class SpottyBunnyAboutInfoTests(SimpleTestCase):
         with (
             patch("app.coherence.get_build_info", return_value=("0.13.0", "newnew")),
             patch("app.coherence.installed_package_version", return_value="0.13.0"),
+            patch("app.coherence.installed_package_commit", return_value="newnew"),
         ):
             self.assertFalse(spotty_self_stale())
 
@@ -3429,7 +3495,9 @@ class SpottyBunnyLaunchTests(SimpleTestCase):
         self.assertIn("installed=is_agent_installed()", source)
         self.assertIn("outdated=self._outdated_badge()", source)
         self.assertIn("def _outdated_badge(self) -> bool:", source)
-        self.assertIn("badge_should_show(self._update_status, self_stale=", source)
+        self.assertIn("badge_should_show(", source)
+        self.assertIn("server_skewed=self._server_skewed,", source)
+        self.assertIn("def _check_update_and_skew(*, force: bool)", source)
         menu_source = (
             Path(__file__).resolve().parents[1] / "app" / "spotty_bunny_menu.py"
         ).read_text(encoding="utf-8")
@@ -3940,6 +4008,9 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
         self.assertTrue(badge_should_show(current_status, self_stale=True))
         self.assertTrue(badge_should_show(outdated_status, self_stale=False))
         self.assertTrue(badge_should_show(outdated_status, self_stale=True))
+        self.assertTrue(
+            badge_should_show(current_status, self_stale=False, server_skewed=True)
+        )
 
     def test_summarize_update_check_prioritizes_self_stale(self) -> None:
         from app.spotty_bunny_update import UpdateStatus, summarize_update_check
@@ -3949,7 +4020,22 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
         )
         self.assertIn(
             "older build",
-            summarize_update_check(outdated_status, self_stale=True),
+            summarize_update_check(
+                outdated_status, self_stale=True, server_skewed=True
+            ),
+        )
+
+    def test_summarize_update_check_reports_server_skew(self) -> None:
+        from app.spotty_bunny_update import UpdateStatus, summarize_update_check
+
+        current_status = UpdateStatus(
+            checked_at=1.0, current="0.13.0", latest="0.13.0", outdated=False
+        )
+        self.assertIn(
+            "Server build differs",
+            summarize_update_check(
+                current_status, self_stale=False, server_skewed=True
+            ),
         )
 
     def test_summarize_update_check_reports_pypi_release(self) -> None:

--- a/bookmarks/test_spotty_bunny.py
+++ b/bookmarks/test_spotty_bunny.py
@@ -4060,6 +4060,20 @@ class SpottyBunnyUpdateTests(SimpleTestCase):
             "Spotty Bunny is up to date.",
         )
 
+    def test_summarize_update_check_reports_failure_not_up_to_date(self) -> None:
+        from app.spotty_bunny_update import UpdateStatus, summarize_update_check
+
+        # latest=None means no PyPI lookup has ever succeeded (offline,
+        # unreachable, transient failure) — must not read as "confirmed
+        # current".
+        never_checked = UpdateStatus(
+            checked_at=1.0, current="0.13.0", latest=None, outdated=False
+        )
+        self.assertEqual(
+            summarize_update_check(never_checked, self_stale=False),
+            "Could not check for updates.",
+        )
+
     def test_is_version_outdated_compares_pep440(self) -> None:
         from app.spotty_bunny_update import is_version_outdated
 

--- a/docs/LOCAL.md
+++ b/docs/LOCAL.md
@@ -186,16 +186,21 @@ process, and clears the pid file. It does not delete the application log or
 your bookmarks. If the agent was never installed, it still succeeds.
 
 To stop the overlay **without** removing the LaunchAgent, right-click the bunny
-icon and choose **Quit Spotty Bunny**. That exits the process and boots the
-agent out so KeepAlive cannot immediately respawn it. The plist stays; the
-agent starts again at next login (`RunAtLoad`) until you `uninstall`.
+icon and choose **Quit**. That exits the process and boots the agent out so
+KeepAlive cannot immediately respawn it. The plist stays; the agent starts
+again at next login (`RunAtLoad`) until you `uninstall`.
 
-The same menu lists **Install Spotty Bunny** when the LaunchAgent is missing
-(then quits so launchd owns the overlay). When the agent is installed it
-offers **Uninstall Spotty Bunny** (confirms, then removes the plist before
-booting the agent out) and, when a newer PyPI release is known, **Upgrade
-Spotty Bunny** (`pipx upgrade`, rewrite the plist, then quit so KeepAlive
-relaunches). Items are listed A–Z by title.
+The same menu always lists **Check for Updates**, which forces an immediate
+PyPI lookup instead of waiting for the daily cache and reports the result
+(up to date, a new release, or "running an older build than what's
+installed"). It also lists **Install** when the LaunchAgent is missing (then
+quits so launchd owns the overlay). When the agent is installed it offers
+**Uninstall** (confirms, then removes the plist before booting the agent
+out) and **Upgrade** whenever a newer PyPI release is known *or* this
+running overlay predates what's currently installed (`pipx upgrade` if
+needed, rewrite the plist for the current binary, then quit so KeepAlive
+relaunches — this also fixes a stale overlay even when PyPI has nothing
+new). Items are listed A–Z by title.
 
 Invoking `bunnify` reuses a running local server and Spotty Bunny overlay
 when they match this CLI's commit. If either is missing it is started; if


### PR DESCRIPTION
## Summary
- Fixes #409: a long-running Spotty Bunny process caches its own build info once per process (`get_build_info()` is `@lru_cache`'d), so after a local upgrade it kept comparing that frozen self-view against the server's `/health` and told the user to fix the *server* ("redeploy" / `bunnify-server upgrade`) when it actually just needed a restart. The menu-bar badge never reflected this at all — only the daily PyPI check drove it.
- Add `installed_package_version()` (`app/version.py`, fresh/uncached) and `spotty_self_stale()` (`app/coherence.py`) to detect this in-place drift; prioritize it in the About panel's skew message (`server_skew_message`), and fold it into the icon badge / Upgrade menu item alongside the existing PyPI check (`badge_should_show` in `app/spotty_bunny_update.py`).
- Add a **Check for Updates** menu action that forces an immediate PyPI check (bypassing the 24h cache) and reports the result (`summarize_update_check`).
- Trim the right-click menu titles ("Quit Spotty Bunny" → "Quit", etc.) since they're redundant on a context menu already anchored to the bunny icon.
- Update README / docs/LOCAL.md to match.

## Test plan
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright --warnings`
- [x] `./test_bunnify` (514 tests, 11 new: self-staleness detection, badge/summary combinators, menu titles/specs, About-panel skew-message priority)
- [x] `./scripts/checks` (full preflight: shellcheck, unit tests, packaging smoke, integration tests)